### PR TITLE
Add Vercel AI SDK governance example

### DIFF
--- a/examples/vercel-ai-governance/README.md
+++ b/examples/vercel-ai-governance/README.md
@@ -1,0 +1,122 @@
+# Vercel AI SDK Governance Example
+
+This example shows TealTiger governance as middleware around Vercel AI SDK
+`generateText()` and `streamText()` calls in a minimal Next.js API route.
+
+## Architecture
+
+```text
+POST /api/chat
+  -> extract user ID from body or x-user-id header
+  -> estimate request cost for the selected model
+  -> run TealEngine policy evaluation
+  -> run a PII guardrail on the latest user message
+  -> check the user's daily budget
+  -> ALLOW: call generateText() or streamText()
+  -> DENY: return 403 with governance metadata
+  -> record model usage with CostTracker after completion
+```
+
+The route returns governance metadata in response headers:
+
+- `x-tealtiger-action`
+- `x-tealtiger-request-id`
+- `x-tealtiger-user-id`
+- `x-tealtiger-policy-allowed`
+- `x-tealtiger-pii-action`
+- `x-tealtiger-pii-risk`
+- `x-tealtiger-estimated-cost-usd`
+- `x-tealtiger-budget-remaining-usd`
+
+## Setup
+
+From the repository root, initialize the TypeScript SDK submodule and install the
+example dependencies:
+
+```bash
+git submodule update --init packages/tealtiger-sdk
+cd examples/vercel-ai-governance
+npm install
+```
+
+AI SDK v6 can route plain `provider/model` strings through Vercel AI Gateway. For
+local development, link a Vercel project and pull environment variables:
+
+```bash
+vercel link
+vercel env pull .env.local
+```
+
+Optional configuration:
+
+```bash
+export AI_MODEL="openai/gpt-5.4"
+export TEALTIGER_USER_DAILY_BUDGET_USD="1.00"
+export TEALTIGER_INPUT_COST_PER_1K="0.00125"
+export TEALTIGER_OUTPUT_COST_PER_1K="0.01"
+export TEALTIGER_ESTIMATED_OUTPUT_TOKENS="500"
+export TEALTIGER_PII_ACTION="block"
+```
+
+Use placeholder values in docs and local examples. Do not commit real provider
+tokens, Vercel OIDC values, or AI Gateway credentials.
+
+## Run
+
+Typecheck the example:
+
+```bash
+npm run typecheck
+```
+
+Start Next.js:
+
+```bash
+npm run dev
+```
+
+Send a non-streaming request:
+
+```bash
+curl -i http://localhost:3000/api/chat \
+  -H "content-type: application/json" \
+  -H "x-user-id: user_123" \
+  -d '{"prompt":"Explain TealTiger governance in one sentence."}'
+```
+
+Send a streaming request:
+
+```bash
+curl -i http://localhost:3000/api/chat \
+  -H "content-type: application/json" \
+  -H "x-user-id: user_123" \
+  -d '{"stream":true,"prompt":"Write a short checklist for AI policy review."}'
+```
+
+Try a PII request:
+
+```bash
+curl -i http://localhost:3000/api/chat \
+  -H "content-type: application/json" \
+  -H "x-user-id: user_123" \
+  -d '{"prompt":"Email Taylor at taylor@example.com with the full report."}'
+```
+
+With the default `TEALTIGER_PII_ACTION=block`, TealTiger returns `403` before the
+LLM call. Set `TEALTIGER_PII_ACTION=redact` to redact supported PII before the
+prompt is sent to the model.
+
+## Files
+
+- `app/api/chat/route.ts` wraps AI SDK `generateText()` and `streamText()` calls.
+- `lib/tealtiger-governance.ts` owns TealEngine policy evaluation, PII guardrail
+  execution, per-user budgets, response headers, and CostTracker records.
+
+## Notes
+
+- The in-memory budget store is intentionally simple for the example. Production
+  apps should back `CostStorage` with durable storage.
+- The route uses a local SDK source import so it typechecks inside this monorepo.
+  In a standalone Next.js app, install `tealtiger` and replace those local imports
+  with package imports.
+- No real API keys are included.

