### PR TITLE
feat: add Bedrock quickstart example with multi-model routing

### DIFF
--- a/examples/bedrock-quickstart/README.md
+++ b/examples/bedrock-quickstart/README.md
@@ -1,0 +1,61 @@
+# TealBedrock Quickstart — Multi-Model Routing
+
+This example shows how to create a guarded Bedrock client with TealTiger and
+route requests to different models based on task type. It demonstrates:
+
+- creating a `TealBedrock` client with AWS credentials;
+- registering PII and content moderation guardrails;
+- tracking Bedrock request cost with per-model pricing;
+- attaching a daily budget and storing request cost records;
+- a **multi-model router** that selects Claude (reasoning), Llama (code),
+  Titan (summarisation), Cohere (creative), or Haiku (fast Q&A) depending on
+  the task.
+
+## Setup
+
+Install the runtime dependencies from a TypeScript project:
+
+```bash
+npm install tealtiger ts-node typescript @types/node
+```
+
+Set your AWS credentials (the IAM principal needs `bedrock:InvokeModel`):
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+```
+
+Run the quickstart from the TealTiger repository root:
+
+```bash
+npx ts-node examples/bedrock-quickstart/index.ts
+```
+
+## What It Does
+
+The example sends five `invokeModel` requests through `TealBedrock`, each
+routed to a different model via the `routeForTask` function:
+
+1. **Reasoning** → `anthropic.claude-v2` — complex analysis.
+2. **Code** → `meta.llama2-70b-chat-v1` — code generation.
+3. **Summary** → `amazon.titan-text-express-v1` — summarisation.
+4. **Creative** → `cohere.command-text-v14` — creative writing.
+5. **Quick Q&A** → `anthropic.claude-3-haiku-20240307-v1:0` — fast & cheap.
+
+Every request runs through the PII and content moderation guardrails. Cost
+is tracked per request and accumulated in the daily budget. At the end a
+session-level cost summary is printed.
+
+## Notes
+
+- The IAM principal must have `bedrock:InvokeModel` permission for *all* of
+  the model IDs used in this example. In production, scope the policy to only
+  the models your application needs.
+- Per-model pricing is registered explicitly via `addCustomPricing` so that
+  `CostTracker` reports non-zero cost metadata. Update the values from the
+  [AWS Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/) if
+  they change.
+- `ContentModerationGuardrail` uses local pattern matching here
+  (`useOpenAI: false`) so the quickstart only needs AWS credentials.

--- a/examples/bedrock-quickstart/index.ts
+++ b/examples/bedrock-quickstart/index.ts
@@ -1,0 +1,200 @@
+/**
+ * TealBedrock Quickstart — Multi-Model Routing
+ *
+ * Demonstrates a guarded Bedrock client that routes requests to different
+ * models based on task type (reasoning → Claude, code → Llama, Q&A → Titan).
+ *
+ * Run with:
+ *
+ *   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+ *     npx ts-node examples/bedrock-quickstart/index.ts
+ */
+
+import {
+  BudgetManager,
+  ContentModerationGuardrail,
+  CostTracker,
+  GuardrailEngine,
+  InMemoryCostStorage,
+  PIIDetectionGuardrail,
+} from 'tealtiger';
+import { TealBedrock } from 'tealtiger/providers/bedrock';
+
+const BEDROCK_PRICING: Record<string, { input: number; output: number }> = {
+  'anthropic.claude-v2':                          { input: 0.01102, output: 0.03268 },
+  'anthropic.claude-instant-v1':                  { input: 0.00163, output: 0.00551 },
+  'anthropic.claude-3-haiku-20240307-v1:0':      { input: 0.00025, output: 0.00125 },
+  'meta.llama2-70b-chat-v1':                     { input: 0.00195, output: 0.00256 },
+  'amazon.titan-text-express-v1':                { input: 0.00080, output: 0.00080 },
+  'cohere.command-text-v14':                     { input: 0.00150, output: 0.00200 },
+};
+
+type TaskType = 'reasoning' | 'code' | 'summary' | 'creative' | 'quick';
+
+interface Route {
+  modelId: string;
+  label: string;
+  config?: { temperature?: number; maxTokens?: number };
+}
+
+function routeForTask(task: TaskType): Route {
+  switch (task) {
+    case 'reasoning':
+      return {
+        modelId: 'anthropic.claude-v2',
+        label: 'Claude v2 (complex reasoning)',
+        config: { temperature: 0.3, maxTokens: 500 },
+      };
+    case 'code':
+      return {
+        modelId: 'meta.llama2-70b-chat-v1',
+        label: 'Llama 2 70B (code generation)',
+        config: { temperature: 0.2, maxTokens: 600 },
+      };
+    case 'summary':
+      return {
+        modelId: 'amazon.titan-text-express-v1',
+        label: 'Titan Text Express (summarization)',
+        config: { temperature: 0.5, maxTokens: 300 },
+      };
+    case 'creative':
+      return {
+        modelId: 'cohere.command-text-v14',
+        label: 'Cohere Command (creative writing)',
+        config: { temperature: 0.8, maxTokens: 400 },
+      };
+    case 'quick':
+      return {
+        modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+        label: 'Claude 3 Haiku (fast & cheap)',
+        config: { temperature: 0.0, maxTokens: 150 },
+      };
+  }
+}
+
+function createGuardrailEngine(): GuardrailEngine {
+  const guardrailEngine = new GuardrailEngine();
+
+  guardrailEngine.registerGuardrail(new PIIDetectionGuardrail({
+    name: 'pii-detection',
+    enabled: true,
+    action: 'redact',
+  }));
+
+  guardrailEngine.registerGuardrail(new ContentModerationGuardrail({
+    name: 'content-moderation',
+    enabled: true,
+    action: 'block',
+    useOpenAI: false,
+  }));
+
+  return guardrailEngine;
+}
+
+function createCostTracker(): CostTracker {
+  const costTracker = new CostTracker({
+    enabled: true,
+    persistRecords: true,
+    enableBudgets: true,
+    enableAlerts: true,
+  });
+
+  for (const [modelId, pricing] of Object.entries(BEDROCK_PRICING)) {
+    costTracker.addCustomPricing(modelId, {
+      provider: 'bedrock',
+      inputCostPer1K: pricing.input,
+      outputCostPer1K: pricing.output,
+      lastUpdated: '2026-05-20',
+    });
+  }
+
+  return costTracker;
+}
+
+async function main() {
+  const guardrailEngine = createGuardrailEngine();
+  const costStorage = new InMemoryCostStorage();
+  const costTracker = createCostTracker();
+  const budgetManager = new BudgetManager(costStorage);
+
+  budgetManager.createBudget({
+    name: 'Bedrock Quickstart Daily Budget',
+    limit: 10.0,
+    period: 'daily',
+    alertThresholds: [50, 75, 90],
+    action: 'alert',
+    enabled: true,
+  });
+
+  const client = new TealBedrock({
+    region: process.env.AWS_REGION || 'us-east-1',
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'your-access-key',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'your-secret-key',
+    },
+    agentId: 'bedrock-quickstart-agent',
+    guardrailEngine,
+    costTracker,
+    budgetManager,
+    costStorage,
+  });
+
+  const tasks: { type: TaskType; prompt: string }[] = [
+    {
+      type: 'reasoning',
+      prompt: 'Explain the difference between symmetric and asymmetric encryption in one paragraph.',
+    },
+    {
+      type: 'code',
+      prompt: 'Write a TypeScript function that fetches data from an API with retry logic.',
+    },
+    {
+      type: 'summary',
+      prompt: 'Summarise the benefits of using guardrails in AI applications in two sentences.',
+    },
+    {
+      type: 'creative',
+      prompt: 'Write a short tagline for a security-focused AI company.',
+    },
+    {
+      type: 'quick',
+      prompt: 'What is 2+2?',
+    },
+  ];
+
+  for (const { type, prompt } of tasks) {
+    const route = routeForTask(type);
+
+    console.log(`\n--- ${route.label} ---`);
+    console.log(`Task: ${type}`);
+    console.log(`Prompt: ${prompt}`);
+
+    const response = await client.invokeModel({
+      modelId: route.modelId,
+      prompt,
+      maxTokens: route.config?.maxTokens ?? 200,
+      temperature: route.config?.temperature,
+    });
+
+    console.log(`Response: ${response.text}`);
+    if (response.metadata?.cost) {
+      console.log(`Cost: $${Number(response.metadata.cost).toFixed(6)}`);
+    }
+    if (response.inputTokens != null) {
+      console.log(`Tokens: ${response.inputTokens} in / ${response.outputTokens} out`);
+    }
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const costSummary = await costStorage.getSummary(today, new Date(), 'bedrock-quickstart-agent');
+
+  console.log('\n--- Cost summary ---');
+  console.log(`Requests tracked: ${costSummary.totalRequests}`);
+  console.log(`Total cost: $${costSummary.totalCost.toFixed(6)}`);
+}
+
+main().catch((error) => {
+  console.error('Bedrock quickstart failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a Bedrock quickstart example (`examples/bedrock-quickstart/`) that demonstrates:

1. **TealBedrock setup** with AWS credentials, guardrails (PII + content moderation), cost tracking, and a daily budget — following the same pattern as the existing `gemini-quickstart` and `quickstart-deepseek` examples.
2. **Multi-model routing** — a `routeForTask()` function selects the optimal Bedrock model based on task type:
   - `reasoning` → Anthropic Claude v2
   - `code` → Meta Llama 2 70B
   - `summary` → Amazon Titan Text Express
   - `creative` → Cohere Command
   - `quick` → Claude 3 Haiku

## Files Added
- `examples/bedrock-quickstart/index.ts` — the quickstart code
- `examples/bedrock-quickstart/README.md` — setup and usage instructions

Closes #72