### PR TITLE
docs: add governed by TealTiger badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Open source. TypeScript + Python. Works with any provider.
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/X2ePf8QAj)
 [![GitHub stars](https://img.shields.io/github/stars/agentguard-ai/tealtiger?style=social)](https://github.com/agentguard-ai/tealtiger)
+[![Governed by TealTiger](./assets/badges/governed-by-tealtiger.svg)](https://github.com/agentguard-ai/tealtiger)
 
 [Website](https://tealtiger.co.in) · [Documentation](#documentation) · [Examples](#examples) · [Discord](https://discord.gg/X2ePf8QAj) · [Contributing](#-build-with-us)
 
@@ -187,6 +188,23 @@ response = client.chat.completions.create(
 - [Security Policy](./SECURITY.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Roadmap](./ROADMAP.md)
+
+### Badge
+
+Use the TealTiger badge to show that a project is governed by deterministic
+agent security and cost policies.
+
+Light badge:
+
+```md
+[![Governed by TealTiger](https://raw.githubusercontent.com/agentguard-ai/tealtiger/main/assets/badges/governed-by-tealtiger.svg)](https://github.com/agentguard-ai/tealtiger)
+```
+
+Dark badge:
+
+```md
+[![Governed by TealTiger](https://raw.githubusercontent.com/agentguard-ai/tealtiger/main/assets/badges/governed-by-tealtiger-dark.svg)](https://github.com/agentguard-ai/tealtiger)
+```
 
 ### TealEngine Policy Schema
 

--- a/assets/badges/governed-by-tealtiger-dark.svg
+++ b/assets/badges/governed-by-tealtiger-dark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="28" role="img" aria-label="Governed by TealTiger">
+  <title>Governed by TealTiger</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#ffffff" stop-opacity=".18"/>
+    <stop offset="1" stop-opacity=".04"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="190" height="28" rx="4"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="88" height="28" fill="#020617"/>
+    <rect x="88" width="102" height="28" fill="#115e59"/>
+    <rect width="190" height="28" fill="url(#s)"/>
+  </g>
+  <g fill="#f8fafc" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="44" y="18">governed by</text>
+    <text x="139" y="18" font-weight="700">TealTiger</text>
+  </g>
+</svg>

--- a/assets/badges/governed-by-tealtiger.svg
+++ b/assets/badges/governed-by-tealtiger.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="28" role="img" aria-label="Governed by TealTiger">
+  <title>Governed by TealTiger</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#ffffff" stop-opacity=".25"/>
+    <stop offset="1" stop-opacity=".08"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="190" height="28" rx="4"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="88" height="28" fill="#334155"/>
+    <rect x="88" width="102" height="28" fill="#0f766e"/>
+    <rect width="190" height="28" fill="url(#s)"/>
+  </g>
+  <g fill="#ffffff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="44" y="18">governed by</text>
+    <text x="139" y="18" font-weight="700">TealTiger</text>
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #143

## Summary
- Added light and dark local SVG badge assets under assets/badges/.
- Added the light badge to the top of the README.
- Added a Badge section with copy-paste snippets that link back to this repository.

## Root Cause
Projects using TealTiger had no first-party badge asset or README snippet to show governance adoption consistently.

## Validation
- git diff --check
- Parsed both SVG files as XML.
- Verified both badge files exist and README references Governed by TealTiger snippets.

## Security
Static documentation/assets only. No scripts, remote code execution, credentials, or policy behavior changed.
