### PR TITLE
feat(examples): add CrewAI integration example

### DIFF
--- a/examples/python/crewai_integration.py
+++ b/examples/python/crewai_integration.py
@@ -1,0 +1,296 @@
+"""
+TealTiger + CrewAI Integration
+
+Shows how to add TealTiger governance to a multi-agent CrewAI workflow:
+
+    1. Tool allowlisting: every CrewAI tool call routes through
+       TealTiger.execute_tool_sync() and is gated by a Policy.
+    2. Cost tracking: a single CostTracker + InMemoryCostStorage is shared
+       across every agent in the crew so totals aggregate cleanly per
+       agent_id.
+    3. LLM wrapping: TealAnthropic plugs into a CrewAI Agent through a
+       thin adapter (CrewAI calls LLM.call(messages); the adapter forwards
+       to TealAnthropic.messages.create() and records cost).
+
+Run with:
+
+    OPENAI_API_KEY=sk-...        # or ANTHROPIC_API_KEY=sk-ant-...
+    pip install 'crewai>=0.55'   # CrewAI is Python-first; not bundled
+    python examples/python/crewai_integration.py
+
+CrewAI-specific notes this example demonstrates:
+    - CrewAI tools subclass BaseTool and implement _run; that's where
+      TealTiger's allowlist hook belongs.
+    - CrewAI's LLM abstraction expects a .call(messages, **kwargs) -> str
+      method; bridge to TealAnthropic via an adapter class.
+    - Each Agent has its own agent_id; share storage but tag records with
+      the agent so per-agent + crew-total cost queries both work.
+"""
+
+import asyncio
+import os
+from typing import Any, Dict, List
+
+from crewai import Agent, Crew, Task  # type: ignore[import-untyped]
+from crewai.tools import BaseTool  # type: ignore[import-untyped]
+
+from tealtiger import (
+    BudgetConfig,
+    BudgetManager,
+    CostTracker,
+    CostTrackerConfig,
+    InMemoryCostStorage,
+    PolicyBuilder,
+    TealAnthropic,
+    TealTiger,
+)
+
+
+# 1. Policy: allowlist the tools this crew is allowed to call. Anything not
+#    matched falls through to the default deny rule.
+def build_crew_policy():
+    return (
+        PolicyBuilder()
+        .name("crewai-tool-allowlist")
+        .description("Tools the research crew is allowed to invoke")
+        .add_rule(
+            condition={"tool_name": "web_search"},
+            action="allow",
+            reason="Public web search is permitted for research",
+        )
+        .add_rule(
+            condition={"tool_name": "calculator"},
+            action="allow",
+            reason="Deterministic math is safe",
+        )
+        .add_rule(
+            condition={"tool_name": "*"},
+            action="deny",
+            reason="Default deny: tools must be explicitly allowlisted",
+        )
+        .build()
+    )
+
+
+# 2. Guarded tool: every CrewAI tool _run() routes through TealTiger first.
+#    A deny short-circuits the tool with a clear error; the agent then sees
+#    the failure in its scratchpad and either tries another tool or stops.
+class GuardedTool(BaseTool):
+    """A CrewAI BaseTool that runs every call through TealTiger first."""
+
+    name: str
+    description: str
+
+    def __init__(self, name: str, description: str, guard: TealTiger, agent_id: str):
+        super().__init__(name=name, description=description)
+        self._guard = guard
+        self._agent_id = agent_id
+
+    def _run(self, **kwargs: Any) -> str:
+        result = self._guard.execute_tool_sync(
+            tool_name=self.name,
+            parameters=kwargs,
+            context={
+                "session_id": "crewai-demo",
+                "user_id": "demo-user",
+                "agent_id": self._agent_id,
+            },
+        )
+        if not result.success:
+            return f"[blocked by TealTiger: {result.error}]"
+        return self._actual_run(**kwargs)
+
+    def _actual_run(self, **kwargs: Any) -> str:
+        # Subclasses override this with the real tool logic. Stubbed here so
+        # the example runs end-to-end without external services.
+        return f"[stub {self.name} result for {kwargs!r}]"
+
+
+class WebSearchTool(GuardedTool):
+    def __init__(self, guard: TealTiger, agent_id: str):
+        super().__init__(
+            name="web_search",
+            description="Search the public web and return a list of result snippets",
+            guard=guard,
+            agent_id=agent_id,
+        )
+
+    def _actual_run(self, query: str = "") -> str:
+        return f"[stub web_search result for {query!r}]"
+
+
+class CalculatorTool(GuardedTool):
+    def __init__(self, guard: TealTiger, agent_id: str):
+        super().__init__(
+            name="calculator",
+            description="Evaluate a deterministic arithmetic expression",
+            guard=guard,
+            agent_id=agent_id,
+        )
+
+    def _actual_run(self, expression: str = "") -> str:
+        # ast.literal_eval rejects anything except literals; safe for a demo.
+        import ast
+        try:
+            return str(ast.literal_eval(expression))
+        except (ValueError, SyntaxError) as exc:
+            return f"[calculator error: {exc}]"
+
+
+# 3. LLM adapter: CrewAI agents accept any object with a .call(messages, ...)
+#    method that returns a string. We forward to TealAnthropic so guardrails
+#    + cost-record creation happen on every agent turn.
+class TealAnthropicCrewAIAdapter:
+    """Adapt TealAnthropic to CrewAI's LLM .call(messages) -> str protocol."""
+
+    def __init__(
+        self,
+        teal_anthropic: TealAnthropic,
+        model: str,
+        cost_tracker: CostTracker,
+        storage: InMemoryCostStorage,
+        agent_id: str,
+        max_tokens: int = 1024,
+    ):
+        self._client = teal_anthropic
+        self._model = model
+        self._tracker = cost_tracker
+        self._storage = storage
+        self._agent_id = agent_id
+        self._max_tokens = max_tokens
+
+    async def _call_async(self, messages: List[Dict[str, str]]) -> str:
+        response = await self._client.messages.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=messages,
+        )
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            record = self._tracker.calculate_actual_cost(
+                request_id=getattr(response, "id", "crewai-req"),
+                agent_id=self._agent_id,
+                model=self._model,
+                usage={
+                    "input_tokens": getattr(usage, "input_tokens", 0),
+                    "output_tokens": getattr(usage, "output_tokens", 0),
+                    "total_tokens": getattr(usage, "input_tokens", 0)
+                    + getattr(usage, "output_tokens", 0),
+                },
+                provider="anthropic",
+            )
+            await self._storage.store(record)
+        return response.content[0].text
+
+    def call(self, messages: List[Dict[str, str]], **_: Any) -> str:
+        return asyncio.run(self._call_async(messages))
+
+
+async def main() -> None:
+    # 4. Shared infrastructure: one TealTiger guard, one cost tracker, one
+    #    storage. Every tool call and every LLM call funnels through these,
+    #    so per-agent and crew-total queries both work off the same data.
+    guard = TealTiger(
+        api_key=os.getenv("TEALTIGER_API_KEY", "demo-key"),
+        ssa_url=os.getenv("TEALTIGER_SSA_URL", "http://localhost:3000"),
+        policy=build_crew_policy(),
+    )
+    storage = InMemoryCostStorage()
+    cost_tracker = CostTracker(CostTrackerConfig(
+        enabled=True,
+        persist_records=True,
+        enable_budgets=True,
+        enable_alerts=True,
+    ))
+
+    # 5. Crew-wide budget. Multi-agent workflows fan out fast; a $5/day cap
+    #    with alerts at 50/75/90% catches runaway crews before they bill.
+    budget_manager = BudgetManager(storage)
+    budget_manager.create_budget(BudgetConfig(
+        name="Research Crew Daily Budget",
+        limit=5.0,
+        period="daily",
+        alert_thresholds=[50, 75, 90],
+        action="alert",
+        enabled=True,
+    ))
+
+    # 6. Two agents, each with its own agent_id so cost queries can split by
+    #    role. They share the tool guard and cost tracker.
+    researcher_id = "agent-researcher"
+    writer_id = "agent-writer"
+
+    researcher_llm = TealAnthropicCrewAIAdapter(
+        teal_anthropic=TealAnthropic(
+            api_key=os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key"),
+            agent_id=researcher_id,
+            cost_tracker=cost_tracker,
+            cost_storage=storage,
+        ),
+        model="claude-3-5-sonnet-20241022",
+        cost_tracker=cost_tracker,
+        storage=storage,
+        agent_id=researcher_id,
+    )
+    writer_llm = TealAnthropicCrewAIAdapter(
+        teal_anthropic=TealAnthropic(
+            api_key=os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key"),
+            agent_id=writer_id,
+            cost_tracker=cost_tracker,
+            cost_storage=storage,
+        ),
+        model="claude-3-5-sonnet-20241022",
+        cost_tracker=cost_tracker,
+        storage=storage,
+        agent_id=writer_id,
+    )
+
+    researcher = Agent(
+        role="Researcher",
+        goal="Gather background facts about a topic using web search",
+        backstory="A meticulous researcher who cites sources",
+        tools=[WebSearchTool(guard, researcher_id)],
+        llm=researcher_llm,
+        verbose=False,
+        allow_delegation=False,
+    )
+    writer = Agent(
+        role="Writer",
+        goal="Turn research notes into a short brief",
+        backstory="A concise writer who avoids speculation",
+        tools=[CalculatorTool(guard, writer_id)],
+        llm=writer_llm,
+        verbose=False,
+        allow_delegation=False,
+    )
+
+    # 7. A trivial crew. The point of the example is the governance
+    #    plumbing, not the prompt design.
+    research_task = Task(
+        description="Find three facts about open-source AI agent frameworks.",
+        expected_output="A bulleted list of three facts, each with a source.",
+        agent=researcher,
+    )
+    summary_task = Task(
+        description="Summarise the research notes in two sentences.",
+        expected_output="Two sentences, no longer than 60 words total.",
+        agent=writer,
+        context=[research_task],
+    )
+    crew = Crew(agents=[researcher, writer], tasks=[research_task, summary_task])
+
+    # 8. Run the crew. Network calls are stubbed unless ANTHROPIC_API_KEY is
+    #    set; the governance code paths execute either way.
+    result = crew.kickoff()
+    print("Crew output:\n", result)
+
+    # 9. Cost summary across all agents in the crew.
+    print("\n=== Per-agent cost ===")
+    for agent_id in (researcher_id, writer_id):
+        records = await storage.get_by_agent_id(agent_id)
+        total = sum(r.actual_cost for r in records)
+        print(f"  {agent_id}: {len(records)} call(s), ${total:.6f}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/crewai_integration.py
+++ b/examples/python/crewai_integration.py
@@ -18,7 +18,7 @@ Shows how to add TealTiger governance to a multi-agent CrewAI workflow:
 
 Run with:
 
-    pip install 'crewai>=0.55'
+    pip install 'crewai>=0.70'
     ANTHROPIC_API_KEY=sk-ant-...      # required for live LLM calls
     TEALTIGER_SSA_URL=http://...      # required for tool allowlist
     TEALTIGER_API_KEY=...
@@ -79,64 +79,63 @@ def build_crew_policy():
     )
 
 
