### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,js,json,yml,yaml,mjs}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Closes #71

Adds .editorconfig at repo root with:
- indent_style = space
- indent_size = 2 for TS/JS/JSON/YAML, 4 for Python
- end_of_line = lf, charset = utf-8
- trim_trailing_whitespace = true (except *.md)
- insert_final_newline = true
- Makefile uses tab