--- a/examples/vercel-ai-governance/app/api/chat/route.ts
+++ b/examples/vercel-ai-governance/app/api/chat/route.ts
@@ -1,0 +1,112 @@
+import { generateText, streamText, type ModelMessage } from 'ai';
+import {
+  createGovernanceHeaders,
+  evaluateChatGovernance,
+  recordModelUsage,
+  summarizeGovernance,
+} from '../../../lib/tealtiger-governance';
+
+export const runtime = 'nodejs';
+
+type ChatRouteBody = {
+  userId?: string;
+  messages?: ModelMessage[];
+  prompt?: string;
+  stream?: boolean;
+};
+
+const MODEL = process.env.AI_MODEL ?? 'openai/gpt-5.4';
+
+function getUserId(req: Request, body: ChatRouteBody): string {
+  return body.userId ?? req.headers.get('x-user-id') ?? 'anonymous-user';
+}
+
+function getMessages(body: ChatRouteBody): ModelMessage[] {
+  if (Array.isArray(body.messages) && body.messages.length > 0) {
+    return body.messages;
+  }
+
+  if (typeof body.prompt === 'string' && body.prompt.trim()) {
+    return [{ role: 'user', content: body.prompt.trim() }];
+  }
+
+  return [];
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const requestId = crypto.randomUUID();
+  const body = await req.json() as ChatRouteBody;
+  const userId = getUserId(req, body);
+  const messages = getMessages(body);
+
+  if (messages.length === 0) {
+    return Response.json(
+      { error: 'messages or prompt is required' },
+      { status: 400 },
+    );
+  }
+
+  const operation = body.stream ? 'ai.streamText' : 'ai.generateText';
+  const governance = await evaluateChatGovernance({
+    userId,
+    messages,
+    model: MODEL,
+    operation,
+    requestId,
+  });
+  const headers = createGovernanceHeaders(governance);
+
+  if (!governance.allowed) {
+    return Response.json(
+      {
+        error: 'TealTiger governance denied the request',
+        reasons: governance.reasons,
+        governance: summarizeGovernance(governance),
+      },
+      {
+        status: 403,
+        headers,
+      },
+    );
+  }
+
+  if (body.stream) {
+    const result = streamText({
+      model: MODEL,
+      messages: governance.messages,
+      onFinish: async ({ totalUsage }) => {
+        await recordModelUsage({
+          userId,
+          model: MODEL,
+          requestId,
+          operation,
+          usage: totalUsage,
+        });
+      },
+    });
+
+    return result.toTextStreamResponse({ headers });
+  }
+
+  const result = await generateText({
+    model: MODEL,
+    messages: governance.messages,
+    onFinish: async ({ totalUsage }) => {
+      await recordModelUsage({
+        userId,
+        model: MODEL,
+        requestId,
+        operation,
+        usage: totalUsage,
+      });
+    },
+  });
+
+  return Response.json(
+    {
+      text: result.text,
+      governance: summarizeGovernance(governance),
+    },
+    { headers },
+  );
+}