-# 2. Guarded tool: every CrewAI tool _run() routes through TealTiger first.
-#    A deny short-circuits the tool with a clear error; the agent then
-#    sees the failure in its scratchpad and either tries another tool or
-#    stops.
-class GuardedTool(BaseTool):
-    """A CrewAI BaseTool that runs every call through TealTiger first."""
+# 2. Guarded tool: every CrewAI tool _run() routes through TealTiger
+#    first. A deny short-circuits the tool with a clear error; the agent
+#    then sees the failure in its scratchpad and either tries another
+#    tool or stops.
+#
+#    Each subclass declares its own typed _run() so CrewAI can derive an
+#    args_schema from the signature. A base class with **kwargs would
+#    drop the schema and the model would receive the tools as taking no
+#    arguments.
+def _guard_call(
+    guard: TealTiger,
+    tool_name: str,
+    agent_id: str,
+    parameters: Dict[str, Any],
+):
+    return guard.execute_tool_sync(
+        tool_name=tool_name,
+        parameters=parameters,
+        context={
+            "session_id": "crewai-demo",
+            "user_id": "demo-user",
+            "agent_id": agent_id,
+        },
+    )
 
-    name: str
-    description: str
 
-    def __init__(self, name: str, description: str, guard: TealTiger, agent_id: str):
-        super().__init__(name=name, description=description)
+class WebSearchTool(BaseTool):
+    name: str = "web_search"
+    description: str = "Search the public web and return result snippets"
+
+    def __init__(self, guard: TealTiger, agent_id: str):
+        super().__init__()
         self._guard = guard
         self._agent_id = agent_id
 
