### PR TITLE
docs: add env examples for quickstarts

### DIFF
--- a/examples/bedrock-quickstart/.env.example
+++ b/examples/bedrock-quickstart/.env.example
@@ -1,0 +1,4 @@
+# Required: AWS credentials for an IAM principal allowed to invoke Bedrock models.
+AWS_ACCESS_KEY_ID=your-aws-access-key-id
+AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+AWS_REGION=us-east-1

--- a/examples/bedrock-quickstart/README.md
+++ b/examples/bedrock-quickstart/README.md
@@ -27,6 +27,9 @@ export AWS_SECRET_ACCESS_KEY=...
 export AWS_REGION=us-east-1
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder values.
+
 Run the quickstart from the TealTiger repository root:
 
 ```bash

--- a/examples/crewai-governance/.env.example
+++ b/examples/crewai-governance/.env.example
@@ -1,0 +1,5 @@
+# Optional: TealTiger Security Sidecar Agent URL for live sidecar mode.
+TEALTIGER_SSA_URL=http://localhost:3000
+
+# Optional: API key for the live TealTiger sidecar.
+TEALTIGER_API_KEY=your-tealtiger-api-key

--- a/examples/crewai-governance/README.md
+++ b/examples/crewai-governance/README.md
@@ -55,5 +55,8 @@ export TEALTIGER_API_KEY="your-tealtiger-api-key"
 python examples/crewai-governance/main.py
 ```
 
+Copy `.env.example` in this directory if you prefer loading sidecar environment
+variables from a file, and replace only the placeholder values.
+
 The same CrewAI tools will call `TealTiger.execute_tool_sync()`, but the policy
 decision will come from the configured SSA instead of the local demo evaluator.

--- a/examples/gemini-quickstart/.env.example
+++ b/examples/gemini-quickstart/.env.example
@@ -1,0 +1,2 @@
+# Required: Google AI Studio or Gemini API key.
+GEMINI_API_KEY=your-gemini-api-key

--- a/examples/gemini-quickstart/README.md
+++ b/examples/gemini-quickstart/README.md
@@ -21,6 +21,9 @@ Set your Gemini API key:
 export GEMINI_API_KEY=your-gemini-api-key
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder value.
+
 Run the quickstart from the TealTiger repository root:
 
 ```bash

--- a/examples/grok-quickstart/.env.example
+++ b/examples/grok-quickstart/.env.example
@@ -1,0 +1,2 @@
+# Required: xAI API key for Grok models.
+XAI_API_KEY=your-xai-api-key

--- a/examples/grok-quickstart/README.md
+++ b/examples/grok-quickstart/README.md
@@ -21,6 +21,9 @@ Set your xAI API key:
 export XAI_API_KEY=your-xai-api-key
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder value.
+
 Run the quickstart from the TealTiger repository root:
 
 ```bash

--- a/examples/groq-quickstart/.env.example
+++ b/examples/groq-quickstart/.env.example
@@ -1,0 +1,2 @@
+# Required: Groq API key.
+GROQ_API_KEY=your-groq-api-key

--- a/examples/groq-quickstart/README.md
+++ b/examples/groq-quickstart/README.md
@@ -23,6 +23,9 @@ Set your Groq API key:
 export GROQ_API_KEY=your-groq-api-key
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder value.
+
 Run the quickstart from the TealTiger repository root:
 
 ```bash

--- a/examples/langchain-governance/.env.example
+++ b/examples/langchain-governance/.env.example
@@ -1,0 +1,5 @@
+# Required: OpenAI API key used by the LangChain chat model.
+OPENAI_API_KEY=your-openai-api-key
+
+# Optional: override the default model used by the example.
+OPENAI_MODEL=gpt-4o-mini

--- a/examples/langchain-governance/README.md
+++ b/examples/langchain-governance/README.md
@@ -39,6 +39,9 @@ Set an OpenAI key:
 export OPENAI_API_KEY="sk-..."
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder values.
+
 On PowerShell:
 
 ```powershell

--- a/examples/openai-agents-governance/.env.example
+++ b/examples/openai-agents-governance/.env.example
@@ -1,0 +1,5 @@
+# Optional: TealTiger Security Sidecar Agent URL for live sidecar mode.
+TEALTIGER_SSA_URL=http://localhost:3000
+
+# Optional: API key for the live TealTiger sidecar.
+TEALTIGER_API_KEY=your-tealtiger-api-key

--- a/examples/openai-agents-governance/README.md
+++ b/examples/openai-agents-governance/README.md
@@ -63,6 +63,9 @@ set TEALTIGER_API_KEY=your-api-key
 python examples/openai-agents-governance/main.py
 ```
 
+Copy `.env.example` in this directory if you prefer loading sidecar environment
+variables from a file, and replace only the placeholder values.
+
 On macOS or Linux:
 
 ```bash

--- a/examples/quickstart-deepseek/.env.example
+++ b/examples/quickstart-deepseek/.env.example
@@ -1,0 +1,2 @@
+# Required: DeepSeek API key.
+DEEPSEEK_API_KEY=your-deepseek-api-key

--- a/examples/quickstart-deepseek/README.md
+++ b/examples/quickstart-deepseek/README.md
@@ -21,6 +21,9 @@ Set your DeepSeek API key:
 export DEEPSEEK_API_KEY=sk-your-deepseek-key
 ```
 
+Copy `.env.example` in this directory if you prefer loading environment
+variables from a file, and replace only the placeholder value.
+
 Run the quickstart from the TealTiger repository root:
 
 ```bash


### PR DESCRIPTION
Fixes #142

## Summary
- Added placeholder-only .env.example files for quickstart directories that need provider or sidecar credentials.
- Updated each touched quickstart README to point users at its local .env.example.
- Kept scope to the .env.example request; the issue body appears to include an unrelated JSON Schema section, so this PR does not touch schema files.

## Root Cause
Several quickstart examples documented environment variables in prose or code comments, but did not provide local copyable .env.example files.

## Validation
- git diff --check
- Listed all added examples/**/.env.example files
- rg .env.example examples
- Secret-pattern check over added .env.example files returned no matches

## Security
All values are placeholders. No real API keys, private endpoints, or production credentials are committed.
