### PR TITLE
Add Redis memory adapter examples

### DIFF
--- a/examples/python/redis_memory_adapter.py
+++ b/examples/python/redis_memory_adapter.py
@@ -1,0 +1,336 @@
+"""Redis-backed TealMemory adapter example.
+
+This example mirrors the TypeScript MemoryAdapter contract with a Python
+Protocol because the Python SDK currently exposes memory detectors but not a
+formal TealMemory adapter interface.
+
+It demonstrates the same governance shape:
+- write governance scans for secrets before Redis writes;
+- read governance enforces memory scope before Redis reads;
+- Redis PX expiry stores the accepted TTL at the storage layer.
+
+Install the standard Redis Python client before running:
+
+    pip install redis
+
+Run with a local Redis server:
+
+    REDIS_URL=redis://localhost:6379 python examples/python/redis_memory_adapter.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Protocol
+
+from redis.asyncio import Redis, from_url
+
+
+MemoryScope = str
+Classification = str
+
+SECRET_PATTERNS = [
+    re.compile(r"(?:api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]\s*\S{8,}", re.I),
+    re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    re.compile(r"sk_live_[A-Za-z0-9]{24,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]+=*"),
+]
+
+
+@dataclass
+class MemoryRecord:
+    scope: MemoryScope
+    classification: Classification
+    value: str
+    ttl_ms: Optional[int] = None
+    id: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    source: Optional[str] = None
+
+
+@dataclass
+class MemoryQuery:
+    scope: MemoryScope
+    tags: List[str] = field(default_factory=list)
+    prefix: Optional[str] = None
+    contains: Optional[str] = None
+    max_results: Optional[int] = None
+
+
+@dataclass
+class MemoryDelete:
+    scope: MemoryScope
+    id: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class MemoryOperationContext:
+    correlation_id: str
+    tenant_id: Optional[str] = None
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
+
+
+class MemoryAdapter(Protocol):
+    async def put(self, record: MemoryRecord, ctx: MemoryOperationContext) -> str:
+        """Store a governed memory record and return its ID."""
+
+    async def get(self, query: MemoryQuery, ctx: MemoryOperationContext) -> List[MemoryRecord]:
+        """Read governed memory records matching a scope and optional selector."""
+
+    async def delete(self, selector: MemoryDelete, ctx: MemoryOperationContext) -> None:
+        """Delete governed memory records matching a scope and optional selector."""
+
+
+class RedisMemoryAdapter:
+    """MemoryAdapter implementation backed by redis-py asyncio."""
+
+    def __init__(self, redis: Redis, namespace: str = "tealtiger:memory") -> None:
+        self.redis = redis
+        self.namespace = namespace
+
+    async def put(self, record: MemoryRecord, ctx: MemoryOperationContext) -> str:
+        record_id = record.id or str(uuid.uuid4())
+        stored = {
+            **asdict(record),
+            "id": record_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "tenant_id": ctx.tenant_id,
+            "user_id": ctx.user_id,
+            "session_id": ctx.session_id,
+        }
+        key = self._record_key(ctx, record.scope, record_id)
+        index_key = self._scope_index_key(ctx, record.scope)
+
+        if record.ttl_ms and record.ttl_ms > 0:
+            await self.redis.set(key, json.dumps(stored), px=record.ttl_ms)
+        else:
+            await self.redis.set(key, json.dumps(stored))
+
+        await self.redis.sadd(index_key, record_id)
+        return record_id
+
+    async def get(self, query: MemoryQuery, ctx: MemoryOperationContext) -> List[MemoryRecord]:
+        ids = await self.redis.smembers(self._scope_index_key(ctx, query.scope))
+        records: List[MemoryRecord] = []
+        max_results = query.max_results or float("inf")
+
+        for raw_id in ids:
+            if len(records) >= max_results:
+                break
+
+            record_id = raw_id.decode() if isinstance(raw_id, bytes) else str(raw_id)
+            key = self._record_key(ctx, query.scope, record_id)
+            raw_record = await self.redis.get(key)
+
+            if raw_record is None:
+                await self.redis.srem(self._scope_index_key(ctx, query.scope), record_id)
+                continue
+
+            payload = json.loads(raw_record)
+            record = self._to_memory_record(payload)
+            if self._matches_query(record, query):
+                records.append(record)
+
+        return records
+
+    async def delete(self, selector: MemoryDelete, ctx: MemoryOperationContext) -> None:
+        if selector.id:
+            ids = [selector.id]
+        else:
+            raw_ids = await self.redis.smembers(self._scope_index_key(ctx, selector.scope))
+            ids = [raw.decode() if isinstance(raw, bytes) else str(raw) for raw in raw_ids]
+
+        index_key = self._scope_index_key(ctx, selector.scope)
+        for record_id in ids:
+            key = self._record_key(ctx, selector.scope, record_id)
+            raw_record = await self.redis.get(key)
+            if raw_record is None:
+                await self.redis.srem(index_key, record_id)
+                continue
+
+            record = self._to_memory_record(json.loads(raw_record))
+            if not self._matches_delete(record, selector):
+                continue
+
+            await self.redis.delete(key)
+            await self.redis.srem(index_key, record_id)
+
+    async def ttl_ms(self, record_id: str, scope: MemoryScope, ctx: MemoryOperationContext) -> int:
+        """Expose Redis PTTL for the example output."""
+        return int(await self.redis.pttl(self._record_key(ctx, scope, record_id)))
+
+    def _context_key(self, ctx: MemoryOperationContext) -> str:
+        tenant = ctx.tenant_id or "tenant:none"
+        user = ctx.user_id or "user:none"
+        session = ctx.session_id or "session:none"
+        return f"{tenant}:{user}:{session}"
+
+    def _scope_index_key(self, ctx: MemoryOperationContext, scope: MemoryScope) -> str:
+        return f"{self.namespace}:{self._context_key(ctx)}:{scope}:ids"
+
+    def _record_key(self, ctx: MemoryOperationContext, scope: MemoryScope, record_id: str) -> str:
+        return f"{self.namespace}:{self._context_key(ctx)}:{scope}:{record_id}"
+
+    def _to_memory_record(self, payload: Dict[str, Any]) -> MemoryRecord:
+        return MemoryRecord(
+            id=payload.get("id"),
+            scope=payload["scope"],
+            classification=payload["classification"],
+            value=payload["value"],
+            ttl_ms=payload.get("ttl_ms"),
+            tags=payload.get("tags") or [],
+            source=payload.get("source"),
+        )
+
+    def _matches_query(self, record: MemoryRecord, query: MemoryQuery) -> bool:
+        if record.scope != query.scope:
+            return False
+        if query.tags and not any(tag in record.tags for tag in query.tags):
+            return False
+        if query.prefix and not record.value.startswith(query.prefix):
+            return False
+        if query.contains and query.contains not in record.value:
+            return False
+        return True
+
+    def _matches_delete(self, record: MemoryRecord, selector: MemoryDelete) -> bool:
+        if record.scope != selector.scope:
+            return False
+        if selector.id and record.id != selector.id:
+            return False
+        if selector.tags and not any(tag in record.tags for tag in selector.tags):
+            return False
+        return True
+
+
+class TealMemoryGovernance:
+    """Small governance wrapper around the adapter for this example."""
+
+    def __init__(
+        self,
+        adapter: MemoryAdapter,
+        allowed_write_scopes: List[MemoryScope],
+        allowed_read_scopes: List[MemoryScope],
+        ttl_required_for: List[Classification],
+        max_ttl_ms: int,
+    ) -> None:
+        self.adapter = adapter
+        self.allowed_write_scopes = allowed_write_scopes
+        self.allowed_read_scopes = allowed_read_scopes
+        self.ttl_required_for = ttl_required_for
+        self.max_ttl_ms = max_ttl_ms
+
+    async def write(self, record: MemoryRecord, ctx: MemoryOperationContext) -> Dict[str, Any]:
+        if record.scope not in self.allowed_write_scopes:
+            return self._deny("DENY_WRITE", "MEMORY_SCOPE_VIOLATION", "Write denied: scope not allowed")
+
+        if record.classification in self.ttl_required_for and not record.ttl_ms:
+            return self._deny("DENY_WRITE", "MEMORY_TTL_REQUIRED", "Write denied: TTL required")
+
+        if record.ttl_ms and record.ttl_ms > self.max_ttl_ms:
+            return self._deny("DENY_WRITE", "MEMORY_TTL_EXCEEDED", "Write denied: TTL too long")
+
+        if self._contains_secret(record.value):
+            return self._deny("DENY_WRITE", "MEMORY_WRITE_DENIED_SECRET", "Write denied: secret detected")
+
+        record_id = await self.adapter.put(record, ctx)
+        return {
+            "action": "ALLOW_WRITE",
+            "reason_codes": ["MEMORY_WRITE_ALLOWED"],
+            "record_id": record_id,
+        }
+
+    async def read(self, query: MemoryQuery, ctx: MemoryOperationContext) -> Dict[str, Any]:
+        if query.scope not in self.allowed_read_scopes:
+            return self._deny("DENY_READ", "MEMORY_READ_DENIED_SCOPE", "Read denied: scope not allowed")
+
+        records = await self.adapter.get(query, ctx)
+        return {
+            "action": "ALLOW",
+            "reason_codes": ["MEMORY_READ_ALLOWED"],
+            "records": records,
+        }
+
+    def _contains_secret(self, value: str) -> bool:
+        return any(pattern.search(value) for pattern in SECRET_PATTERNS)
+
+    def _deny(self, action: str, reason_code: str, reason: str) -> Dict[str, Any]:
+        return {
+            "action": action,
+            "reason_codes": [reason_code],
+            "reason": reason,
+        }
+
+
+async def main() -> None:
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    redis = from_url(redis_url, decode_responses=True)
+    await redis.ping()
+
+    adapter = RedisMemoryAdapter(redis)
+    memory = TealMemoryGovernance(
+        adapter=adapter,
+        allowed_write_scopes=["SESSION", "USER"],
+        allowed_read_scopes=["SESSION"],
+        ttl_required_for=["CONFIDENTIAL", "RESTRICTED"],
+        max_ttl_ms=60_000,
+    )
+    ctx = MemoryOperationContext(
+        correlation_id="redis-memory-demo",
+        tenant_id="tenant-acme",
+        user_id="user-42",
+        session_id="session-123",
+    )
+
+    print("\n--- Write governance: secret scanning happens before Redis writes ---")
+    secret_write = await memory.write(
+        MemoryRecord(
+            scope="SESSION",
+            classification="CONFIDENTIAL",
+            ttl_ms=30_000,
+            value="api_key=sk_live_this_should_not_be_stored",
+            tags=["support-case"],
+            source="MODEL",
+        ),
+        ctx,
+    )
+    print(secret_write["action"], secret_write["reason_codes"])
+
+    print("\n--- TTL enforcement: accepted records use Redis PX expiry ---")
+    clean_write = await memory.write(
+        MemoryRecord(
+            scope="SESSION",
+            classification="CONFIDENTIAL",
+            ttl_ms=30_000,
+            value="Customer prefers email updates about ticket 123.",
+            tags=["support-case"],
+            source="USER",
+        ),
+        ctx,
+    )
+    print(clean_write["action"], clean_write["reason_codes"])
+    ttl = await adapter.ttl_ms(clean_write["record_id"], "SESSION", ctx)
+    print("Redis TTL remaining (ms):", ttl)
+
+    print("\n--- Read governance: allowed SESSION scope returns Redis records ---")
+    allowed_read = await memory.read(MemoryQuery(scope="SESSION", tags=["support-case"]), ctx)
+    print(allowed_read["action"], allowed_read["reason_codes"])
+    print("Records returned:", len(allowed_read["records"]))
+
+    print("\n--- Read governance: disallowed GLOBAL scope is denied before Redis reads ---")
+    denied_read = await memory.read(MemoryQuery(scope="GLOBAL"), ctx)
+    print(denied_read["action"], denied_read["reason_codes"])
+
+    await redis.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/typescript/redis-memory-adapter.ts
+++ b/examples/typescript/redis-memory-adapter.ts
@@ -1,0 +1,294 @@
+/**
+ * Redis-backed TealMemory adapter example.
+ *
+ * This file shows the adapter pattern TealMemory expects:
+ * - Redis stores only records that pass TealMemory write governance.
+ * - TealMemory performs secret scanning before calling adapter.put().
+ * - TealMemory performs read scope checks before calling adapter.get().
+ * - Redis PX expiry enforces the accepted ttlMs value at the storage layer.
+ *
+ * Install the example dependencies from the repository root before running:
+ *
+ *   npm install redis ts-node typescript
+ *
+ * Run with a local Redis server:
+ *
+ *   REDIS_URL=redis://localhost:6379 npx ts-node examples/typescript/redis-memory-adapter.ts
+ */
+
+import { randomUUID } from 'crypto';
+import { createClient } from 'redis';
+import {
+  TealMemory,
+  type MemoryAdapter,
+  type MemoryDelete,
+  type MemoryOperationContext,
+  type MemoryQuery,
+  type MemoryRecord,
+  type MemoryScope,
+  type TealMemoryPolicy,
+} from '../../packages/tealtiger-sdk/src/memory';
+
+type RedisClient = ReturnType<typeof createClient>;
+
+type StoredMemoryRecord = MemoryRecord & {
+  id: string;
+  createdAt: string;
+  tenant_id?: string;
+  user_id?: string;
+  session_id?: string;
+};
+
+class RedisMemoryAdapter implements MemoryAdapter {
+  constructor(
+    private readonly redis: RedisClient,
+    private readonly namespace = 'tealtiger:memory',
+  ) {}
+
+  async put(record: MemoryRecord, ctx: MemoryOperationContext): Promise<{ id: string }> {
+    const id = record.id ?? randomUUID();
+    const stored: StoredMemoryRecord = {
+      ...record,
+      id,
+      createdAt: new Date().toISOString(),
+      ...(ctx.tenant_id ? { tenant_id: ctx.tenant_id } : {}),
+      ...(ctx.user_id ? { user_id: ctx.user_id } : {}),
+      ...(ctx.session_id ? { session_id: ctx.session_id } : {}),
+    };
+
+    const key = this.recordKey(ctx, record.scope, id);
+    const indexKey = this.scopeIndexKey(ctx, record.scope);
+    const serialized = JSON.stringify(stored);
+    const transaction = this.redis.multi();
+
+    if (record.ttlMs && record.ttlMs > 0) {
+      transaction.set(key, serialized, { PX: record.ttlMs });
+    } else {
+      transaction.set(key, serialized);
+    }
+
+    transaction.sAdd(indexKey, id);
+    await transaction.exec();
+
+    return { id };
+  }
+
+  async get(query: MemoryQuery, ctx: MemoryOperationContext): Promise<MemoryRecord[]> {
+    const ids = await this.redis.sMembers(this.scopeIndexKey(ctx, query.scope));
+    const records: MemoryRecord[] = [];
+    const maxResults = query.maxResults ?? Number.POSITIVE_INFINITY;
+
+    for (const rawId of ids) {
+      if (records.length >= maxResults) break;
+
+      const id = this.decodeRedisValue(rawId);
+      const key = this.recordKey(ctx, query.scope, id);
+      const serialized = await this.redis.get(key);
+
+      if (!serialized) {
+        // The Redis key may have expired while the index member remains.
+        await this.redis.sRem(this.scopeIndexKey(ctx, query.scope), id);
+        continue;
+      }
+
+      const record = JSON.parse(this.decodeRedisValue(serialized)) as StoredMemoryRecord;
+      if (this.matchesQuery(record, query)) {
+        records.push(this.toMemoryRecord(record));
+      }
+    }
+
+    return records;
+  }
+
+  async delete(selector: MemoryDelete, ctx: MemoryOperationContext): Promise<void> {
+    const ids = selector.selector?.id
+      ? [selector.selector.id]
+      : (await this.redis.sMembers(this.scopeIndexKey(ctx, selector.scope))).map((id) =>
+          this.decodeRedisValue(id),
+        );
+    const indexKey = this.scopeIndexKey(ctx, selector.scope);
+
+    for (const id of ids) {
+      const key = this.recordKey(ctx, selector.scope, id);
+      const serialized = await this.redis.get(key);
+      if (!serialized) {
+        await this.redis.sRem(indexKey, id);
+        continue;
+      }
+
+      const record = JSON.parse(this.decodeRedisValue(serialized)) as StoredMemoryRecord;
+      if (!this.matchesDelete(record, selector)) continue;
+
+      await this.redis
+        .multi()
+        .del(key)
+        .sRem(indexKey, id)
+        .exec();
+    }
+  }
+
+  async ttlMs(recordId: string, scope: MemoryScope, ctx: MemoryOperationContext): Promise<number> {
+    const ttl = await this.redis.pTTL(this.recordKey(ctx, scope, recordId));
+    return typeof ttl === 'number' ? ttl : Number(ttl);
+  }
+
+  private decodeRedisValue(value: string | Buffer): string {
+    return Buffer.isBuffer(value) ? value.toString('utf8') : value;
+  }
+
+  private scopeIndexKey(ctx: MemoryOperationContext, scope: MemoryScope): string {
+    return `${this.namespace}:${this.contextKey(ctx)}:${scope}:ids`;
+  }
+
+  private recordKey(ctx: MemoryOperationContext, scope: MemoryScope, id: string): string {
+    return `${this.namespace}:${this.contextKey(ctx)}:${scope}:${id}`;
+  }
+
+  private contextKey(ctx: MemoryOperationContext): string {
+    const tenant = ctx.tenant_id ?? 'tenant:none';
+    const user = ctx.user_id ?? 'user:none';
+    const session = ctx.session_id ?? 'session:none';
+    return `${tenant}:${user}:${session}`;
+  }
+
+  private matchesQuery(record: StoredMemoryRecord, query: MemoryQuery): boolean {
+    if (record.scope !== query.scope) return false;
+    const selector = query.selector;
+    if (!selector) return true;
+
+    if (selector.tags?.length) {
+      const recordTags = record.tags ?? [];
+      if (!selector.tags.some((tag) => recordTags.includes(tag))) return false;
+    }
+    if (selector.prefix && !record.value.startsWith(selector.prefix)) return false;
+    if (selector.contains && !record.value.includes(selector.contains)) return false;
+
+    return true;
+  }
+
+  private matchesDelete(record: StoredMemoryRecord, selector: MemoryDelete): boolean {
+    if (record.scope !== selector.scope) return false;
+    if (!selector.selector) return true;
+
+    if (selector.selector.id && record.id !== selector.selector.id) return false;
+    if (selector.selector.tags?.length) {
+      const recordTags = record.tags ?? [];
+      return selector.selector.tags.some((tag) => recordTags.includes(tag));
+    }
+
+    return true;
+  }
+
+  private toMemoryRecord(record: StoredMemoryRecord): MemoryRecord {
+    return {
+      id: record.id,
+      scope: record.scope,
+      classification: record.classification,
+      value: record.value,
+      ...(record.ttlMs !== undefined ? { ttlMs: record.ttlMs } : {}),
+      ...(record.tags !== undefined ? { tags: record.tags } : {}),
+      ...(record.source !== undefined ? { source: record.source } : {}),
+    };
+  }
+}
+
+const memoryPolicy: TealMemoryPolicy = {
+  enabled: true,
+  write: {
+    allowed_scopes: ['SESSION', 'USER'],
+    deny_if: {
+      secrets: true,
+      pii: true,
+    },
+  },
+  read: {
+    allowed_scopes: ['SESSION'],
+    enforce_classification: true,
+    max_results: 10,
+  },
+  retention: {
+    ttl_required_for: ['CONFIDENTIAL', 'RESTRICTED'],
+    max_ttl_ms: 60_000,
+  },
+};
+
+async function runExample(): Promise<void> {
+  const redis = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  });
+
+  redis.on('error', (error) => {
+    console.error('Redis client error:', error.message);
+  });
+
+  await redis.connect();
+
+  const adapter = new RedisMemoryAdapter(redis);
+  const memory = new TealMemory({ adapter });
+  const ctx: MemoryOperationContext = {
+    correlation_id: 'redis-memory-demo',
+    tenant_id: 'tenant-acme',
+    user_id: 'user-42',
+    session_id: 'session-123',
+  };
+
+  console.log('\n--- Write governance: secret scanning happens before Redis writes ---');
+  const secretWrite = await memory.write(
+    {
+      scope: 'SESSION',
+      classification: 'CONFIDENTIAL',
+      ttlMs: 30_000,
+      value: 'api_key=sk_live_this_should_not_be_stored',
+      tags: ['support-case'],
+      source: 'MODEL',
+    },
+    ctx,
+    memoryPolicy,
+  );
+  console.log(secretWrite.action, secretWrite.reason_codes);
+
+  console.log('\n--- TTL enforcement: accepted records use Redis PX expiry ---');
+  const cleanWrite = await memory.write(
+    {
+      scope: 'SESSION',
+      classification: 'CONFIDENTIAL',
+      ttlMs: 30_000,
+      value: 'Customer prefers email updates about ticket 123.',
+      tags: ['support-case'],
+      source: 'USER',
+    },
+    ctx,
+    memoryPolicy,
+  );
+  console.log(cleanWrite.action, cleanWrite.reason_codes);
+
+  const records = await adapter.get({ scope: 'SESSION', maxResults: 1 }, ctx);
+  const ttl = records[0]?.id
+    ? await adapter.ttlMs(records[0].id, records[0].scope, ctx)
+    : -2;
+  console.log('Redis TTL remaining (ms):', ttl);
+
+  console.log('\n--- Read governance: allowed SESSION scope returns Redis records ---');
+  const allowedRead = await memory.read(
+    { scope: 'SESSION', selector: { tags: ['support-case'] } },
+    ctx,
+    memoryPolicy,
+  );
+  console.log(allowedRead.decision.action, allowedRead.decision.reason_codes);
+  console.log('Records returned:', allowedRead.records.length);
+
+  console.log('\n--- Read governance: disallowed GLOBAL scope is denied before Redis reads ---');
+  const deniedRead = await memory.read(
+    { scope: 'GLOBAL' },
+    ctx,
+    memoryPolicy,
+  );
+  console.log(deniedRead.decision.action, deniedRead.decision.reason_codes);
+
+  await redis.quit();
+}
+
+runExample().catch((error) => {
+  console.error('Redis memory adapter example failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a TypeScript Redis MemoryAdapter example for TealMemory.
- Add a Python redis-py asyncio adapter example that mirrors the MemoryAdapter contract.
- Demonstrate write governance, read scope enforcement, and Redis TTL enforcement.

## Validation
- npx tsc --noEmit --module commonjs --target es2020 --moduleResolution node --esModuleInterop --skipLibCheck --strict --noUnusedLocals --noUnusedParameters --exactOptionalPropertyTypes --baseUrl ./node_modules ../../examples/typescript/redis-memory-adapter.ts
- python3 -c "from pathlib import Path; p=Path('examples/python/redis_memory_adapter.py'); compile(p.read_text(), str(p), 'exec'); print('python syntax ok')"

Fixes #16