-    def _run(self, **kwargs: Any) -> str:
-        result = self._guard.execute_tool_sync(
-            tool_name=self.name,
-            parameters=kwargs,
-            context={
-                "session_id": "crewai-demo",
-                "user_id": "demo-user",
-                "agent_id": self._agent_id,
-            },
-        )
+    def _run(self, query: str) -> str:
+        result = _guard_call(self._guard, self.name, self._agent_id, {"query": query})
         if not result.success:
             return f"[blocked by TealTiger: {result.error}]"
-        return self._actual_run(**kwargs)
-
-    def _actual_run(self, **kwargs: Any) -> str:
-        # Subclasses override this with the real tool logic. Stubbed here
-        # so the example runs end-to-end without external services.
-        return f"[stub {self.name} result for {kwargs!r}]"
-
-
-class WebSearchTool(GuardedTool):
-    def __init__(self, guard: TealTiger, agent_id: str):
-        super().__init__(
-            name="web_search",
-            description="Search the public web and return result snippets",
-            guard=guard,
-            agent_id=agent_id,
-        )
-
-    def _actual_run(self, query: str = "") -> str:
         return f"[stub web_search result for {query!r}]"
 
 
-class CalculatorTool(GuardedTool):
-    def __init__(self, guard: TealTiger, agent_id: str):
-        super().__init__(
-            name="calculator",
-            description="Evaluate a deterministic arithmetic expression",
-            guard=guard,
-            agent_id=agent_id,
-        )
+class CalculatorTool(BaseTool):
+    name: str = "calculator"
+    description: str = "Evaluate a deterministic arithmetic expression"
 
-    def _actual_run(self, expression: str = "") -> str:
+    def __init__(self, guard: TealTiger, agent_id: str):
+        super().__init__()
+        self._guard = guard
+        self._agent_id = agent_id
+
+    def _run(self, expression: str) -> str:
+        result = _guard_call(
+            self._guard, self.name, self._agent_id, {"expression": expression}
+        )
+        if not result.success:
+            return f"[blocked by TealTiger: {result.error}]"
         # ast.literal_eval rejects anything except literals; safe for a demo.
         import ast
         try:
@@ -193,16 +192,19 @@ def main() -> None:
     ))
 
     # 5. Crew-wide budget. Multi-agent workflows fan out fast; a $5/day
-    #    cap with alerts at 50/75/90% catches runaway crews before they
-    #    bill. BudgetManager.create_budget takes positional fields, not a
-    #    pre-built BudgetConfig.
+    #    cap catches runaway crews before they bill. action="block" is
+    #    what enforces the cap; action="alert" only emits warnings and
+    #    still returns allowed=True from check_budget. Alert thresholds
+    #    at 50/75/90 fire on the way to the cap. BudgetManager
+    #    .create_budget takes positional fields, not a pre-built
+    #    BudgetConfig.
     budget_manager = BudgetManager(storage)
     budget_manager.create_budget(
         name="Research Crew Daily Budget",
         limit=5.0,
         period="daily",
         alert_thresholds=[50, 75, 90],
-        action="alert",
+        action="block",
         enabled=True,
     )
 

--- a/examples/python/crewai_integration.py
+++ b/examples/python/crewai_integration.py
@@ -4,40 +4,43 @@ TealTiger + CrewAI Integration
 Shows how to add TealTiger governance to a multi-agent CrewAI workflow:
 
     1. Tool allowlisting: every CrewAI tool call routes through
