### PR TITLE
Add DeepSeek quickstart example

### DIFF
--- a/examples/quickstart-deepseek/README.md
+++ b/examples/quickstart-deepseek/README.md
@@ -1,0 +1,43 @@
+# TealDeepSeek Quickstart
+
+This example shows how to create a guarded DeepSeek client with TealTiger. It demonstrates:
+
+- creating a `TealDeepSeek` client;
+- registering PII and content moderation guardrails;
+- tracking DeepSeek request cost with model-specific pricing;
+- attaching a daily budget and storing request cost records.
+
+## Setup
+
+Install the runtime dependencies from a TypeScript project:
+
+```bash
+npm install tealtiger ts-node typescript @types/node
+```
+
+Set your DeepSeek API key:
+
+```bash
+export DEEPSEEK_API_KEY=sk-your-deepseek-key
+```
+
+Run the quickstart from the TealTiger repository root:
+
+```bash
+npx ts-node examples/quickstart-deepseek/index.ts
+```
+
+## What It Does
+
+The example sends two `chat.completions.create` requests through `TealDeepSeek`:
+
+1. A basic prompt that prints the model response, token count, and tracked cost.
+2. A PII prompt that triggers the PII guardrail in `redact` mode and prints the redacted text from the guardrail metadata.
+
+At the end it prints a cost summary for the `deepseek-quickstart-agent` session.
+
+## Notes
+
+- `TealDeepSeek` uses the OpenAI-compatible `chat.completions.create` shape.
+- The example registers DeepSeek pricing from `DEEPSEEK_PRICING` with `CostTracker` so cost metadata is non-zero for `deepseek-chat`.
+- `ContentModerationGuardrail` uses local pattern matching here (`useOpenAI: false`) so the quickstart only needs a DeepSeek API key.

--- a/examples/quickstart-deepseek/index.ts
+++ b/examples/quickstart-deepseek/index.ts
@@ -1,0 +1,147 @@
+/**
+ * TealDeepSeek Quickstart
+ *
+ * Demonstrates a guarded DeepSeek client with input guardrails,
+ * a daily budget, and per-request cost tracking.
+ *
+ * Run with:
+ *
+ *   DEEPSEEK_API_KEY=sk-... npx ts-node examples/quickstart-deepseek/index.ts
+ */
+
+import {
+  BudgetManager,
+  ContentModerationGuardrail,
+  CostTracker,
+  GuardrailEngine,
+  InMemoryCostStorage,
+  PIIDetectionGuardrail,
+} from 'tealtiger';
+import { DEEPSEEK_PRICING, TealDeepSeek } from 'tealtiger/providers/deepseek';
+
+const MODEL = 'deepseek-chat';
+
+function createGuardrailEngine(): GuardrailEngine {
+  const guardrailEngine = new GuardrailEngine();
+
+  guardrailEngine.registerGuardrail(new PIIDetectionGuardrail({
+    name: 'pii-detection',
+    enabled: true,
+    action: 'redact',
+  }));
+
+  guardrailEngine.registerGuardrail(new ContentModerationGuardrail({
+    name: 'content-moderation',
+    enabled: true,
+    action: 'block',
+    useOpenAI: false,
+  }));
+
+  return guardrailEngine;
+}
+
+function createCostTracker(): CostTracker {
+  const costTracker = new CostTracker({
+    enabled: true,
+    persistRecords: true,
+    enableBudgets: true,
+    enableAlerts: true,
+  });
+
+  const pricing = DEEPSEEK_PRICING[MODEL];
+  costTracker.addCustomPricing(MODEL, {
+    provider: 'custom',
+    inputCostPer1K: pricing.input,
+    outputCostPer1K: pricing.output,
+    lastUpdated: '2026-05-20',
+  });
+
+  return costTracker;
+}
+
+async function main() {
+  const guardrailEngine = createGuardrailEngine();
+  const costStorage = new InMemoryCostStorage();
+  const costTracker = createCostTracker();
+  const budgetManager = new BudgetManager(costStorage);
+
+  budgetManager.createBudget({
+    name: 'DeepSeek Quickstart Daily Budget',
+    limit: 5.0,
+    period: 'daily',
+    alertThresholds: [50, 75, 90],
+    action: 'alert',
+    enabled: true,
+  });
+
+  const client = new TealDeepSeek({
+    apiKey: process.env.DEEPSEEK_API_KEY || 'your-deepseek-api-key',
+    agentId: 'deepseek-quickstart-agent',
+    model: MODEL,
+    guardrailEngine,
+    costTracker,
+    budgetManager,
+    costStorage,
+  });
+
+  console.log('--- Basic DeepSeek request ---');
+  const basic = await client.chat.completions.create({
+    model: MODEL,
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a concise security engineer.',
+      },
+      {
+        role: 'user',
+        content: 'In one sentence, what does TealTiger add around DeepSeek calls?',
+      },
+    ],
+    max_tokens: 120,
+  });
+
+  console.log('Response:', basic.choices[0].message.content);
+  if (basic.security?.costRecord) {
+    console.log(`Cost: $${basic.security.costRecord.actualCost.toFixed(6)}`);
+    console.log(`Tokens: ${basic.security.costRecord.actualTokens.totalTokens}`);
+  }
+
+  console.log('\n--- PII guardrail request ---');
+  const guarded = await client.chat.completions.create({
+    model: MODEL,
+    messages: [
+      {
+        role: 'user',
+        content: 'Draft a support reply for Taylor at taylor@example.com without repeating the email address.',
+      },
+    ],
+    max_tokens: 120,
+  });
+
+  const inputGuardrails = guarded.security?.guardrailResult;
+  const piiResult = inputGuardrails?.results.find(
+    (result) => result.guardrailName === 'pii-detection',
+  );
+  const redactedText = piiResult?.result?.metadata.redactedText;
+
+  console.log('Guardrail summary:', inputGuardrails?.getSummary());
+  if (redactedText) {
+    console.log('Redacted input:', redactedText);
+  }
+  if (guarded.security?.costRecord) {
+    console.log(`Cost: $${guarded.security.costRecord.actualCost.toFixed(6)}`);
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const costSummary = await costStorage.getSummary(today, new Date(), 'deepseek-quickstart-agent');
+
+  console.log('\n--- Cost summary ---');
+  console.log(`Requests tracked: ${costSummary.totalRequests}`);
+  console.log(`Total cost: $${costSummary.totalCost.toFixed(6)}`);
+}
+
+main().catch((error) => {
+  console.error('DeepSeek quickstart failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a new TealDeepSeek quickstart under examples/quickstart-deepseek
- demonstrate PII/content guardrails, daily budget setup, and cost tracking
- document setup and run instructions in the example README

Closes #49.

## Validation
- ./node_modules/.bin/tsc --noEmit --target es2022 --module node16 --moduleResolution node16 --skipLibCheck --types node examples/quickstart-deepseek/index.ts