### PR TITLE
Docs: Add LangChain governance example with TealTiger

### DIFF
--- a/examples/langchain-governance/README.md
+++ b/examples/langchain-governance/README.md
@@ -1,0 +1,78 @@
+# LangChain Governance Example
+
+This example shows how to add TealTiger governance to a LangChain tool-calling agent with a small wrapper around each tool.
+
+It demonstrates:
+
+- a LangChain agent with two tools;
+- a TealEngine policy evaluation before each tool call;
+- an `ALLOW` decision for the read-only `search_docs` tool;
+- a `DENY` decision for the destructive `delete_customer` tool;
+- blocked tool execution when TealTiger returns `DENY`;
+- cost tracking across the agent run with `CostTracker`, `BudgetManager`, and `InMemoryCostStorage`.
+
+## How It Works
+
+LangChain owns agent orchestration and tool selection. TealTiger owns the governance decision before each tool body runs.
+
+The example uses this flow:
+
+1. Create a `TealEngine` policy that allows `search_docs` and denies `delete_customer`.
+2. Create a LangChain tool-calling agent with both tools available.
+3. Wrap each tool body with `TealEngine.evaluateWithMode(...)`.
+4. Execute the tool only when the decision action is `ALLOW`.
+5. Return a blocked result to the agent when the decision action is `DENY`.
+6. Record LangChain model token usage with TealTiger cost tracking.
+7. Print the final agent response and cost summary.
+
+## Run
+
+From the repository root, install the example dependencies:
+
+```bash
+npm install tealtiger@1.3.0 langchain @langchain/openai @langchain/core zod ts-node typescript
+```
+
+Set an OpenAI key:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+On PowerShell:
+
+```powershell
+$env:OPENAI_API_KEY="sk-..."
+```
+
+Run the example:
+
+```bash
+npx ts-node examples/langchain-governance/index.ts
+```
+
+Optional:
+
+```bash
+export OPENAI_MODEL="gpt-4o-mini"
+```
+
+## Expected Output
+
+The output includes two governance decisions:
+
+1. `search_docs` is allowed because it is explicitly permitted by the TealEngine policy.
+2. `delete_customer` is denied because it is explicitly blocked by the TealEngine policy.
+
+The important lines look like:
+
+```text
+[TealTiger] ALLOW tool=search_docs reasons=POLICY_COMPLIANT
+[TealTiger] DENY tool=delete_customer reasons=POLICY_VIOLATION,TOOL_NOT_ALLOWED
+```
+
+The denied tool body is not executed. The agent receives a blocked tool result instead, then the example prints a cost summary for the run.
+
+## Why This Matters
+
+LangChain can decide which tools an agent wants to call, but production systems still need a deterministic control point before side effects happen. Wrapping tool execution with TealEngine keeps that boundary explicit: the agent may request a tool call, but TealTiger decides whether the call is allowed before the tool body runs.

--- a/examples/langchain-governance/index.ts
+++ b/examples/langchain-governance/index.ts
@@ -13,25 +13,20 @@
  *   npx ts-node examples/langchain-governance/index.ts
  */
 
-const AGENT_ID = 'langchain-governance-demo-agent';
-const RUN_ID = `langchain-demo-${Date.now()}`;
-const MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
-
-if (!process.env.OPENAI_API_KEY) {
-  console.error('LangChain governance example failed: Error: OPENAI_API_KEY is required to run the LangChain governance example.');
-  process.exit(1);
-}
-
-const { ChatOpenAI } = require('@langchain/openai');
-const { tool, createAgent } = require('langchain');
-const z = require('zod');
-const {
+import { ChatOpenAI } from '@langchain/openai';
+import { createAgent, tool } from 'langchain';
+import * as z from 'zod';
+import {
   BudgetManager,
   CostTracker,
   ContextManager,
   InMemoryCostStorage,
   TealEngine,
-} = require('tealtiger');
+} from 'tealtiger';
+
+const AGENT_ID = 'langchain-governance-demo-agent';
+const RUN_ID = `langchain-demo-${Date.now()}`;
+const MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 
 type ToolCallInput = Record<string, unknown>;
 
@@ -206,6 +201,10 @@ const deleteCustomer = tool(
 );
 
 async function main(): Promise<void> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY is required to run the LangChain governance example.');