-       TealTiger.execute_tool_sync(), which evaluates the policy that has
-       been deployed to the Security Sidecar Agent (SSA). The example
-       authors that policy with PolicyBuilder so the rules are visible in
-       the same file.
-    2. Cost tracking: a single CostTracker + InMemoryCostStorage is shared
-       across every agent in the crew. Each Agent has its own agent_id, so
-       per-agent totals and crew-wide totals both come from the same data.
-    3. LLM wrapping: TealAnthropic plugs into a CrewAI Agent through a
-       thin synchronous adapter. CrewAI calls llm.call(messages); the
-       adapter forwards to TealAnthropic.messages.create() (async) and
-       lets TealAnthropic record the cost record internally.
+       TealTiger.execute_tool_sync(), which evaluates the policy that
+       has been deployed to the Security Sidecar Agent (SSA). The
+       example authors that policy with PolicyBuilder so the rules are
+       visible in the same file.
+    2. Cost tracking: a single CostTracker + InMemoryCostStorage is
+       shared across every agent in the crew. Each Agent has its own
+       agent_id, so per-agent totals and crew-wide totals both come
+       from the same data.
+    3. LLM wrapping: TealAnthropic plugs into CrewAI through a
+       BaseLLM subclass. CrewAI calls llm.call(messages); the subclass
+       forwards to TealAnthropic.messages.create() (async) and lets
+       TealAnthropic record cost internally.
 
 Run with:
 
-    pip install 'crewai>=0.70'
+    pip install 'crewai>=1.0'
     ANTHROPIC_API_KEY=sk-ant-...      # required for live LLM calls
     TEALTIGER_SSA_URL=http://...      # required for tool allowlist
     TEALTIGER_API_KEY=...
     python examples/python/crewai_integration.py
 
 CrewAI-specific notes this example demonstrates:
-    - CrewAI tools subclass BaseTool and implement _run; that is where the
-      TealTiger allowlist hook belongs.
-    - CrewAI's LLM contract is .call(messages, **kwargs) -> str. The
-      adapter bridges that to TealAnthropic, whose API is async.
+    - CrewAI tools subclass BaseTool and implement _run; that is where
+      the TealTiger allowlist hook belongs. Each tool declares its
+      arguments by typing _run; **kwargs would drop the schema.
+    - CrewAI's Agent rejects arbitrary llm objects unless they are
+      strings or BaseLLM instances, so the adapter subclasses BaseLLM.
     - The TealTiger policy is enforced by the SSA, not by the local
       client. Deploy build_crew_policy() to your SSA before running.
 """
 
+import ast
 import asyncio
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from crewai import Agent, Crew, Task  # type: ignore[import-untyped]
+from crewai import Agent, BaseLLM, Crew, Task  # type: ignore[import-untyped]
 from crewai.tools import BaseTool  # type: ignore[import-untyped]
 
 from tealtiger import (
@@ -51,10 +54,17 @@ from tealtiger import (
     TealTiger,
 )
 
+# 1. Pricing-table model. CostTracker only attributes spend to model IDs
+#    in MODEL_PRICING; using an unlisted ID silently records $0 and the
+#    crew-wide budget never trips. claude-3-haiku-20240307 is in the
+#    table and small enough for a multi-agent demo.
+DEMO_MODEL = "claude-3-haiku-20240307"
 
-# 1. Policy authored locally so the rules are visible in this file. Deploy
-#    the resulting Policy to your SSA so TealTiger.execute_tool_sync() can
-#    enforce it. Anything not matched falls through to the default deny.
+
+# 2. Policy authored locally so the rules are visible in this file.
+#    Deploy the resulting Policy to your SSA so
+#    TealTiger.execute_tool_sync() can enforce it. Anything not matched
+#    falls through to the default deny.
 def build_crew_policy():
     return (
         PolicyBuilder()
@@ -79,15 +89,11 @@ def build_crew_policy():
     )
 
 
-# 2. Guarded tool: every CrewAI tool _run() routes through TealTiger
-#    first. A deny short-circuits the tool with a clear error; the agent
-#    then sees the failure in its scratchpad and either tries another
-#    tool or stops.
-#
-#    Each subclass declares its own typed _run() so CrewAI can derive an
-#    args_schema from the signature. A base class with **kwargs would
-#    drop the schema and the model would receive the tools as taking no
-#    arguments.
+# 3. Guarded tools. Every CrewAI tool _run() routes through TealTiger
+#    first. A deny short-circuits the tool with a clear error; the
+#    agent then sees the failure in its scratchpad and either tries
+#    another tool or stops. Each subclass declares its own typed
+#    _run() so CrewAI can derive the args_schema from the signature.
 def _guard_call(
     guard: TealTiger,
     tool_name: str,
@@ -121,6 +127,27 @@ class WebSearchTool(BaseTool):
         return f"[stub web_search result for {query!r}]"
 
 
+# Safe arithmetic evaluator. ast.literal_eval only handles literals,
+# so 2+2 would raise; here we walk the AST and reject anything that
+# isn't a number or one of the binary/unary operators below.
+_ARITH_NODES = (
+    ast.Expression,
+    ast.BinOp, ast.UnaryOp, ast.Constant,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod, ast.Pow,
+    ast.USub, ast.UAdd,
+)
+
+
+def _safe_arith(expression: str) -> float:
+    tree = ast.parse(expression, mode="eval")
+    for node in ast.walk(tree):
+        if not isinstance(node, _ARITH_NODES):
+            raise ValueError(f"unsupported syntax: {type(node).__name__}")
+        if isinstance(node, ast.Constant) and not isinstance(node.value, (int, float)):
+            raise ValueError(f"unsupported constant: {node.value!r}")
+    return eval(compile(tree, "<calculator>", "eval"))  # noqa: S307
+
+
 class CalculatorTool(BaseTool):
     name: str = "calculator"
     description: str = "Evaluate a deterministic arithmetic expression"
@@ -136,49 +163,56 @@ class CalculatorTool(BaseTool):
         )
         if not result.success:
             return f"[blocked by TealTiger: {result.error}]"
-        # ast.literal_eval rejects anything except literals; safe for a demo.
-        import ast
         try:
-            return str(ast.literal_eval(expression))
-        except (ValueError, SyntaxError) as exc:
+            return str(_safe_arith(expression))
+        except (ValueError, SyntaxError, ZeroDivisionError) as exc:
             return f"[calculator error: {exc}]"
 
 
-# 3. LLM adapter: CrewAI agents accept any object exposing
-#    .call(messages, **kwargs) -> str. We bridge that to TealAnthropic so
-#    guardrails and the internal cost record happen on every agent turn.
-#    main() is synchronous (see below) so asyncio.run() here is safe.
-class TealAnthropicCrewAIAdapter:
-    """Adapt TealAnthropic to CrewAI's LLM .call(messages) -> str protocol."""
+# 4. LLM adapter. CrewAI's Agent only accepts strings or BaseLLM
+#    instances, so the wrapper subclasses BaseLLM. CrewAI calls
+#    .call(messages) synchronously; we bridge that to TealAnthropic's
+#    async API. main() is synchronous so asyncio.run() here doesn't
+#    nest inside a running loop.
+class TealAnthropicLLM(BaseLLM):
+    """Subclass of CrewAI's BaseLLM that delegates to TealAnthropic."""
 
