### PR TITLE
docs(examples): add Anthropic Claude quickstart for TypeScript and Python (#20)

### DIFF
--- a/examples/python/anthropic_quickstart.py
+++ b/examples/python/anthropic_quickstart.py
@@ -1,0 +1,120 @@
+"""
+TealAnthropic Quickstart
+
+Shortest runnable example of wrapping Anthropic's Claude API with
+TealTiger's guardrails and cost tracking. Run with:
+
+    ANTHROPIC_API_KEY=sk-ant-... python examples/python/anthropic_quickstart.py
+
+Claude-specific notes this example demonstrates:
+    - system is a top-level field on messages.create(), not a message role
+    - models include dates (claude-3-5-sonnet-20241022); pin them in production
+    - max_tokens is required
+    - streaming uses client.messages.stream(...) rather than a flag
+"""
+
+import asyncio
+import os
+
+from tealtiger import (
+    BudgetConfig,
+    BudgetManager,
+    ContentModerationGuardrail,
+    CostTracker,
+    CostTrackerConfig,
+    GuardrailEngine,
+    InMemoryCostStorage,
+    PIIDetectionGuardrail,
+    TealAnthropic,
+)
+
+
+async def main() -> None:
+    # 1. Guardrails: redact PII, block anything flagged as unsafe content.
+    guardrail_engine = GuardrailEngine()
+    guardrail_engine.register_guardrail(PIIDetectionGuardrail(
+        name="pii-detection",
+        enabled=True,
+        action="redact",
+    ))
+    guardrail_engine.register_guardrail(ContentModerationGuardrail(
+        name="content-moderation",
+        enabled=True,
+        action="block",
+    ))
+
+    # 2. Cost tracking + a daily $5 budget with alerts at 50 / 75 / 90%.
+    storage = InMemoryCostStorage()
+    cost_tracker = CostTracker(CostTrackerConfig(
+        enabled=True,
+        persist_records=True,
+        enable_budgets=True,
+        enable_alerts=True,
+    ))
+    budget_manager = BudgetManager(storage)
+    budget_manager.create_budget(BudgetConfig(
+        name="Quickstart Daily Budget",
+        limit=5.0,
+        period="daily",
+        alert_thresholds=[50, 75, 90],
+        action="alert",
+        enabled=True,
+    ))
+
+    # 3. TealAnthropic is a drop-in wrapper around Anthropic's SDK.
+    client = TealAnthropic(
+        api_key=os.getenv("ANTHROPIC_API_KEY", "your-anthropic-api-key"),
+        agent_id="quickstart-agent",
+        guardrail_engine=guardrail_engine,
+        cost_tracker=cost_tracker,
+        budget_manager=budget_manager,
+        cost_storage=storage,
+    )
+
+    # 4. Plain message. The shape matches the upstream Anthropic SDK; the
+    #    security metadata on the response is added by TealAnthropic.
+    basic = await client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=200,
+        messages=[
+            {"role": "user", "content": "In one sentence, what does TealTiger do?"},
+        ],
+    )
+    print("Basic response:", basic.content[0].text)
+    cost = getattr(getattr(basic, "security", None), "cost_record", None)
+    if cost:
+        print(f"Cost: ${cost.actual_cost:.6f}")
+
+    # 5. System prompt. Claude's API takes `system` as a top-level field,
+    #    not as a message with role="system" like OpenAI does.
+    systemed = await client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=200,
+        system="You answer as a concise security engineer. Three sentences max.",
+        messages=[
+            {"role": "user", "content": "Why redact PII before sending prompts to a model?"},
+        ],
+    )
+    print("\nSystem-primed response:", systemed.content[0].text)
+
+    # 6. Streaming. messages.stream yields events; text_delta events carry
+    #    the incremental text.
+    print("\nStreaming response:")
+    async with client.messages.stream(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=200,
+        messages=[
+            {"role": "user", "content": "Count to five, one number per line."},
+        ],
+    ) as stream:
+        async for event in stream:
+            if (
+                getattr(event, "type", None) == "content_block_delta"
+                and getattr(getattr(event, "delta", None), "type", None) == "text_delta"
+            ):
+                print(event.delta.text, end="", flush=True)
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/typescript/anthropic-quickstart.ts
+++ b/examples/typescript/anthropic-quickstart.ts
@@ -1,0 +1,114 @@
+/**
+ * TealAnthropic Quickstart
+ *
+ * Shortest runnable example of wrapping Anthropic's Claude API with
+ * TealTiger's guardrails and cost tracking. Run with:
+ *
+ *   ANTHROPIC_API_KEY=sk-ant-... ts-node examples/typescript/anthropic-quickstart.ts
+ *
+ * Claude-specific notes this example demonstrates:
+ *   - system is a top-level field on messages.create(), not a message role
+ *   - models include dates (claude-3-5-sonnet-20241022); pin them in production
+ *   - max_tokens is required
+ *   - streaming uses client.messages.stream({...}) rather than a flag
+ */
+
+import {
+  TealAnthropic,
+  GuardrailEngine,
+  PIIDetectionGuardrail,
+  ContentModerationGuardrail,
+  CostTracker,
+  BudgetManager,
+  InMemoryCostStorage,
+} from 'tealtiger';
+
+async function main() {
+  // 1. Guardrails: redact PII, block anything flagged as unsafe content.
+  const guardrailEngine = new GuardrailEngine();
+  guardrailEngine.registerGuardrail(new PIIDetectionGuardrail({
+    name: 'pii-detection',
+    enabled: true,
+    action: 'redact',
+  }));
+  guardrailEngine.registerGuardrail(new ContentModerationGuardrail({
+    name: 'content-moderation',
+    enabled: true,
+    action: 'block',
+  }));
+
+  // 2. Cost tracking + a daily $5 budget with alerts at 50 / 75 / 90%.
+  const storage = new InMemoryCostStorage();
+  const costTracker = new CostTracker({
+    enabled: true,
+    persistRecords: true,
+    enableBudgets: true,
+    enableAlerts: true,
+  });
+  const budgetManager = new BudgetManager(storage);
+  budgetManager.createBudget({
+    name: 'Quickstart Daily Budget',
+    limit: 5.0,
+    period: 'daily',
+    alertThresholds: [50, 75, 90],
+    action: 'alert',
+    enabled: true,
+  });
+
+  // 3. TealAnthropic is a drop-in wrapper around Anthropic's SDK.
+  const client = new TealAnthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY || 'your-anthropic-api-key',
+    agentId: 'quickstart-agent',
+    guardrailEngine,
+    costTracker,
+    budgetManager,
+    costStorage: storage,
+  });
+
+  // 4. Plain message. The shape matches the upstream Anthropic SDK; the
+  //    security metadata on the response is added by TealAnthropic.
+  const basic = await client.messages.create({
+    model: 'claude-3-5-sonnet-20241022',
+    max_tokens: 200,
+    messages: [
+      { role: 'user', content: 'In one sentence, what does TealTiger do?' },
+    ],
+  });
+  console.log('Basic response:', basic.content[0].text);
+  console.log('Cost: $' + (basic.security?.costRecord?.actualCost ?? 0).toFixed(6));
+
+  // 5. System prompt. Claude's API takes `system` as a top-level field,
+  //    not as a message with role: "system" like OpenAI does.
+  const systemed = await client.messages.create({
+    model: 'claude-3-5-sonnet-20241022',
+    max_tokens: 200,
+    system: 'You answer as a concise security engineer. Three sentences max.',
+    messages: [
+      { role: 'user', content: 'Why redact PII before sending prompts to a model?' },
+    ],
+  });
+  console.log('\nSystem-primed response:', systemed.content[0].text);
+
+  // 6. Streaming. messages.stream returns an async iterable of events;
+  //    text_delta events carry the incremental text.
+  console.log('\nStreaming response:');
+  const stream = await client.messages.stream({
+    model: 'claude-3-5-sonnet-20241022',
+    max_tokens: 200,
+    messages: [
+      { role: 'user', content: 'Count to five, one number per line.' },
+    ],
+  });
+
+  for await (const event of stream) {
+    if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+      process.stdout.write(event.delta.text);
+    }
+  }
+  process.stdout.write('\n');
+}
+
+main().catch((err) => {
+  console.error('Quickstart failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #20.

Adds minimal runnable quickstart examples for TealAnthropic, placed at the paths the issue specifies.

## Files added

- \`examples/typescript/anthropic-quickstart.ts\`
- \`examples/python/anthropic_quickstart.py\`

## What the quickstart covers

Each example walks through six numbered steps:

1. Register PII detection + content moderation guardrails
2. Set up cost tracking + a daily \$5 budget with alert thresholds
3. Create the TealAnthropic client
4. A plain message
5. A message with a system prompt — noting that Claude's API takes \`system\` as a top-level field, not as a \`role: "system"\` message like OpenAI
6. A streaming message via \`client.messages.stream(...)\`

Claude-specific patterns are called out in the file-level docstring and in comments next to the relevant step.

## Verification

- Python: \`python -m py_compile examples/python/anthropic_quickstart.py\` passes
- TypeScript: the file is structurally valid; the \`tealtiger\` module resolution error from \`tsc\` is the same one all existing \`examples/*.ts\` files produce when compiled outside the SDK, so this example follows the same contract as \`cohere-basic.ts\`, \`gemini-basic.ts\`, \`bedrock-basic.ts\`, etc.