--- a/examples/vercel-ai-governance/lib/tealtiger-governance.ts
+++ b/examples/vercel-ai-governance/lib/tealtiger-governance.ts
@@ -1,0 +1,381 @@
+import type { ModelMessage } from 'ai';
+import { BudgetManager } from '../../../packages/tealtiger-sdk/src/cost/BudgetManager';
+import { CostTracker } from '../../../packages/tealtiger-sdk/src/cost/CostTracker';
+import { InMemoryCostStorage } from '../../../packages/tealtiger-sdk/src/cost/CostStorage';
+import type { CostEstimate, CostRecord, TokenUsage } from '../../../packages/tealtiger-sdk/src/cost/types';
+import { TealEngine } from '../../../packages/tealtiger-sdk/src/core/engine/TealEngine';
+import type { PolicyEvaluationResult } from '../../../packages/tealtiger-sdk/src/core/engine/types';
+import { PIIDetectionGuardrail } from '../../../packages/tealtiger-sdk/src/guardrails/pii-detection';
+import type { GuardrailResult } from '../../../packages/tealtiger-sdk/src/guardrails/base';
+
+type Operation = 'ai.generateText' | 'ai.streamText';
+
+type EvaluateChatGovernanceInput = {
+  userId: string;
+  messages: ModelMessage[];
+  model: string;
+  operation: Operation;
+  requestId: string;
+};
+
+export type ChatGovernanceDecision = {
+  allowed: boolean;
+  userId: string;
+  model: string;
+  operation: Operation;
+  requestId: string;
+  messages: ModelMessage[];
+  reasons: string[];
+  policy: PolicyEvaluationResult;
+  pii: GuardrailResult;
+  costEstimate: CostEstimate;
+  budget: {
+    allowed: boolean;
+    remaining?: number;
+    percentageUsed?: number;
+    blockedBy?: string;
+  };
+};
+
+type UsageLike = Partial<TokenUsage> & {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+};
+
+const DEFAULT_DAILY_BUDGET_USD = readNumber('TEALTIGER_USER_DAILY_BUDGET_USD', 1);
+const INPUT_COST_PER_1K = readNumber('TEALTIGER_INPUT_COST_PER_1K', 0.00125);
+const OUTPUT_COST_PER_1K = readNumber('TEALTIGER_OUTPUT_COST_PER_1K', 0.01);
+const ESTIMATED_OUTPUT_TOKENS = readNumber('TEALTIGER_ESTIMATED_OUTPUT_TOKENS', 500);
+const PII_ACTION = process.env.TEALTIGER_PII_ACTION === 'redact' ? 'redact' : 'block';
+
+const costStorage = new InMemoryCostStorage();
+const budgetManager = new BudgetManager(costStorage);
+const costTracker = new CostTracker({
+  enabled: true,
+  persistRecords: true,
+  enableBudgets: true,
+  enableAlerts: true,
+});
+const piiGuardrail = new PIIDetectionGuardrail({
+  name: 'vercel-ai-pii',
+  enabled: true,
+  action: PII_ACTION,
+  detectTypes: ['email', 'phone', 'ssn', 'creditCard'],
+});
+const userBudgets = new Set<string>();
+const pricedModels = new Set<string>();
+
+export async function evaluateChatGovernance(
+  input: EvaluateChatGovernanceInput,
+): Promise<ChatGovernanceDecision> {
+  ensureModelPricing(input.model);
+  ensureUserBudget(input.userId);
+
+  const latestUserText = getLatestUserText(input.messages);
+  const pii = await piiGuardrail.evaluate(latestUserText, {
+    userId: input.userId,
+    requestId: input.requestId,
+  });
+  const messages = buildGovernedMessages(input.messages, pii);
+  const estimatedTokens = estimateTokens(messages);
+  const costEstimate = costTracker.estimateCost(input.model, estimatedTokens, 'custom');
+  const engine = createEngine(input.userId);
+  const policy = engine.evaluate({
+    agentId: input.userId,
+    action: 'chat.completion',
+    tool: input.operation,
+    content: latestUserText,
+    cost: costEstimate.estimatedCost,
+    metadata: {
+      model: input.model,
+      requestId: input.requestId,
+      piiAction: pii.action,
+      piiRiskScore: pii.riskScore,
+    },
+  });
+  const budget = await budgetManager.checkBudget(input.userId, costEstimate.estimatedCost);
+  const status = budget.blockedBy
+    ? budget.status
+    : await getUserBudgetStatus(input.userId);
+  const reasons = collectReasons(policy, pii, budget);
+
+  return {
+    allowed: reasons.length === 0,
+    userId: input.userId,
+    model: input.model,
+    operation: input.operation,
+    requestId: input.requestId,
+    messages,
+    reasons: reasons.length > 0 ? reasons : ['Policy compliant'],
+    policy,
+    pii,
+    costEstimate,
+    budget: {
+      allowed: budget.allowed,
+      remaining: status?.remaining,
+      percentageUsed: status?.percentageUsed,
+      blockedBy: budget.blockedBy?.name,
+    },
+  };
+}
+
+export async function recordModelUsage(input: {
+  userId: string;
+  model: string;
+  requestId: string;
+  operation: Operation;
+  usage: UsageLike;
+}): Promise<CostRecord> {
+  ensureModelPricing(input.model);
+
+  const tokens = normalizeUsage(input.usage);
+  const record = costTracker.calculateActualCost(
+    input.requestId,
+    input.userId,
+    input.model,
+    tokens,
+    'custom',
+    {
+      operation: input.operation,
+      provider: 'vercel-ai-sdk',
+    },
+  );
+
+  await costStorage.store(record);
+  await budgetManager.recordCost(record);
+  return record;
+}
+
+export function createGovernanceHeaders(decision: ChatGovernanceDecision): Headers {
+  const headers = new Headers();
+
+  headers.set('x-tealtiger-action', decision.allowed ? 'ALLOW' : 'DENY');
+  headers.set('x-tealtiger-request-id', decision.requestId);
+  headers.set('x-tealtiger-user-id', decision.userId);
+  headers.set('x-tealtiger-policy-allowed', String(decision.policy.allowed));
+  headers.set('x-tealtiger-pii-action', decision.pii.action);
+  headers.set('x-tealtiger-pii-risk', String(decision.pii.riskScore));
+  headers.set('x-tealtiger-estimated-cost-usd', decision.costEstimate.estimatedCost.toFixed(6));
+
+  if (decision.budget.remaining != null) {
+    headers.set('x-tealtiger-budget-remaining-usd', decision.budget.remaining.toFixed(6));
+  }
+
+  return headers;
+}
+
+export function summarizeGovernance(decision: ChatGovernanceDecision) {
+  return {
+    action: decision.allowed ? 'ALLOW' : 'DENY',
+    requestId: decision.requestId,
+    userId: decision.userId,
+    operation: decision.operation,
+    reasons: decision.reasons,
+    policy: {
+      allowed: decision.policy.allowed,
+      triggeredPolicies: decision.policy.triggeredPolicies,
+      reason: decision.policy.reason,
+    },
+    pii: {
+      action: decision.pii.action,
+      passed: decision.pii.passed,
+      reason: decision.pii.reason,
+      riskScore: decision.pii.riskScore,
+    },
+    cost: {
+      estimatedUsd: decision.costEstimate.estimatedCost,
+      estimatedTokens: decision.costEstimate.estimatedTokens,
+    },
+    budget: decision.budget,
+  };
+}
+
+function readNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function ensureModelPricing(model: string): void {
+  if (pricedModels.has(model)) {
+    return;
+  }
+
+  costTracker.addCustomPricing(model, {
+    model,
+    provider: 'custom',
+    inputCostPer1K: INPUT_COST_PER_1K,
+    outputCostPer1K: OUTPUT_COST_PER_1K,
+    lastUpdated: '2026-05-27',
+  });
+  pricedModels.add(model);
+}
+
+function ensureUserBudget(userId: string): void {
+  if (userBudgets.has(userId)) {
+    return;
+  }
+
+  budgetManager.createBudget({
+    name: `Vercel AI daily budget for ${userId}`,
+    limit: DEFAULT_DAILY_BUDGET_USD,
+    period: 'daily',
+    alertThresholds: [50, 75, 90, 100],
+    action: 'block',
+    scope: {
+      type: 'agent',
+      id: userId,
+    },
+    enabled: true,
+  });
+  userBudgets.add(userId);
+}
+
+function createEngine(userId: string): TealEngine {
+  return new TealEngine({
+    identity: {
+      agentId: userId,
+      role: 'web-user',
+      permissions: ['chat:generate'],
+    },
+    tools: {
+      'ai.generateText': { allowed: true },
+      'ai.streamText': { allowed: true },
+    },
+    behavioral: {
+      costLimit: {
+        daily: DEFAULT_DAILY_BUDGET_USD,
+      },
+      rateLimit: {
+        requests: 60,
+        window: '1h',
+      },
+    },
+    content: {
+      pii: {
+        enabled: true,
+        blockedTypes: ['email', 'phone', 'ssn', 'creditCard'],
+        redactInLogs: true,
+      },
+    },
+  });
+}
+
+function collectReasons(
+  policy: PolicyEvaluationResult,
+  pii: GuardrailResult,
+  budget: Awaited<ReturnType<BudgetManager['checkBudget']>>,
+): string[] {
+  const reasons: string[] = [];
+
+  if (!policy.allowed) {
+    reasons.push(policy.reason ?? 'TealEngine policy denied the request');
+  }
+
+  if (pii.shouldBlock()) {
+    reasons.push(pii.reason);
+  }
+
+  if (!budget.allowed) {
+    reasons.push(`Budget "${budget.blockedBy?.name ?? 'unknown'}" would be exceeded`);
+  }
+
+  return reasons;
+}
+
+function getLatestUserText(messages: ModelMessage[]): string {
+  const latestUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+  return latestUserMessage ? messageContentToText(latestUserMessage.content) : '';
+}
+
+function buildGovernedMessages(messages: ModelMessage[], pii: GuardrailResult): ModelMessage[] {
+  const redactedText = typeof pii.metadata.redactedText === 'string'
+    ? pii.metadata.redactedText
+    : undefined;
+
+  if (!redactedText || pii.action !== 'redact') {
+    return messages;
+  }
+
+  const next = [...messages];
+  const latestUserIndex = findLatestUserIndex(next);
+
+  if (latestUserIndex === -1) {
+    return messages;
+  }
+
+  next[latestUserIndex] = {
+    ...next[latestUserIndex],
+    content: redactedText,
+  } as ModelMessage;
+
+  return next;
+}
+
+function findLatestUserIndex(messages: ModelMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role === 'user') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function estimateTokens(messages: ModelMessage[]): TokenUsage {
+  const text = messages.map((message) => messageContentToText(message.content)).join('\n');
+  const inputTokens = Math.max(1, Math.ceil(text.length / 4));
+  const outputTokens = ESTIMATED_OUTPUT_TOKENS;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+function normalizeUsage(usage: UsageLike): TokenUsage {
+  const inputTokens = usage.inputTokens ?? usage.promptTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? usage.completionTokens ?? 0;
+  const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+  };
+}
+
+function messageContentToText(content: ModelMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+
+      if (part && typeof part === 'object' && 'text' in part && typeof part.text === 'string') {
+        return part.text;
+      }
+
+      return '';
+    }).join(' ');
+  }
+
+  return '';
+}
+
+async function getUserBudgetStatus(userId: string) {
+  const budget = budgetManager.getBudgetsByScope('agent', userId)[0];
+  return budget ? budgetManager.getBudgetStatus(budget.id) : undefined;
+}

--- a/examples/vercel-ai-governance/package.json
+++ b/examples/vercel-ai-governance/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tealtiger-vercel-ai-governance-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ai": "^6.0.191",
+    "next": "^16.2.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tealtiger": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=20.9.0"
+  }
+}

--- a/examples/vercel-ai-governance/tsconfig.json
+++ b/examples/vercel-ai-governance/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "preserve",
+    "forceConsistentCasingInFileNames": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["app/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Fixes #126

## Summary
- Added a minimal Next.js API route example that wraps Vercel AI SDK generateText and streamText calls with TealTiger governance.
- Added TealEngine policy evaluation, per-user budget checks, PII guardrail handling, governance response headers, and CostTracker usage recording.
- Documented setup, AI SDK v6 gateway model usage, request examples, and PII block/redact behavior.

## Validation
- npm install --package-lock=false
- npm run typecheck
- git diff --check

## Security
- No real API keys or private credentials are committed.
- The README uses placeholder configuration and calls out that provider tokens, Vercel OIDC values, and AI Gateway credentials should not be committed.