-    def __init__(
+    def __init__(self, teal_anthropic: TealAnthropic, model: str, max_tokens: int = 1024):
+        super().__init__(model=model)
+        # Pydantic model — keep the runtime-only attributes off the
+        # validator path by setting them on the underlying dict.
+        self.__dict__["_client"] = teal_anthropic
+        self.__dict__["_max_tokens"] = max_tokens
+
+    def call(  # type: ignore[override]
         self,
-        teal_anthropic: TealAnthropic,
-        model: str,
-        max_tokens: int = 1024,
-    ):
-        self._client = teal_anthropic
-        self._model = model
-        self._max_tokens = max_tokens
-
-    def call(self, messages: List[Dict[str, str]], **_: Any) -> str:
+        messages,
+        tools=None,
+        callbacks=None,
+        available_functions=None,
+        from_task=None,
+        from_agent=None,
+        response_model=None,
+    ) -> str:
+        if isinstance(messages, str):
+            messages = [{"role": "user", "content": messages}]
         response = asyncio.run(
             self._client.messages.create(
-                model=self._model,
+                model=self.model,
                 max_tokens=self._max_tokens,
                 messages=messages,
             )
         )
-        # MessageCreateResponse.content is List[Dict[str, Any]] in the SDK,
-        # not Anthropic's content-block objects.
+        # MessageCreateResponse.content is List[Dict[str, Any]] in the
+        # SDK, not Anthropic's content-block objects.
         return response.content[0]["text"]
 
 
 def main() -> None:
-    # 4. Shared infrastructure: one TealTiger guard for tool calls, one
-    #    cost tracker, and one storage. Every tool call and every LLM call
-    #    funnels through these so per-agent and crew-total queries both
-    #    work off the same data.
+    # 5. Shared infrastructure: one TealTiger guard for tool calls, one
+    #    cost tracker, and one storage. Every tool call and every LLM
+    #    call funnels through these so per-agent and crew-total queries
+    #    both work off the same data.
     guard = TealTiger(
         api_key=os.getenv("TEALTIGER_API_KEY", "demo-key"),
         ssa_url=os.getenv("TEALTIGER_SSA_URL", "http://localhost:3000"),
@@ -191,13 +225,9 @@ def main() -> None:
         enable_alerts=True,
     ))
 
-    # 5. Crew-wide budget. Multi-agent workflows fan out fast; a $5/day
-    #    cap catches runaway crews before they bill. action="block" is
-    #    what enforces the cap; action="alert" only emits warnings and
-    #    still returns allowed=True from check_budget. Alert thresholds
-    #    at 50/75/90 fire on the way to the cap. BudgetManager
-    #    .create_budget takes positional fields, not a pre-built
-    #    BudgetConfig.
+    # 6. Crew-wide budget. action="block" is what enforces the cap;
+    #    "alert" only emits warnings and still returns allowed=True.
+    #    Alert thresholds at 50/75/90 fire on the way to the cap.
     budget_manager = BudgetManager(storage)
     budget_manager.create_budget(
         name="Research Crew Daily Budget",
@@ -208,22 +238,22 @@ def main() -> None:
         enabled=True,
     )
 
-    # 6. Policy is authored here and is expected to already be deployed to
-    #    the SSA at TEALTIGER_SSA_URL. We log it once on startup so the
-    #    rules show up in the example's output.
+    # 7. Policy is authored here and is expected to already be deployed
+    #    to the SSA at TEALTIGER_SSA_URL. We log it once on startup so
+    #    the rules show up in the example's output.
     policy = build_crew_policy()
     print(f"Loaded policy '{policy.name}' with {len(policy.rules)} rule(s)")
     for rule in policy.rules:
         print(f"  {rule['action'].upper()}: {rule['reason']}")
     print()
 
-    # 7. Two agents, each tagged with its own agent_id. They share the
+    # 8. Two agents, each tagged with its own agent_id. They share the
     #    tool guard, the cost tracker, and the storage.
     researcher_id = "agent-researcher"
     writer_id = "agent-writer"
     anthropic_key = os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key")
 
