### PR TITLE
feat(examples): add Python quickstart for TealOpenAI

### DIFF
--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -1,0 +1,114 @@
+"""
+TealOpenAI Quickstart
+
+Shortest runnable example of wrapping OpenAI's API with TealTiger's
+guardrails, prompt-injection detection, and cost tracking. Run with:
+
+    OPENAI_API_KEY=sk-... python examples/python/quickstart.py
+
+What this example demonstrates:
+    - PII detection (redact mode) so e.g. emails / phone numbers in user
+      prompts are scrubbed before they reach the model
+    - Prompt-injection detection (block mode) so jailbreak-style prompts
+      are stopped before billing kicks in
+    - A daily $5 budget with alerts at 50 / 75 / 90% thresholds
+    - The `response.security` envelope that TealOpenAI adds on top of
+      OpenAI's normal chat-completion response (guardrail outcome, cost
+      record, budget check)
+"""
+
+import asyncio
+import os
+
+from tealtiger import (
+    BudgetConfig,
+    BudgetManager,
+    CostTracker,
+    CostTrackerConfig,
+    GuardrailEngine,
+    InMemoryCostStorage,
+    PIIDetectionGuardrail,
+    PromptInjectionGuardrail,
+    TealOpenAI,
+)
+
+
+async def main() -> None:
+    """Build a TealOpenAI client, send one chat completion, print metadata."""
+    # 1. Guardrails: redact PII, block obvious prompt-injection attempts.
+    guardrail_engine = GuardrailEngine()
+    guardrail_engine.register_guardrail(PIIDetectionGuardrail(
+        name="pii-detection",
+        enabled=True,
+        action="redact",
+    ))
+    guardrail_engine.register_guardrail(PromptInjectionGuardrail(
+        name="prompt-injection",
+        enabled=True,
+        action="block",
+    ))
+
+    # 2. Cost tracking + a daily $5 budget with alerts at 50 / 75 / 90%.
+    storage = InMemoryCostStorage()
+    cost_tracker = CostTracker(CostTrackerConfig(
+        enabled=True,
+        persist_records=True,
+        enable_budgets=True,
+        enable_alerts=True,
+    ))
+    budget_manager = BudgetManager(storage)
+    budget_manager.create_budget(BudgetConfig(
+        name="Quickstart Daily Budget",
+        limit=5.0,
+        period="daily",
+        alert_thresholds=[50, 75, 90],
+        action="alert",
+        enabled=True,
+    ))
+
+    # 3. TealOpenAI is a drop-in wrapper around the upstream OpenAI SDK;
+    #    method shapes (`client.chat.completions.create(...)`) match.
+    client = TealOpenAI(
+        api_key=os.getenv("OPENAI_API_KEY", "your-openai-api-key"),
+        agent_id="quickstart-agent",
+        guardrail_engine=guardrail_engine,
+        cost_tracker=cost_tracker,
+        budget_manager=budget_manager,
+        cost_storage=storage,
+    )
+
+    # 4. One chat completion. The user message contains an email so the
+    #    PII guardrail has something to redact in its pre-flight pass; the
+    #    redacted text is what actually reaches OpenAI.
+    response = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        max_tokens=120,
+        messages=[
+            {"role": "system", "content": "You answer in one sentence."},
+            {
+                "role": "user",
+                "content": (
+                    "My email is jane@example.com — in one sentence, what "
+                    "does TealTiger do?"
+                ),
+            },
+        ],
+    )
+
+    # 5. Plain-OpenAI fields work as usual.
+    print("Response:", response.choices[0].message.content)
+
+    # 6. The `security` attribute is what TealOpenAI adds on top.
+    security = getattr(response, "security", None)
+    if security is None:
+        return
+    if security.guardrail_result is not None:
+        print(f"Guardrails passed: {security.guardrail_result.passed}")
+    if security.cost_record is not None:
+        print(f"Cost: ${security.cost_record.actual_cost:.6f}")
+    if security.budget_check is not None:
+        print(f"Budget allowed: {security.budget_check.allowed}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Closes #12

## Summary

Adds `examples/python/quickstart.py` as the OpenAI sibling of the existing `examples/python/anthropic_quickstart.py`. Same single-async-main shape, same numbered-step comments, same `response.security` envelope at the end - just the OpenAI flavor.

## Acceptance criteria

- [x] **Uses TealOpenAI client** - imports and instantiates `TealOpenAI` with the same constructor shape used in `packages/tealtiger-python/examples/guarded_openai_demo.py`.
- [x] **PII detection enabled** - `PIIDetectionGuardrail` registered in `redact` mode, and the demo user prompt embeds a fake email so the guardrail has something to scrub before the message reaches OpenAI.
- [x] **Prompt injection guardrail enabled** - `PromptInjectionGuardrail` registered in `block` mode.
- [x] **Budget limit set** - `BudgetManager` + `BudgetConfig`: $5/day with alert thresholds at 50 / 75 / 90%.
- [x] **Response shows security metadata** - prints the `response.security` envelope (guardrail outcome, cost, budget allowance) on top of the normal `response.choices[0].message.content`.
- [x] **Comments per step** - numbered 1-6, each block annotated.
- [x] **Type hints + docstring** - module docstring, `async def main() -> None:` with a one-line docstring.

## Files

- `examples/python/quickstart.py` - new, 114 lines.

## How to run

```bash
OPENAI_API_KEY=sk-... python examples/python/quickstart.py
```

## Notes

- Mirrors `anthropic_quickstart.py` deliberately so the two read as a clean before-and-after of the cross-provider story.
- Used `gpt-4o-mini` as the model so the budget alert never fires in practice for a smoke run; the budget limit is a config demo, not a stress test.
- `ruff check` clean. (No black step - the existing `anthropic_quickstart.py` doesn't conform to `black --line-length 100` either, since `tool.black` config lives under `packages/tealtiger-python/`, not the repo root.)
