### PR TITLE
fix: correct Python coverage reporting in CI

### DIFF
--- a/ci/python-ci.yml
+++ b/ci/python-ci.yml
@@ -1,0 +1,95 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: windows-latest
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
+          - os: macos-latest
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.12'
+
+    defaults:
+      run:
+        working-directory: packages/tealtiger-python
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run linter
+      run: |
+        ruff check src tests
+
+    - name: Run tests with coverage
+      run: |
+        pytest -v --cov=tealtiger --cov-report=term-missing --cov-report=html --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+
+  security:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/tealtiger-python
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install safety
+
+    - name: Run security audit
+      run: |
+        safety check


### PR DESCRIPTION
Closes #64

## Summary

Adds a dedicated Python CI workflow that runs tests with coverage reporting across multiple Python versions and OS platforms.

## Changes

- **ci/python-ci.yml** — Python CI workflow configuration (to be moved to `.github/workflows/python-ci.yml`)
- Generates `coverage.xml` (Cobertura format) for proper Codecov integration instead of uploading the HTML report
- Runs `pytest` with `--cov-report=xml` alongside existing `--cov-report=term-missing` and `--cov-report=html`
- Includes ruff linting and safety security audit steps
- Uploads coverage results only on ubuntu-latest with Python 3.11

## Fix in detail

The original submodules `test.yml` workflow uploaded `htmlcov/index.html` to Codecov, which Codecov cannot parse. This fix:
1. Adds `--cov-report=xml` so `coverage.xml` is produced
2. Fixes the Codecov upload to reference `coverage.xml` instead of `htmlcov/index.html`

## Note

This file should be placed at `.github/workflows/python-ci.yml` by a maintainer with the `workflow` GitHub OAuth scope to enable GitHub Actions.