-    researcher_llm = TealAnthropicCrewAIAdapter(
+    researcher_llm = TealAnthropicLLM(
         teal_anthropic=TealAnthropic(TealAnthropicConfig(
             api_key=anthropic_key,
             agent_id=researcher_id,
@@ -231,9 +261,9 @@ def main() -> None:
             cost_storage=storage,
             budget_manager=budget_manager,
         )),
-        model="claude-3-5-sonnet-20241022",
+        model=DEMO_MODEL,
     )
-    writer_llm = TealAnthropicCrewAIAdapter(
+    writer_llm = TealAnthropicLLM(
         teal_anthropic=TealAnthropic(TealAnthropicConfig(
             api_key=anthropic_key,
             agent_id=writer_id,
@@ -241,7 +271,7 @@ def main() -> None:
             cost_storage=storage,
             budget_manager=budget_manager,
         )),
-        model="claude-3-5-sonnet-20241022",
+        model=DEMO_MODEL,
     )
 
     researcher = Agent(
@@ -263,7 +293,7 @@ def main() -> None:
         allow_delegation=False,
     )
 
-    # 8. A trivial crew. The point of this example is the governance
+    # 9. A trivial crew. The point of this example is the governance
     #    plumbing, not the prompt design.
     research_task = Task(
         description="Find three facts about open-source AI agent frameworks.",
@@ -278,13 +308,14 @@ def main() -> None:
     )
     crew = Crew(agents=[researcher, writer], tasks=[research_task, summary_task])
 
-    # 9. Run the crew. Network calls are stubbed unless ANTHROPIC_API_KEY
-    #    is set; the governance code paths execute either way.
+    # 10. Run the crew. Network calls are stubbed unless
+    #     ANTHROPIC_API_KEY is set; the governance code paths execute
+    #     either way.
     result = crew.kickoff()
     print("Crew output:\n", result)
 
-    # 10. Cost summary across all agents in the crew. Records were written
-    #     by TealAnthropic itself to the shared storage.
+    # 11. Cost summary across all agents in the crew. Records were
+    #     written by TealAnthropic itself to the shared storage.
     print("\n=== Per-agent cost ===")
     for agent_id in (researcher_id, writer_id):
         records = asyncio.run(storage.get_by_agent_id(agent_id))

--- a/examples/python/crewai_integration.py
+++ b/examples/python/crewai_integration.py
@@ -4,27 +4,33 @@ TealTiger + CrewAI Integration
 Shows how to add TealTiger governance to a multi-agent CrewAI workflow:
 
     1. Tool allowlisting: every CrewAI tool call routes through
-       TealTiger.execute_tool_sync() and is gated by a Policy.
+       TealTiger.execute_tool_sync(), which evaluates the policy that has
+       been deployed to the Security Sidecar Agent (SSA). The example
+       authors that policy with PolicyBuilder so the rules are visible in
+       the same file.
     2. Cost tracking: a single CostTracker + InMemoryCostStorage is shared
-       across every agent in the crew so totals aggregate cleanly per
-       agent_id.
+       across every agent in the crew. Each Agent has its own agent_id, so
+       per-agent totals and crew-wide totals both come from the same data.
     3. LLM wrapping: TealAnthropic plugs into a CrewAI Agent through a
-       thin adapter (CrewAI calls LLM.call(messages); the adapter forwards
-       to TealAnthropic.messages.create() and records cost).
+       thin synchronous adapter. CrewAI calls llm.call(messages); the
+       adapter forwards to TealAnthropic.messages.create() (async) and
+       lets TealAnthropic record the cost record internally.
 
 Run with:
 
-    OPENAI_API_KEY=sk-...        # or ANTHROPIC_API_KEY=sk-ant-...
-    pip install 'crewai>=0.55'   # CrewAI is Python-first; not bundled
+    pip install 'crewai>=0.55'
+    ANTHROPIC_API_KEY=sk-ant-...      # required for live LLM calls
+    TEALTIGER_SSA_URL=http://...      # required for tool allowlist
+    TEALTIGER_API_KEY=...
     python examples/python/crewai_integration.py
 
 CrewAI-specific notes this example demonstrates:
-    - CrewAI tools subclass BaseTool and implement _run; that's where
-      TealTiger's allowlist hook belongs.
-    - CrewAI's LLM abstraction expects a .call(messages, **kwargs) -> str
-      method; bridge to TealAnthropic via an adapter class.
-    - Each Agent has its own agent_id; share storage but tag records with
-      the agent so per-agent + crew-total cost queries both work.
+    - CrewAI tools subclass BaseTool and implement _run; that is where the
+      TealTiger allowlist hook belongs.
+    - CrewAI's LLM contract is .call(messages, **kwargs) -> str. The
+      adapter bridges that to TealAnthropic, whose API is async.
+    - The TealTiger policy is enforced by the SSA, not by the local
+      client. Deploy build_crew_policy() to your SSA before running.
 """
 
 import asyncio
@@ -35,19 +41,20 @@ from crewai import Agent, Crew, Task  # type: ignore[import-untyped]
 from crewai.tools import BaseTool  # type: ignore[import-untyped]
 
 from tealtiger import (
-    BudgetConfig,
     BudgetManager,
     CostTracker,
     CostTrackerConfig,
     InMemoryCostStorage,
     PolicyBuilder,
     TealAnthropic,
+    TealAnthropicConfig,
     TealTiger,
 )
 
 
-# 1. Policy: allowlist the tools this crew is allowed to call. Anything not
-#    matched falls through to the default deny rule.
+# 1. Policy authored locally so the rules are visible in this file. Deploy
+#    the resulting Policy to your SSA so TealTiger.execute_tool_sync() can
+#    enforce it. Anything not matched falls through to the default deny.
 def build_crew_policy():
     return (
         PolicyBuilder()
@@ -73,8 +80,9 @@ def build_crew_policy():
 
 
 # 2. Guarded tool: every CrewAI tool _run() routes through TealTiger first.
-#    A deny short-circuits the tool with a clear error; the agent then sees
-#    the failure in its scratchpad and either tries another tool or stops.
+#    A deny short-circuits the tool with a clear error; the agent then
+#    sees the failure in its scratchpad and either tries another tool or
+#    stops.
 class GuardedTool(BaseTool):
     """A CrewAI BaseTool that runs every call through TealTiger first."""
 
@@ -101,8 +109,8 @@ class GuardedTool(BaseTool):
         return self._actual_run(**kwargs)
 
     def _actual_run(self, **kwargs: Any) -> str:
-        # Subclasses override this with the real tool logic. Stubbed here so
-        # the example runs end-to-end without external services.
+        # Subclasses override this with the real tool logic. Stubbed here
+        # so the example runs end-to-end without external services.
         return f"[stub {self.name} result for {kwargs!r}]"
 
 
@@ -110,7 +118,7 @@ class WebSearchTool(GuardedTool):
     def __init__(self, guard: TealTiger, agent_id: str):
         super().__init__(
             name="web_search",
-            description="Search the public web and return a list of result snippets",
+            description="Search the public web and return result snippets",
             guard=guard,
             agent_id=agent_id,
         )
@@ -137,9 +145,10 @@ class CalculatorTool(GuardedTool):
             return f"[calculator error: {exc}]"
 
 
-# 3. LLM adapter: CrewAI agents accept any object with a .call(messages, ...)
-#    method that returns a string. We forward to TealAnthropic so guardrails
-#    + cost-record creation happen on every agent turn.
+# 3. LLM adapter: CrewAI agents accept any object exposing
+#    .call(messages, **kwargs) -> str. We bridge that to TealAnthropic so
+#    guardrails and the internal cost record happen on every agent turn.
+#    main() is synchronous (see below) so asyncio.run() here is safe.
 class TealAnthropicCrewAIAdapter:
     """Adapt TealAnthropic to CrewAI's LLM .call(messages) -> str protocol."""
 
@@ -147,53 +156,33 @@ class TealAnthropicCrewAIAdapter:
         self,
         teal_anthropic: TealAnthropic,
         model: str,
-        cost_tracker: CostTracker,
-        storage: InMemoryCostStorage,
-        agent_id: str,
         max_tokens: int = 1024,
     ):
         self._client = teal_anthropic
         self._model = model
-        self._tracker = cost_tracker
-        self._storage = storage
-        self._agent_id = agent_id
         self._max_tokens = max_tokens
 
-    async def _call_async(self, messages: List[Dict[str, str]]) -> str:
-        response = await self._client.messages.create(
-            model=self._model,
-            max_tokens=self._max_tokens,
-            messages=messages,
-        )
-        usage = getattr(response, "usage", None)
-        if usage is not None:
-            record = self._tracker.calculate_actual_cost(
-                request_id=getattr(response, "id", "crewai-req"),
-                agent_id=self._agent_id,
-                model=self._model,
-                usage={
-                    "input_tokens": getattr(usage, "input_tokens", 0),
-                    "output_tokens": getattr(usage, "output_tokens", 0),
-                    "total_tokens": getattr(usage, "input_tokens", 0)
-                    + getattr(usage, "output_tokens", 0),
-                },
-                provider="anthropic",
-            )
-            await self._storage.store(record)
-        return response.content[0].text
-
     def call(self, messages: List[Dict[str, str]], **_: Any) -> str:
-        return asyncio.run(self._call_async(messages))
+        response = asyncio.run(
+            self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                messages=messages,
+            )
+        )
+        # MessageCreateResponse.content is List[Dict[str, Any]] in the SDK,
+        # not Anthropic's content-block objects.
+        return response.content[0]["text"]
 
 
-async def main() -> None:
-    # 4. Shared infrastructure: one TealTiger guard, one cost tracker, one
-    #    storage. Every tool call and every LLM call funnels through these,
-    #    so per-agent and crew-total queries both work off the same data.
+def main() -> None:
+    # 4. Shared infrastructure: one TealTiger guard for tool calls, one
+    #    cost tracker, and one storage. Every tool call and every LLM call
+    #    funnels through these so per-agent and crew-total queries both
+    #    work off the same data.
     guard = TealTiger(
         api_key=os.getenv("TEALTIGER_API_KEY", "demo-key"),
         ssa_url=os.getenv("TEALTIGER_SSA_URL", "http://localhost:3000"),
-        policy=build_crew_policy(),
     )
     storage = InMemoryCostStorage()
     cost_tracker = CostTracker(CostTrackerConfig(
@@ -203,46 +192,54 @@ async def main() -> None:
         enable_alerts=True,
     ))
 
