### PR TITLE
docs: add Hugging Face TGI Python quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ response = client.chat.completions.create(
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Roadmap](./ROADMAP.md)
 
+### Python Hugging Face TGI Quickstart
+
+Use `examples/python/huggingface_tgi_quickstart.py` to try the guarded
+Hugging Face Text Generation Inference provider from the Python SDK.
+
+```bash
+export HF_API_TOKEN="your-hugging-face-token"
+export HF_TGI_ENDPOINT="https://your-endpoint.endpoints.huggingface.cloud"
+export HF_TGI_MODEL="meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+python examples/python/huggingface_tgi_quickstart.py
+```
+
+The example enables guardrail and cost-tracking configuration, sends one sample
+chat request, then prints the response, token usage, estimated cost, provider,
+and correlation ID. Use placeholder values in docs and `.env.example` files;
+never commit a real `HF_API_TOKEN`.
+
 ### TealEngine Policy Schema
 
 Use [`schemas/tealtiger-policy.schema.json`](./schemas/tealtiger-policy.schema.json) for editor autocomplete and validation when authoring TealEngine policy JSON or YAML files. JSON policy files can include:

--- a/examples/python/huggingface_tgi_quickstart.py
+++ b/examples/python/huggingface_tgi_quickstart.py
@@ -1,0 +1,100 @@
+"""
+TealTiger Hugging Face TGI quickstart.
+
+Run with:
+
+    HF_API_TOKEN=hf_... \
+    HF_TGI_ENDPOINT=https://your-endpoint.endpoints.huggingface.cloud \
+    python examples/python/huggingface_tgi_quickstart.py
+
+The example shows:
+    - Hugging Face TGI endpoint configuration.
+    - Guardrail and cost tracking switches on the guarded provider config.
+    - A prompt containing sample PII so the governance layer has a realistic
+      input to evaluate when an engine is attached.
+    - Response text, token usage, and a simple cost summary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from tealtiger.clients.new_providers import (
+    HF_TGI_PRICING,
+    ProviderConfig,
+    TealHfTgi,
+)
+
+
+DEFAULT_MODEL = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+
+def estimate_cost(model: str, usage: dict[str, Any]) -> float:
+    """Estimate request cost from HF TGI reference pricing."""
+    pricing = HF_TGI_PRICING.get(model, HF_TGI_PRICING["custom-model"])
+    prompt_tokens = int(usage.get("prompt_tokens", 0))
+    completion_tokens = int(usage.get("completion_tokens", 0))
+    return (
+        (prompt_tokens / 1000) * pricing["input"]
+        + (completion_tokens / 1000) * pricing["output"]
+    )
+
+
+async def main() -> None:
+    """Create a guarded HF TGI client, send one prompt, and print metadata."""
+    endpoint = os.getenv("HF_TGI_ENDPOINT", "http://localhost:8080")
+    token = os.getenv("HF_API_TOKEN", "")
+    model = os.getenv("HF_TGI_MODEL", DEFAULT_MODEL)
+
+    if not token and not endpoint.startswith("http://localhost"):
+        raise RuntimeError(
+            "Set HF_API_TOKEN for hosted Hugging Face Inference Endpoints, "
+            "or point HF_TGI_ENDPOINT at a local TGI server."
+        )
+
+    client = TealHfTgi(
+        ProviderConfig(
+            api_key=token,
+            base_url=endpoint,
+            model=model,
+            agent_id="hf-tgi-quickstart-agent",
+            enable_guardrails=True,
+            enable_cost_tracking=True,
+        )
+    )
+
+    response = await client.chat_completion(
+        messages=[
+            {
+                "role": "system",
+                "content": "Answer in one concise sentence.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    "My email is jane@example.com. Explain what TealTiger "
+                    "does for a Hugging Face TGI deployment."
+                ),
+            },
+        ],
+        max_tokens=96,
+    )
+
+    usage = response.get("usage", {})
+    estimated_cost = estimate_cost(model, usage)
+
+    print("Response:", response["choices"][0]["message"]["content"])
+    print("Prompt tokens:", usage.get("prompt_tokens", 0))
+    print("Completion tokens:", usage.get("completion_tokens", 0))
+    print("Total tokens:", usage.get("total_tokens", 0))
+    print(f"Estimated cost: ${estimated_cost:.6f}")
+
+    governance = response.get("governance", {})
+    print("Provider:", governance.get("provider", "hf-tgi"))
+    print("Correlation ID:", governance.get("correlation_id", "n/a"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Fixes #140

## Summary
- Added examples/python/huggingface_tgi_quickstart.py for the Python HF TGI provider path.
- Documented HF_API_TOKEN, HF_TGI_ENDPOINT, and HF_TGI_MODEL setup in the README.
- The example configures guardrail/cost switches, sends a sample chat request, and prints response text, token usage, estimated cost, provider, and correlation ID.

## Root Cause
The README advertises HuggingFace TGI support, but there was no Python quickstart showing the minimal endpoint/token setup and metadata output expected from a guarded request.

## Validation
- python -m py_compile examples/python/huggingface_tgi_quickstart.py
- git diff --check
- rg HF_API_TOKEN/HF_TGI_ENDPOINT/HF_TGI_MODEL and output fields in README.md and the example file

## Security
No real tokens or private endpoints are committed. The example uses environment variables, placeholder values, and explicitly warns not to commit a real HF_API_TOKEN.