+  }
+
   const model = new ChatOpenAI({
     model: MODEL,
     temperature: 0,

--- a/examples/langchain-governance/index.ts
+++ b/examples/langchain-governance/index.ts
@@ -1,0 +1,259 @@
+/**
+ * LangChain governance example with TealEngine.
+ *
+ * The example models the security boundary around LangChain tool calls:
+ * 1. A LangChain tool-calling agent chooses tools.
+ * 2. Each tool wrapper evaluates the call with TealEngine before execution.
+ * 3. Allowed tool calls execute normally.
+ * 4. Denied tool calls return a blocked result without running the tool body.
+ * 5. LangChain model token usage is recorded with TealTiger cost tracking.
+ *
+ * Run from the repository root with:
+ *
+ *   npx ts-node examples/langchain-governance/index.ts
+ */
+
+const AGENT_ID = 'langchain-governance-demo-agent';
+const RUN_ID = `langchain-demo-${Date.now()}`;
+const MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+if (!process.env.OPENAI_API_KEY) {
+  console.error('LangChain governance example failed: Error: OPENAI_API_KEY is required to run the LangChain governance example.');
+  process.exit(1);
+}
+
+const { ChatOpenAI } = require('@langchain/openai');
+const { tool, createAgent } = require('langchain');
+const z = require('zod');
+const {
+  BudgetManager,
+  CostTracker,
+  ContextManager,
+  InMemoryCostStorage,
+  TealEngine,
+} = require('tealtiger');
+
+type ToolCallInput = Record<string, unknown>;
+
+type GovernedToolSpec = {
+  name: string;
+  description: string;
+  execute: (input: ToolCallInput) => Promise<string> | string;
+};
+
+const engine = new TealEngine(
+  {
+    identity: {
+      agentId: AGENT_ID,
+      role: 'support-agent',
+      permissions: ['read:docs'],
+      forbidden: ['delete:customer'],
+    },
+    tools: {
+      search_docs: { allowed: true },
+      delete_customer: { allowed: false },
+    },
+    behavioral: {
+      costLimit: {
+        daily: 5.0,
+        hourly: 1.0,
+      },
+      rateLimit: {
+        requests: 20,
+        window: '1h',
+      },
+    },
+  },
+  {
+    mode: { default: 'ENFORCE' },
+  } as any,
+);
+
+const executionContext = ContextManager.createContext({
+  application: 'langchain-governance-example',
+  environment: 'development',
+  run_id: RUN_ID,
+});
+
+const costStorage = new InMemoryCostStorage();
+const costTracker = new CostTracker({
+  enabled: true,
+  persistRecords: true,
+  enableBudgets: true,
+  enableAlerts: true,
+});
+const budgetManager = new BudgetManager(costStorage);
+
+costTracker.addCustomPricing(MODEL, {
+  model: MODEL,
+  provider: 'openai',
+  inputCostPer1K: 0.00015,
+  outputCostPer1K: 0.0006,
+  lastUpdated: '2026-05-22',
+});
+
+budgetManager.createBudget({
+  name: 'LangChain Governance Demo Budget',
+  limit: 5.0,
+  period: 'daily',
+  alertThresholds: [50, 75, 90, 100],
+  action: 'alert',
+  enabled: true,
+});
+
+let governedToolCalls = 0;
+let trackedModelCostUsd = 0;
+
+function reasonCodes(decision: any): string[] {
+  return decision.reason_codes || decision.reasonCodes || [];
+}
+
+function evaluateToolCall(toolName: string, toolArgs: ToolCallInput) {
+  return engine.evaluateWithMode(
+    {
+      agentId: AGENT_ID,
+      action: 'tool.execute',
+      tool: toolName,
+      toolParams: toolArgs,
+      metadata: {
+        run_id: RUN_ID,
+        environment: 'development',
+      },
+    },
+    executionContext,
+  );
+}
+
+function createGovernedTool(spec: GovernedToolSpec) {
+  return async (input: ToolCallInput): Promise<string> => {
+    const decision = evaluateToolCall(spec.name, input);
+    const codes = reasonCodes(decision);
+
+    governedToolCalls += 1;
+    console.log(`[TealTiger] ${decision.action} tool=${spec.name} reasons=${codes.join(',')}`);
+
+    if (decision.action === 'DENY') {
+      return `TealTiger DENY: ${spec.name} was blocked before execution. Reason: ${decision.reason}`;
+    }
+
+    return spec.execute(input);
+  };
+}
+
+function extractTokenUsage(output: any): { inputTokens: number; outputTokens: number } | undefined {
+  const usage = output?.llmOutput?.tokenUsage || output?.llmOutput?.usage;
+  const inputTokens = usage?.promptTokens || usage?.prompt_tokens || usage?.input_tokens;
+  const outputTokens = usage?.completionTokens || usage?.completion_tokens || usage?.output_tokens;
+
+  if (typeof inputTokens !== 'number' || typeof outputTokens !== 'number') {
+    return undefined;
+  }
+
+  return { inputTokens, outputTokens };
+}
+
+async function recordModelUsage(inputTokens: number, outputTokens: number): Promise<void> {
+  const record = costTracker.calculateActualCost(
+    `${RUN_ID}-llm-${Date.now()}`,
+    AGENT_ID,
+    MODEL,
+    {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    },
+    'openai',
+    { runId: RUN_ID },
+  );
+
+  await costStorage.store(record);
+  await budgetManager.recordCost(record);
+  trackedModelCostUsd += record.actualCost;
+}
+
+const searchDocs = tool(
+  createGovernedTool({
+    name: 'search_docs',
+    description: 'Search public TealTiger documentation. This read-only tool is allowed.',
+    execute: ({ query }) => {
+      return `Docs result for "${query}": TealTiger evaluates each LangChain tool call before side effects.`;
+    },
+  }),
+  {
+    name: 'search_docs',
+    description: 'Search public TealTiger documentation. This read-only tool is allowed.',
+    schema: z.object({
+      query: z.string().describe('Short documentation search query.'),
+    }),
+  },
+);
+
+const deleteCustomer = tool(
+  createGovernedTool({
+    name: 'delete_customer',
+    description: 'Delete a customer account. This destructive tool is denied by policy.',
+    execute: ({ customer_id }) => {
+      return `Deleted customer ${customer_id}`;
+    },
+  }),
+  {
+    name: 'delete_customer',
+    description: 'Delete a customer account. This destructive tool is denied by policy.',
+    schema: z.object({
+      customer_id: z.string().describe('Customer identifier to delete.'),
+    }),
+  },
+);
+
+async function main(): Promise<void> {
+  const model = new ChatOpenAI({
+    model: MODEL,
+    temperature: 0,
+    callbacks: [
+      {
+        handleLLMEnd: async (output) => {
+          const usage = extractTokenUsage(output);
+          if (usage) {
+            await recordModelUsage(usage.inputTokens, usage.outputTokens);
+          }
+        },
+      },
+    ],
+  });
+
+  const agent = createAgent({
+    model,
+    tools: [searchDocs, deleteCustomer],
+    systemPrompt: [
+      'You are a deterministic governance demo agent.',
+      'First call search_docs with query "TealTiger LangChain governance".',
+      'Then call delete_customer with customer_id "cus_demo_123".',
+      'Finally summarize which tool was allowed and which tool was denied.',
+    ].join(' '),
+  });
+
+  const result = await agent.invoke({
+    messages: [
+      {
+        role: 'user',
+        content: 'Demonstrate TealTiger governance around LangChain tool calls.',
+      },
+    ],
+  } as any);
+
+  const latestMessage = result.messages?.[result.messages.length - 1];
+
+  console.log('\nAgent output:');
+  console.log(latestMessage?.content || JSON.stringify(result, null, 2));
+  console.log('\nCost summary:');
+  console.log({
+    model: MODEL,
+    governedToolCalls,
+    trackedModelCostUsd: trackedModelCostUsd.toFixed(6),
+  });
+}
+
+main().catch((error) => {
+  console.error('LangChain governance example failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `examples/langchain-governance/` with a TypeScript LangChain tool-calling governance example
- wrap LangChain tool execution with `TealEngine.evaluateWithMode(...)` before each tool body runs
- demonstrate an allowed `search_docs` tool call and a denied `delete_customer` tool call
- add TealTiger cost tracking across the agent run with `CostTracker`, `BudgetManager`, and `InMemoryCostStorage`
- document setup, run instructions, expected decisions, and the governance boundary in the example README

## Testing
- `npx ts-node examples/langchain-governance/index.ts`
  - verified missing `OPENAI_API_KEY` fails clearly before dependency/provider execution

Fixes #46 