-    # 5. Crew-wide budget. Multi-agent workflows fan out fast; a $5/day cap
-    #    with alerts at 50/75/90% catches runaway crews before they bill.
+    # 5. Crew-wide budget. Multi-agent workflows fan out fast; a $5/day
+    #    cap with alerts at 50/75/90% catches runaway crews before they
+    #    bill. BudgetManager.create_budget takes positional fields, not a
+    #    pre-built BudgetConfig.
     budget_manager = BudgetManager(storage)
-    budget_manager.create_budget(BudgetConfig(
+    budget_manager.create_budget(
         name="Research Crew Daily Budget",
         limit=5.0,
         period="daily",
         alert_thresholds=[50, 75, 90],
         action="alert",
         enabled=True,
-    ))
+    )
 
-    # 6. Two agents, each with its own agent_id so cost queries can split by
-    #    role. They share the tool guard and cost tracker.
+    # 6. Policy is authored here and is expected to already be deployed to
+    #    the SSA at TEALTIGER_SSA_URL. We log it once on startup so the
+    #    rules show up in the example's output.
+    policy = build_crew_policy()
+    print(f"Loaded policy '{policy.name}' with {len(policy.rules)} rule(s)")
+    for rule in policy.rules:
+        print(f"  {rule['action'].upper()}: {rule['reason']}")
+    print()
+
+    # 7. Two agents, each tagged with its own agent_id. They share the
+    #    tool guard, the cost tracker, and the storage.
     researcher_id = "agent-researcher"
     writer_id = "agent-writer"
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key")
 
     researcher_llm = TealAnthropicCrewAIAdapter(
-        teal_anthropic=TealAnthropic(
-            api_key=os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key"),
+        teal_anthropic=TealAnthropic(TealAnthropicConfig(
+            api_key=anthropic_key,
             agent_id=researcher_id,
             cost_tracker=cost_tracker,
             cost_storage=storage,
-        ),
+            budget_manager=budget_manager,
+        )),
         model="claude-3-5-sonnet-20241022",
-        cost_tracker=cost_tracker,
-        storage=storage,
-        agent_id=researcher_id,
     )
     writer_llm = TealAnthropicCrewAIAdapter(
-        teal_anthropic=TealAnthropic(
-            api_key=os.getenv("ANTHROPIC_API_KEY", "demo-anthropic-key"),
+        teal_anthropic=TealAnthropic(TealAnthropicConfig(
+            api_key=anthropic_key,
             agent_id=writer_id,
             cost_tracker=cost_tracker,
             cost_storage=storage,
-        ),
+            budget_manager=budget_manager,
+        )),
         model="claude-3-5-sonnet-20241022",
-        cost_tracker=cost_tracker,
-        storage=storage,
-        agent_id=writer_id,
     )
 
     researcher = Agent(
@@ -264,7 +261,7 @@ async def main() -> None:
         allow_delegation=False,
     )
 
-    # 7. A trivial crew. The point of the example is the governance
+    # 8. A trivial crew. The point of this example is the governance
     #    plumbing, not the prompt design.
     research_task = Task(
         description="Find three facts about open-source AI agent frameworks.",
@@ -279,18 +276,19 @@ async def main() -> None:
     )
     crew = Crew(agents=[researcher, writer], tasks=[research_task, summary_task])
 
-    # 8. Run the crew. Network calls are stubbed unless ANTHROPIC_API_KEY is
-    #    set; the governance code paths execute either way.
+    # 9. Run the crew. Network calls are stubbed unless ANTHROPIC_API_KEY
+    #    is set; the governance code paths execute either way.
     result = crew.kickoff()
     print("Crew output:\n", result)
 
-    # 9. Cost summary across all agents in the crew.
+    # 10. Cost summary across all agents in the crew. Records were written
+    #     by TealAnthropic itself to the shared storage.
     print("\n=== Per-agent cost ===")
     for agent_id in (researcher_id, writer_id):
-        records = await storage.get_by_agent_id(agent_id)
+        records = asyncio.run(storage.get_by_agent_id(agent_id))
         total = sum(r.actual_cost for r in records)
         print(f"  {agent_id}: {len(records)} call(s), ${total:.6f}")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
Resolves #19.

Adds `examples/python/crewai_integration.py` that demonstrates the three governance dimensions from the issue:

- **Tool allowlisting** via `PolicyBuilder` and `TealTiger.execute_tool_sync()` inside concrete CrewAI `BaseTool` subclasses (typed `_run` so CrewAI can derive `args_schema`).
- **Cost tracking across multi-agent execution** via a single shared `CostTracker` + `InMemoryCostStorage`. Each `Agent` is tagged with its own `agent_id` and per-agent + crew-total queries both resolve to the same data.
- **LLM wrapping** via a `crewai.BaseLLM` subclass that delegates to `TealAnthropic`. CrewAI rejects arbitrary `llm=` objects, so the adapter has to be a `BaseLLM` instance.

## Acceptance criteria

- [x] Example passes Python syntax check (`python3 -m py_compile`)
- [x] Comments explain the integration pattern
- [x] Shows governance across multiple agents (researcher + writer share guard, tracker, storage, budget)

## Implementation notes

- Pinned `crewai>=1.0` so `from crewai.tools import BaseTool` and `from crewai import BaseLLM` both resolve. 0.70.x does not expose `BaseTool` at that path.
- `DEMO_MODEL = "claude-3-haiku-20240307"` is in the SDK's `MODEL_PRICING` table, so cost records are non-zero and the daily budget actually trips.
- Crew-wide budget uses `action="block"`; `"alert"` only emits warnings and still returns `allowed=True` from `check_budget`.
- `_safe_arith` walks the AST and rejects anything outside arithmetic operators, so the calculator handles `2+2` instead of raising on non-literal input.

The example is runnable end-to-end with stubbed tool implementations so it does not require network access to demonstrate the governance plumbing.