### PR TITLE
Add governance events API

### DIFF
--- a/api/governance-events/database.ts
+++ b/api/governance-events/database.ts
@@ -1,0 +1,71 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { createClient, type Client } from '@libsql/client';
+import { drizzle, type LibSQLDatabase } from 'drizzle-orm/libsql';
+
+import { governanceEvents, type NewGovernanceEventRow } from './schema';
+
+export interface ApiDatabase {
+  client: Client;
+  db: LibSQLDatabase;
+}
+
+export async function createApiDatabase(databaseUrl: string): Promise<ApiDatabase> {
+  ensureDatabaseDirectory(databaseUrl);
+  const client = createClient({ url: databaseUrl });
+  const db = drizzle(client);
+  await initializeSchema(client);
+  return { client, db };
+}
+
+function ensureDatabaseDirectory(databaseUrl: string): void {
+  if (!databaseUrl.startsWith('file:') || databaseUrl === 'file::memory:') {
+    return;
+  }
+
+  const filePath = databaseUrl.replace('file:', '');
+  if (!filePath || filePath.startsWith(':')) {
+    return;
+  }
+
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+export async function initializeSchema(client: Client): Promise<void> {
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS governance_events (
+      id TEXT PRIMARY KEY,
+      timestamp INTEGER NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_name TEXT,
+      decision TEXT NOT NULL,
+      tool TEXT,
+      provider TEXT,
+      model TEXT,
+      cost_usd REAL NOT NULL DEFAULT 0,
+      severity TEXT,
+      reason TEXT NOT NULL,
+      framework TEXT,
+      receipt_json TEXT NOT NULL,
+      metadata_json TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+
+  await client.execute('CREATE INDEX IF NOT EXISTS idx_events_timestamp ON governance_events(timestamp)');
+  await client.execute('CREATE INDEX IF NOT EXISTS idx_events_agent ON governance_events(agent_id)');
+  await client.execute('CREATE INDEX IF NOT EXISTS idx_events_decision ON governance_events(decision)');
+  await client.execute('CREATE INDEX IF NOT EXISTS idx_events_tool ON governance_events(tool)');
+  await client.execute('CREATE INDEX IF NOT EXISTS idx_events_severity ON governance_events(severity)');
+}
+
+export async function seedGovernanceEvents(
+  database: ApiDatabase,
+  events: NewGovernanceEventRow[],
+): Promise<void> {
+  if (events.length === 0) {
+    return;
+  }
+
+  await database.db.insert(governanceEvents).values(events);
+}

--- a/api/governance-events/index.ts
+++ b/api/governance-events/index.ts
@@ -1,0 +1,19 @@
+import { createGovernanceApiServer } from './server';
+
+const port = Number(process.env.PORT ?? 3001);
+const host = process.env.HOST ?? '0.0.0.0';
+const databaseUrl = process.env.TEALTIGER_DB_URL ?? 'file:./data/tealtiger-events.sqlite';
+
+async function main(): Promise<void> {
+  const { app } = await createGovernanceApiServer({
+    databaseUrl,
+    logger: true,
+  });
+
+  await app.listen({ port, host });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/api/governance-events/openapi.ts
+++ b/api/governance-events/openapi.ts
@@ -1,0 +1,73 @@
+export const paginationOpenApiSchema = {
+  type: 'object',
+  required: ['page', 'limit', 'total'],
+  properties: {
+    page: { type: 'integer', minimum: 1 },
+    limit: { type: 'integer', minimum: 1 },
+    total: { type: 'integer', minimum: 0 },
+  },
+} as const;
+
+export const metaOpenApiSchema = {
+  type: 'object',
+  required: ['query_time_ms'],
+  properties: {
+    query_time_ms: { type: 'number' },
+  },
+} as const;
+
+export const eventOpenApiSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'timestamp',
+    'agent_id',
+    'decision',
+    'cost_usd',
+    'reason',
+    'metadata',
+  ],
+  properties: {
+    id: { type: 'string' },
+    timestamp: { type: 'string', format: 'date-time' },
+    agent_id: { type: 'string' },
+    agent_name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    decision: { type: 'string', enum: ['ALLOW', 'DENY', 'REVISE', 'REQUIRE_APPROVAL'] },
+    tool: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    provider: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    model: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    cost_usd: { type: 'number' },
+    severity: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    reason: { type: 'string' },
+    framework: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    metadata: { type: 'object', additionalProperties: true },
+  },
+} as const;
+
+export const eventWithReceiptOpenApiSchema = {
+  ...eventOpenApiSchema,
+  required: [...eventOpenApiSchema.required, 'receipt'],
+  properties: {
+    ...eventOpenApiSchema.properties,
+    receipt: { type: 'object', additionalProperties: true },
+  },
+} as const;
+
+export const eventListOpenApiSchema = {
+  type: 'object',
+  required: ['data', 'pagination', 'meta'],
+  properties: {
+    data: { type: 'array', items: eventOpenApiSchema },
+    pagination: paginationOpenApiSchema,
+    meta: metaOpenApiSchema,
+  },
+} as const;
+
+export const standardErrorOpenApiSchema = {
+  type: 'object',
+  required: ['error', 'message'],
+  properties: {
+    error: { type: 'string' },
+    message: { type: 'string' },
+  },
+} as const;

--- a/api/governance-events/repository.ts
+++ b/api/governance-events/repository.ts
@@ -1,0 +1,485 @@
+import { type Client, type Row } from '@libsql/client';
+import { and, asc, count, desc, eq, gte, like, lte, sql, type SQL } from 'drizzle-orm';
+
+import { type ApiDatabase } from './database';
+import { governanceEvents, type GovernanceEventRow, type NewGovernanceEventRow } from './schema';
+import {
+  type ComplianceReportBody,
+  type CostQuery,
+  type EventQuery,
+  type EventResponse,
+  type EventWithReceiptResponse,
+  type TimelineQuery,
+} from './validation';
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+  };
+  meta: {
+    query_time_ms: number;
+  };
+}
+
+export interface AgentStats {
+  id: string;
+  name: string | null;
+  event_count: number;
+  total_cost_usd: number;
+  security_event_count: number;
+  decisions: Record<string, number>;
+  tools: Array<{ tool: string; count: number; total_cost_usd: number }>;
+  last_seen: string | null;
+}
+
+type SqlArgs = Array<string | number | bigint | boolean | null>;
+
+export class GovernanceEventRepository {
+  constructor(private readonly database: ApiDatabase) {}
+
+  async insertEvents(events: NewGovernanceEventRow[]): Promise<void> {
+    if (events.length === 0) {
+      return;
+    }
+
+    await this.database.db.insert(governanceEvents).values(events);
+  }
+
+  async listEvents(query: EventQuery): Promise<PaginatedResult<EventResponse>> {
+    return this.listEventsWithScope(query);
+  }
+
+  async listSecurityEvents(query: EventQuery): Promise<PaginatedResult<EventResponse>> {
+    return this.listEventsWithScope(query, true);
+  }
+
+  private async listEventsWithScope(
+    query: EventQuery,
+    securityOnly = false,
+  ): Promise<PaginatedResult<EventResponse>> {
+    const startedAt = Date.now();
+    const whereClause = buildEventWhereClause(query, securityOnly);
+    const orderBy = getEventOrderBy(query.sort);
+    const offset = (query.page - 1) * query.limit;
+
+    const [rows, totalResult] = await Promise.all([
+      this.database.db
+        .select()
+        .from(governanceEvents)
+        .where(whereClause)
+        .orderBy(orderBy)
+        .limit(query.limit)
+        .offset(offset),
+      this.database.db
+        .select({ total: count() })
+        .from(governanceEvents)
+        .where(whereClause),
+    ]);
+
+    return {
+      data: rows.map((row) => mapEventRow(row)),
+      pagination: {
+        page: query.page,
+        limit: query.limit,
+        total: Number(totalResult[0]?.total ?? 0),
+      },
+      meta: {
+        query_time_ms: Date.now() - startedAt,
+      },
+    };
+  }
+
+  async getEvent(id: string): Promise<EventWithReceiptResponse | null> {
+    const rows = await this.database.db
+      .select()
+      .from(governanceEvents)
+      .where(eq(governanceEvents.id, id))
+      .limit(1);
+
+    if (!rows[0]) {
+      return null;
+    }
+
+    return mapEventRow(rows[0], true);
+  }
+
+  async listAgents(page = 1, limit = 50): Promise<PaginatedResult<{
+    id: string;
+    name: string | null;
+    event_count: number;
+    total_cost_usd: number;
+    last_seen: string | null;
+  }>> {
+    const startedAt = Date.now();
+    const offset = (page - 1) * limit;
+    const [agentRows, totalRows] = await Promise.all([
+      executeRows(this.database.client, `
+        SELECT
+          agent_id,
+          MAX(agent_name) AS agent_name,
+          COUNT(*) AS event_count,
+          COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+          MAX(timestamp) AS last_seen
+        FROM governance_events
+        GROUP BY agent_id
+        ORDER BY last_seen DESC
+        LIMIT ? OFFSET ?
+      `, [limit, offset]),
+      executeRows(this.database.client, 'SELECT COUNT(*) AS total FROM (SELECT agent_id FROM governance_events GROUP BY agent_id)', []),
+    ]);
+
+    return {
+      data: agentRows.map((row) => ({
+        id: stringValue(row.agent_id),
+        name: nullableStringValue(row.agent_name),
+        event_count: numberValue(row.event_count),
+        total_cost_usd: numberValue(row.total_cost_usd),
+        last_seen: dateValue(row.last_seen),
+      })),
+      pagination: {
+        page,
+        limit,
+        total: numberValue(totalRows[0]?.total),
+      },
+      meta: {
+        query_time_ms: Date.now() - startedAt,
+      },
+    };
+  }
+
+  async getAgentStats(agentId: string): Promise<AgentStats | null> {
+    const [agentRows, decisionRows, toolRows, securityRows] = await Promise.all([
+      executeRows(this.database.client, `
+        SELECT
+          agent_id,
+          MAX(agent_name) AS agent_name,
+          COUNT(*) AS event_count,
+          COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+          MAX(timestamp) AS last_seen
+        FROM governance_events
+        WHERE agent_id = ?
+        GROUP BY agent_id
+      `, [agentId]),
+      executeRows(this.database.client, `
+        SELECT decision, COUNT(*) AS count
+        FROM governance_events
+        WHERE agent_id = ?
+        GROUP BY decision
+      `, [agentId]),
+      executeRows(this.database.client, `
+        SELECT COALESCE(tool, 'unknown') AS tool, COUNT(*) AS count, COALESCE(SUM(cost_usd), 0) AS total_cost_usd
+        FROM governance_events
+        WHERE agent_id = ?
+        GROUP BY tool
+        ORDER BY count DESC
+      `, [agentId]),
+      executeRows(this.database.client, `
+        SELECT COUNT(*) AS count
+        FROM governance_events
+        WHERE agent_id = ? AND severity IS NOT NULL
+      `, [agentId]),
+    ]);
+
+    const agent = agentRows[0];
+    if (!agent) {
+      return null;
+    }
+
+    return {
+      id: stringValue(agent.agent_id),
+      name: nullableStringValue(agent.agent_name),
+      event_count: numberValue(agent.event_count),
+      total_cost_usd: numberValue(agent.total_cost_usd),
+      security_event_count: numberValue(securityRows[0]?.count),
+      decisions: Object.fromEntries(
+        decisionRows.map((row) => [stringValue(row.decision), numberValue(row.count)]),
+      ),
+      tools: toolRows.map((row) => ({
+        tool: stringValue(row.tool),
+        count: numberValue(row.count),
+        total_cost_usd: numberValue(row.total_cost_usd),
+      })),
+      last_seen: dateValue(agent.last_seen),
+    };
+  }
+
+  async getCostSummary(query: CostQuery): Promise<{
+    total_cost_usd: number;
+    total_events: number;
+    by_agent: Array<{ agent_id: string; total_cost_usd: number; event_count: number }>;
+    by_provider: Array<{ provider: string; total_cost_usd: number; event_count: number }>;
+    meta: { query_time_ms: number };
+  }> {
+    const startedAt = Date.now();
+    const { whereSql, args } = buildSqlFilter(query);
+    const [summaryRows, agentRows, providerRows] = await Promise.all([
+      executeRows(this.database.client, `
+        SELECT COALESCE(SUM(cost_usd), 0) AS total_cost_usd, COUNT(*) AS total_events
+        FROM governance_events
+        ${whereSql}
+      `, args),
+      executeRows(this.database.client, `
+        SELECT agent_id, COALESCE(SUM(cost_usd), 0) AS total_cost_usd, COUNT(*) AS event_count
+        FROM governance_events
+        ${whereSql}
+        GROUP BY agent_id
+        ORDER BY total_cost_usd DESC
+      `, args),
+      executeRows(this.database.client, `
+        SELECT COALESCE(provider, 'unknown') AS provider, COALESCE(SUM(cost_usd), 0) AS total_cost_usd, COUNT(*) AS event_count
+        FROM governance_events
+        ${whereSql}
+        GROUP BY provider
+        ORDER BY total_cost_usd DESC
+      `, args),
+    ]);
+
+    return {
+      total_cost_usd: numberValue(summaryRows[0]?.total_cost_usd),
+      total_events: numberValue(summaryRows[0]?.total_events),
+      by_agent: agentRows.map((row) => ({
+        agent_id: stringValue(row.agent_id),
+        total_cost_usd: numberValue(row.total_cost_usd),
+        event_count: numberValue(row.event_count),
+      })),
+      by_provider: providerRows.map((row) => ({
+        provider: stringValue(row.provider),
+        total_cost_usd: numberValue(row.total_cost_usd),
+        event_count: numberValue(row.event_count),
+      })),
+      meta: {
+        query_time_ms: Date.now() - startedAt,
+      },
+    };
+  }
+
+  async getCostTimeline(query: TimelineQuery): Promise<{
+    data: Array<{ bucket: string; total_cost_usd: number; event_count: number }>;
+    meta: { query_time_ms: number };
+  }> {
+    const startedAt = Date.now();
+    const { whereSql, args } = buildSqlFilter(query);
+    const divisor = query.granularity === 'hourly' ? 3600000 : 86400000;
+    const rows = await executeRows(this.database.client, `
+      SELECT
+        CAST((timestamp / ?) AS INTEGER) * ? AS bucket_start,
+        COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+        COUNT(*) AS event_count
+      FROM governance_events
+      ${whereSql}
+      GROUP BY bucket_start
+      ORDER BY bucket_start ASC
+    `, [divisor, divisor, ...args]);
+
+    return {
+      data: rows.map((row) => ({
+        bucket: dateValue(row.bucket_start) ?? new Date(0).toISOString(),
+        total_cost_usd: numberValue(row.total_cost_usd),
+        event_count: numberValue(row.event_count),
+      })),
+      meta: {
+        query_time_ms: Date.now() - startedAt,
+      },
+    };
+  }
+
+  async getComplianceStatus(framework: string, query: CostQuery = {}): Promise<{
+    framework: string;
+    status: 'pass' | 'warn' | 'fail';
+    total_events: number;
+    violation_count: number;
+    evidence_count: number;
+    controls: Array<{ id: string; status: 'pass' | 'warn' | 'fail'; evidence_count: number }>;
+    meta: { query_time_ms: number };
+  }> {
+    const startedAt = Date.now();
+    const scopedQuery = { ...query, framework };
+    const { whereSql, args } = buildSqlFilter(scopedQuery);
+    const rows = await executeRows(this.database.client, `
+      SELECT
+        COUNT(*) AS total_events,
+        SUM(CASE WHEN decision IN ('DENY', 'REQUIRE_APPROVAL') OR severity IN ('high', 'critical') THEN 1 ELSE 0 END) AS violation_count,
+        SUM(CASE WHEN receipt_json IS NOT NULL THEN 1 ELSE 0 END) AS evidence_count
+      FROM governance_events
+      ${whereSql}
+    `, args);
+
+    const totalEvents = numberValue(rows[0]?.total_events);
+    const violationCount = numberValue(rows[0]?.violation_count);
+    const evidenceCount = numberValue(rows[0]?.evidence_count);
+    const status = totalEvents === 0 ? 'warn' : violationCount > 0 ? 'fail' : 'pass';
+
+    return {
+      framework,
+      status,
+      total_events: totalEvents,
+      violation_count: violationCount,
+      evidence_count: evidenceCount,
+      controls: [
+        {
+          id: `${framework}:runtime-governance`,
+          status,
+          evidence_count: evidenceCount,
+        },
+      ],
+      meta: {
+        query_time_ms: Date.now() - startedAt,
+      },
+    };
+  }
+
+  async generateComplianceReport(body: ComplianceReportBody): Promise<{
+    id: string;
+    framework: string;
+    generated_at: string;
+    status: 'pass' | 'warn' | 'fail';
+    summary: {
+      total_events: number;
+      violation_count: number;
+      evidence_count: number;
+    };
+    controls: Array<{ id: string; status: 'pass' | 'warn' | 'fail'; evidence_count: number }>;
+  }> {
+    const status = await this.getComplianceStatus(body.framework, {
+      from: body.from,
+      to: body.to,
+    });
+
+    return {
+      id: `report_${body.framework}_${Date.now()}`,
+      framework: body.framework,
+      generated_at: new Date().toISOString(),
+      status: status.status,
+      summary: {
+        total_events: status.total_events,
+        violation_count: status.violation_count,
+        evidence_count: status.evidence_count,
+      },
+      controls: status.controls,
+    };
+  }
+}
+
+function buildEventWhereClause(query: EventQuery, securityOnly = false): SQL {
+  const clauses: SQL[] = [];
+
+  if (query.agent) clauses.push(eq(governanceEvents.agentId, query.agent));
+  if (query.decision) clauses.push(eq(governanceEvents.decision, query.decision));
+  if (query.tool) clauses.push(eq(governanceEvents.tool, query.tool));
+  if (query.severity) clauses.push(eq(governanceEvents.severity, query.severity));
+  if (query.from) clauses.push(gte(governanceEvents.timestamp, Date.parse(query.from)));
+  if (query.to) clauses.push(lte(governanceEvents.timestamp, Date.parse(query.to)));
+  if (query.search) clauses.push(like(governanceEvents.reason, `%${query.search}%`));
+  if (securityOnly) clauses.push(sql`${governanceEvents.severity} IS NOT NULL`);
+
+  return clauses.length > 0 ? and(...clauses) ?? sql`1 = 1` : sql`1 = 1`;
+}
+
+function getEventOrderBy(sort: string): SQL {
+  const descending = sort.startsWith('-');
+  const field = descending ? sort.slice(1) : sort;
+  const columns: Record<string, typeof governanceEvents.timestamp> = {
+    timestamp: governanceEvents.timestamp,
+  };
+  const genericColumns = {
+    agent: governanceEvents.agentId,
+    decision: governanceEvents.decision,
+    tool: governanceEvents.tool,
+    severity: governanceEvents.severity,
+    cost: governanceEvents.costUsd,
+    cost_usd: governanceEvents.costUsd,
+  };
+  const column = columns[field] ?? genericColumns[field as keyof typeof genericColumns] ?? governanceEvents.timestamp;
+  return descending ? desc(column) : asc(column);
+}
+
+function mapEventRow(row: GovernanceEventRow, includeReceipt = false): EventWithReceiptResponse {
+  const event = {
+    id: row.id,
+    timestamp: new Date(row.timestamp).toISOString(),
+    agent_id: row.agentId,
+    agent_name: row.agentName,
+    decision: row.decision as EventWithReceiptResponse['decision'],
+    tool: row.tool,
+    provider: row.provider,
+    model: row.model,
+    cost_usd: row.costUsd,
+    severity: row.severity as EventWithReceiptResponse['severity'],
+    reason: row.reason,
+    framework: row.framework,
+    metadata: parseJson(row.metadataJson, {}),
+    receipt: includeReceipt ? parseJson(row.receiptJson, {}) : {},
+  };
+
+  if (!includeReceipt) {
+    delete (event as Partial<typeof event>).receipt;
+  }
+
+  return event as EventWithReceiptResponse;
+}
+
+function buildSqlFilter(query: CostQuery & { framework?: string }): { whereSql: string; args: SqlArgs } {
+  const clauses: string[] = [];
+  const args: SqlArgs = [];
+
+  if (query.agent) {
+    clauses.push('agent_id = ?');
+    args.push(query.agent);
+  }
+  if (query.provider) {
+    clauses.push('provider = ?');
+    args.push(query.provider);
+  }
+  if (query.framework) {
+    clauses.push('framework = ?');
+    args.push(query.framework);
+  }
+  if (query.from) {
+    clauses.push('timestamp >= ?');
+    args.push(Date.parse(query.from));
+  }
+  if (query.to) {
+    clauses.push('timestamp <= ?');
+    args.push(Date.parse(query.to));
+  }
+
+  return {
+    whereSql: clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '',
+    args,
+  };
+}
+
+async function executeRows(client: Client, statement: string, args: SqlArgs): Promise<Row[]> {
+  const result = await client.execute({ sql: statement, args });
+  return [...result.rows];
+}
+
+function parseJson(value: string, fallback: Record<string, unknown>): Record<string, unknown> {
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return fallback;
+  }
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === 'number' ? value : Number(value ?? 0);
+}
+
+function stringValue(value: unknown): string {
+  return String(value ?? '');
+}
+
+function nullableStringValue(value: unknown): string | null {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function dateValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return new Date(numberValue(value)).toISOString();
+}

--- a/api/governance-events/schema.ts
+++ b/api/governance-events/schema.ts
@@ -1,0 +1,21 @@
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const governanceEvents = sqliteTable('governance_events', {
+  id: text('id').primaryKey(),
+  timestamp: integer('timestamp', { mode: 'number' }).notNull(),
+  agentId: text('agent_id').notNull(),
+  agentName: text('agent_name'),
+  decision: text('decision').notNull(),
+  tool: text('tool'),
+  provider: text('provider'),
+  model: text('model'),
+  costUsd: real('cost_usd').notNull().default(0),
+  severity: text('severity'),
+  reason: text('reason').notNull(),
+  framework: text('framework'),
+  receiptJson: text('receipt_json').notNull(),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+});
+
+export type GovernanceEventRow = typeof governanceEvents.$inferSelect;
+export type NewGovernanceEventRow = typeof governanceEvents.$inferInsert;

--- a/api/governance-events/server.ts
+++ b/api/governance-events/server.ts
@@ -1,0 +1,344 @@
+import swagger from '@fastify/swagger';
+import Fastify, { type FastifyError, type FastifyInstance } from 'fastify';
+import { ZodError } from 'zod';
+
+import { createApiDatabase, seedGovernanceEvents, type ApiDatabase } from './database';
+import {
+  eventListOpenApiSchema,
+  eventWithReceiptOpenApiSchema,
+  metaOpenApiSchema,
+  paginationOpenApiSchema,
+  standardErrorOpenApiSchema,
+} from './openapi';
+import { GovernanceEventRepository } from './repository';
+import { type NewGovernanceEventRow } from './schema';
+import {
+  complianceReportBodySchema,
+  costQuerySchema,
+  eventQuerySchema,
+  eventWithReceiptResponseSchema,
+  healthResponseSchema,
+  paginatedAgentsResponseSchema,
+  paginatedEventsResponseSchema,
+  paginationQuerySchema,
+  timelineQuerySchema,
+} from './validation';
+
+export interface CreateServerOptions {
+  databaseUrl?: string;
+  seedEvents?: NewGovernanceEventRow[];
+  logger?: boolean;
+}
+
+export interface GovernanceApiServer {
+  app: FastifyInstance;
+  database: ApiDatabase;
+  repository: GovernanceEventRepository;
+}
+
+const DEFAULT_DATABASE_URL = 'file:./data/tealtiger-events.sqlite';
+
+export async function createGovernanceApiServer(
+  options: CreateServerOptions = {},
+): Promise<GovernanceApiServer> {
+  const app = Fastify({ logger: options.logger ?? false });
+  const database = await createApiDatabase(options.databaseUrl ?? process.env.TEALTIGER_DB_URL ?? DEFAULT_DATABASE_URL);
+  const repository = new GovernanceEventRepository(database);
+  const startedAt = Date.now();
+
+  if (options.seedEvents) {
+    await seedGovernanceEvents(database, options.seedEvents);
+  }
+
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: 'TealTiger Governance Events API',
+        version: '1.0.0',
+      },
+      tags: [
+        { name: 'events', description: 'Governance event queries' },
+        { name: 'agents', description: 'Agent inventory and statistics' },
+        { name: 'cost', description: 'Cost analytics' },
+        { name: 'security', description: 'Security event views' },
+        { name: 'compliance', description: 'Compliance evidence and reports' },
+        { name: 'health', description: 'Service health' },
+      ],
+    },
+  });
+
+  app.setErrorHandler((error: FastifyError, _request, reply) => {
+    const statusCode = error instanceof ZodError
+      ? 400
+      : error.statusCode && error.statusCode >= 400
+        ? error.statusCode
+        : 500;
+    reply.status(statusCode).send({
+      error: statusCode === 500 ? 'internal_server_error' : 'request_error',
+      message: error.message,
+    });
+  });
+
+  app.get('/api/v1/health', {
+    schema: {
+      tags: ['health'],
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            status: { type: 'string' },
+            service: { type: 'string' },
+            database: { type: 'string' },
+            uptime_seconds: { type: 'number' },
+            timestamp: { type: 'string', format: 'date-time' },
+          },
+        },
+      },
+    },
+  }, async () => healthResponseSchema.parse({
+    status: 'ok',
+    service: 'tealtiger-governance-api',
+    database: 'connected',
+    uptime_seconds: (Date.now() - startedAt) / 1000,
+    timestamp: new Date().toISOString(),
+  }));
+
+  app.get('/api/v1/openapi.json', {
+    schema: {
+      tags: ['health'],
+      response: { 200: { type: 'object', additionalProperties: true } },
+    },
+  }, async () => app.swagger());
+
+  app.get('/api/v1/events', {
+    schema: {
+      tags: ['events'],
+      querystring: eventQueryOpenApiSchema(),
+      response: {
+        200: eventListOpenApiSchema,
+        400: standardErrorOpenApiSchema,
+      },
+    },
+  }, async (request) => {
+    const query = eventQuerySchema.parse(request.query);
+    return paginatedEventsResponseSchema.parse(await repository.listEvents(query));
+  });
+
+  app.get('/api/v1/events/stream', {
+    schema: {
+      tags: ['events'],
+      response: {
+        200: { type: 'string' },
+      },
+    },
+  }, async (_request, reply) => {
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    reply.raw.write('event: ready\n');
+    reply.raw.write(`data: ${JSON.stringify({ status: 'connected' })}\n\n`);
+    reply.raw.end();
+  });
+
+  app.get('/api/v1/events/:id', {
+    schema: {
+      tags: ['events'],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+      response: {
+        200: eventWithReceiptOpenApiSchema,
+        404: standardErrorOpenApiSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const event = await repository.getEvent(id);
+    if (!event) {
+      return reply.status(404).send({ error: 'not_found', message: `Event ${id} not found` });
+    }
+    return eventWithReceiptResponseSchema.parse(event);
+  });
+
+  app.get('/api/v1/agents', {
+    schema: {
+      tags: ['agents'],
+      querystring: paginationOpenApiQuerySchema(),
+      response: {
+        200: {
+          type: 'object',
+          required: ['data', 'pagination', 'meta'],
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+                  event_count: { type: 'integer' },
+                  total_cost_usd: { type: 'number' },
+                  last_seen: { anyOf: [{ type: 'string', format: 'date-time' }, { type: 'null' }] },
+                },
+              },
+            },
+            pagination: paginationOpenApiSchema,
+            meta: metaOpenApiSchema,
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const query = paginationQuerySchema.parse(request.query);
+    return paginatedAgentsResponseSchema.parse(await repository.listAgents(query.page, query.limit));
+  });
+
+  app.get('/api/v1/agents/:id/stats', {
+    schema: {
+      tags: ['agents'],
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: { id: { type: 'string' } },
+      },
+      response: {
+        200: { type: 'object', additionalProperties: true },
+        404: standardErrorOpenApiSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const stats = await repository.getAgentStats(id);
+    if (!stats) {
+      return reply.status(404).send({ error: 'not_found', message: `Agent ${id} not found` });
+    }
+    return stats;
+  });
+
+  app.get('/api/v1/cost/summary', {
+    schema: {
+      tags: ['cost'],
+      querystring: costQueryOpenApiSchema(),
+      response: {
+        200: { type: 'object', additionalProperties: true },
+      },
+    },
+  }, async (request) => repository.getCostSummary(costQuerySchema.parse(request.query)));
+
+  app.get('/api/v1/cost/timeline', {
+    schema: {
+      tags: ['cost'],
+      querystring: timelineQueryOpenApiSchema(),
+      response: {
+        200: { type: 'object', additionalProperties: true },
+      },
+    },
+  }, async (request) => repository.getCostTimeline(timelineQuerySchema.parse(request.query)));
+
+  app.get('/api/v1/security/events', {
+    schema: {
+      tags: ['security'],
+      querystring: eventQueryOpenApiSchema(),
+      response: {
+        200: eventListOpenApiSchema,
+      },
+    },
+  }, async (request) => {
+    const query = eventQuerySchema.parse(request.query);
+    return paginatedEventsResponseSchema.parse(await repository.listSecurityEvents(query));
+  });
+
+  app.get('/api/v1/compliance/:framework', {
+    schema: {
+      tags: ['compliance'],
+      params: {
+        type: 'object',
+        required: ['framework'],
+        properties: { framework: { type: 'string' } },
+      },
+      querystring: costQueryOpenApiSchema(),
+      response: {
+        200: { type: 'object', additionalProperties: true },
+      },
+    },
+  }, async (request) => {
+    const { framework } = request.params as { framework: string };
+    return repository.getComplianceStatus(framework, costQuerySchema.parse(request.query));
+  });
+
+  app.post('/api/v1/compliance/report', {
+    schema: {
+      tags: ['compliance'],
+      body: {
+        type: 'object',
+        required: ['framework'],
+        properties: {
+          framework: { type: 'string' },
+          from: { type: 'string', format: 'date-time' },
+          to: { type: 'string', format: 'date-time' },
+        },
+      },
+      response: {
+        200: { type: 'object', additionalProperties: true },
+      },
+    },
+  }, async (request) => repository.generateComplianceReport(
+    complianceReportBodySchema.parse(request.body),
+  ));
+
+  return { app, database, repository };
+}
+
+function eventQueryOpenApiSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      agent: { type: 'string' },
+      decision: { type: 'string', enum: ['ALLOW', 'DENY', 'REVISE', 'REQUIRE_APPROVAL'] },
+      tool: { type: 'string' },
+      from: { type: 'string', format: 'date-time' },
+      to: { type: 'string', format: 'date-time' },
+      severity: { type: 'string', enum: ['info', 'low', 'medium', 'high', 'critical'] },
+      page: { type: 'integer', minimum: 1, default: 1 },
+      limit: { type: 'integer', minimum: 1, maximum: 200, default: 50 },
+      sort: { type: 'string', default: '-timestamp' },
+      search: { type: 'string' },
+    },
+  };
+}
+
+function paginationOpenApiQuerySchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      page: { type: 'integer', minimum: 1, default: 1 },
+      limit: { type: 'integer', minimum: 1, maximum: 200, default: 50 },
+    },
+  };
+}
+
+function costQueryOpenApiSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      agent: { type: 'string' },
+      provider: { type: 'string' },
+      from: { type: 'string', format: 'date-time' },
+      to: { type: 'string', format: 'date-time' },
+    },
+  };
+}
+
+function timelineQueryOpenApiSchema(): Record<string, unknown> {
+  return {
+    ...costQueryOpenApiSchema(),
+    properties: {
+      ...costQueryOpenApiSchema().properties as Record<string, unknown>,
+      granularity: { type: 'string', enum: ['hourly', 'daily'], default: 'daily' },
+    },
+  };
+}

--- a/api/governance-events/validation.ts
+++ b/api/governance-events/validation.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+
+export const decisionSchema = z.enum(['ALLOW', 'DENY', 'REVISE', 'REQUIRE_APPROVAL']);
+export const severitySchema = z.enum(['info', 'low', 'medium', 'high', 'critical']);
+export const timelineGranularitySchema = z.enum(['hourly', 'daily']).default('daily');
+
+export const paginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+export const eventQuerySchema = paginationQuerySchema.extend({
+  agent: z.string().min(1).optional(),
+  decision: decisionSchema.optional(),
+  tool: z.string().min(1).optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  severity: severitySchema.optional(),
+  sort: z.string().min(1).default('-timestamp'),
+  search: z.string().min(1).optional(),
+});
+
+export const costQuerySchema = z.object({
+  agent: z.string().min(1).optional(),
+  provider: z.string().min(1).optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+
+export const timelineQuerySchema = costQuerySchema.extend({
+  granularity: timelineGranularitySchema,
+});
+
+export const complianceReportBodySchema = z.object({
+  framework: z.string().min(1),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+
+export const eventResponseSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  agent_id: z.string(),
+  agent_name: z.string().nullable(),
+  decision: decisionSchema,
+  tool: z.string().nullable(),
+  provider: z.string().nullable(),
+  model: z.string().nullable(),
+  cost_usd: z.number(),
+  severity: severitySchema.nullable(),
+  reason: z.string(),
+  framework: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+export const eventWithReceiptResponseSchema = eventResponseSchema.extend({
+  receipt: z.record(z.string(), z.unknown()),
+});
+
+export const paginationResponseSchema = z.object({
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
+});
+
+export const metaResponseSchema = z.object({
+  query_time_ms: z.number(),
+});
+
+export const paginatedEventsResponseSchema = z.object({
+  data: z.array(eventResponseSchema),
+  pagination: paginationResponseSchema,
+  meta: metaResponseSchema,
+});
+
+export const agentResponseSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  event_count: z.number().int(),
+  total_cost_usd: z.number(),
+  last_seen: z.string().nullable(),
+});
+
+export const paginatedAgentsResponseSchema = z.object({
+  data: z.array(agentResponseSchema),
+  pagination: paginationResponseSchema,
+  meta: metaResponseSchema,
+});
+
+export const healthResponseSchema = z.object({
+  status: z.literal('ok'),
+  service: z.literal('tealtiger-governance-api'),
+  database: z.literal('connected'),
+  uptime_seconds: z.number(),
+  timestamp: z.string(),
+});
+
+export type EventQuery = z.infer<typeof eventQuerySchema>;
+export type CostQuery = z.infer<typeof costQuerySchema>;
+export type TimelineQuery = z.infer<typeof timelineQuerySchema>;
+export type ComplianceReportBody = z.infer<typeof complianceReportBodySchema>;
+export type EventResponse = z.infer<typeof eventResponseSchema>;
+export type EventWithReceiptResponse = z.infer<typeof eventWithReceiptResponseSchema>;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "commonjs",
   "description": "Hub repository utilities for TealTiger documentation, schemas, examples, and integrations.",
   "scripts": {
+    "api:start": "ts-node api/governance-events/index.ts",
+    "build": "tsc --noEmit",
+    "test:api": "node --test -r ts-node/register tests/api/*.test.ts",
     "validate:policy": "ts-node scripts/validate-policy.ts",
     "test:policy-validator": "ts-node scripts/test-validate-policy.ts"
   },
@@ -14,5 +17,12 @@
     "ajv-formats": "^3.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/swagger": "^9.7.0",
+    "@libsql/client": "^0.17.3",
+    "drizzle-orm": "^0.45.2",
+    "fastify": "^5.8.5",
+    "zod": "^4.4.3"
   }
 }

--- a/tests/api/governance-api.test.ts
+++ b/tests/api/governance-api.test.ts
@@ -1,0 +1,260 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGovernanceApiServer, type GovernanceApiServer } from '../../api/governance-events/server';
+import { type NewGovernanceEventRow } from '../../api/governance-events/schema';
+
+const baseTime = Date.parse('2026-05-30T12:00:00.000Z');
+
+test('health and OpenAPI endpoints are available', async (t) => {
+  const server = await buildTestServer(t);
+
+  const health = await server.app.inject({ method: 'GET', url: '/api/v1/health' });
+  assert.equal(health.statusCode, 200);
+  assert.equal(health.json().status, 'ok');
+  assert.equal(health.json().database, 'connected');
+
+  const openApi = await server.app.inject({ method: 'GET', url: '/api/v1/openapi.json' });
+  assert.equal(openApi.statusCode, 200);
+  assert.equal(openApi.json().info.title, 'TealTiger Governance Events API');
+  assert.ok(openApi.json().paths['/api/v1/events']);
+});
+
+test('events endpoint supports pagination, filtering, sorting, and search', async (t) => {
+  const server = await buildTestServer(t);
+
+  const pageOne = await server.app.inject({
+    method: 'GET',
+    url: '/api/v1/events?agent=checkout-agent&limit=1&page=1&sort=timestamp',
+  });
+  assert.equal(pageOne.statusCode, 200);
+  assert.equal(pageOne.json().data.length, 1);
+  assert.equal(pageOne.json().pagination.total, 2);
+  assert.equal(pageOne.json().data[0].id, 'evt-1');
+  assert.ok(pageOne.json().meta.query_time_ms < 50);
+
+  const pageTwo = await server.app.inject({
+    method: 'GET',
+    url: '/api/v1/events?agent=checkout-agent&limit=1&page=2&sort=timestamp',
+  });
+  assert.equal(pageTwo.json().data[0].id, 'evt-2');
+
+  const denied = await server.app.inject({
+    method: 'GET',
+    url: '/api/v1/events?decision=DENY&tool=delete_record&search=denied',
+  });
+  assert.equal(denied.statusCode, 200);
+  assert.equal(denied.json().pagination.total, 1);
+  assert.equal(denied.json().data[0].decision, 'DENY');
+
+  const ranged = await server.app.inject({
+    method: 'GET',
+    url: `/api/v1/events?from=${encodeURIComponent(new Date(baseTime + 1).toISOString())}`,
+  });
+  assert.equal(ranged.statusCode, 200);
+  assert.equal(ranged.json().pagination.total, 4);
+
+  const invalid = await server.app.inject({
+    method: 'GET',
+    url: '/api/v1/events?decision=BLOCK',
+  });
+  assert.equal(invalid.statusCode, 400);
+});
+
+test('single event endpoint returns the full TEEC receipt', async (t) => {
+  const server = await buildTestServer(t);
+
+  const found = await server.app.inject({ method: 'GET', url: '/api/v1/events/evt-2' });
+  assert.equal(found.statusCode, 200);
+  assert.equal(found.json().id, 'evt-2');
+  assert.equal(found.json().receipt.decision, 'DENY');
+  assert.equal(found.json().receipt.receipt_id, 'receipt-evt-2');
+
+  const missing = await server.app.inject({ method: 'GET', url: '/api/v1/events/not-found' });
+  assert.equal(missing.statusCode, 404);
+});
+
+test('agents endpoints return known agents and aggregate stats', async (t) => {
+  const server = await buildTestServer(t);
+
+  const agents = await server.app.inject({ method: 'GET', url: '/api/v1/agents?limit=2' });
+  assert.equal(agents.statusCode, 200);
+  assert.equal(agents.json().pagination.total, 3);
+  assert.equal(agents.json().data.length, 2);
+
+  const stats = await server.app.inject({ method: 'GET', url: '/api/v1/agents/checkout-agent/stats' });
+  assert.equal(stats.statusCode, 200);
+  assert.equal(stats.json().event_count, 2);
+  assert.equal(stats.json().decisions.ALLOW, 1);
+  assert.equal(stats.json().decisions.DENY, 1);
+  assert.equal(stats.json().security_event_count, 1);
+});
+
+test('cost endpoints summarize by agent, provider, and timeline bucket', async (t) => {
+  const server = await buildTestServer(t);
+
+  const summary = await server.app.inject({ method: 'GET', url: '/api/v1/cost/summary?provider=openai' });
+  assert.equal(summary.statusCode, 200);
+  assert.equal(summary.json().total_events, 4);
+  assert.ok(summary.json().total_cost_usd > 0);
+  assert.equal(summary.json().by_provider[0].provider, 'openai');
+
+  const timeline = await server.app.inject({ method: 'GET', url: '/api/v1/cost/timeline?granularity=hourly' });
+  assert.equal(timeline.statusCode, 200);
+  assert.ok(timeline.json().data.length >= 1);
+  assert.ok(timeline.json().data[0].bucket.endsWith('Z'));
+});
+
+test('security events endpoint returns severity-scoped events', async (t) => {
+  const server = await buildTestServer(t);
+
+  const allSecurity = await server.app.inject({ method: 'GET', url: '/api/v1/security/events' });
+  assert.equal(allSecurity.statusCode, 200);
+  assert.equal(allSecurity.json().pagination.total, 3);
+  assert.ok(allSecurity.json().data.every((event: { severity: string | null }) => event.severity !== null));
+
+  const highSeverity = await server.app.inject({ method: 'GET', url: '/api/v1/security/events?severity=high' });
+  assert.equal(highSeverity.statusCode, 200);
+  assert.equal(highSeverity.json().pagination.total, 1);
+  assert.equal(highSeverity.json().data[0].id, 'evt-2');
+});
+
+test('compliance endpoints return status and generated reports', async (t) => {
+  const server = await buildTestServer(t);
+
+  const status = await server.app.inject({ method: 'GET', url: '/api/v1/compliance/eu-ai-act' });
+  assert.equal(status.statusCode, 200);
+  assert.equal(status.json().framework, 'eu-ai-act');
+  assert.equal(status.json().status, 'fail');
+  assert.equal(status.json().violation_count, 2);
+
+  const report = await server.app.inject({
+    method: 'POST',
+    url: '/api/v1/compliance/report',
+    payload: { framework: 'eu-ai-act' },
+  });
+  assert.equal(report.statusCode, 200);
+  assert.equal(report.json().framework, 'eu-ai-act');
+  assert.equal(report.json().summary.violation_count, 2);
+});
+
+test('SSE stream endpoint returns an event stream response', async (t) => {
+  const server = await buildTestServer(t);
+  const response = await server.app.inject({ method: 'GET', url: '/api/v1/events/stream' });
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.headers['content-type'] as string, /text\/event-stream/);
+  assert.match(response.body, /event: ready/);
+});
+
+async function buildTestServer(t: test.TestContext): Promise<GovernanceApiServer> {
+  const directory = mkdtempSync(join(tmpdir(), 'tealtiger-api-'));
+  const databasePath = join(directory, 'events.sqlite');
+  const server = await createGovernanceApiServer({
+    databaseUrl: `file:${databasePath}`,
+    seedEvents: fixtureEvents(),
+  });
+
+  t.after(async () => {
+    await server.app.close();
+    server.database.client.close();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  return server;
+}
+
+function fixtureEvents(): NewGovernanceEventRow[] {
+  return [
+    eventFixture({
+      id: 'evt-1',
+      timestamp: baseTime,
+      agentId: 'checkout-agent',
+      agentName: 'Checkout Agent',
+      decision: 'ALLOW',
+      tool: 'search_docs',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      costUsd: 0.12,
+      severity: null,
+      reason: 'Request allowed by policy',
+      framework: 'eu-ai-act',
+    }),
+    eventFixture({
+      id: 'evt-2',
+      timestamp: baseTime + 60_000,
+      agentId: 'checkout-agent',
+      agentName: 'Checkout Agent',
+      decision: 'DENY',
+      tool: 'delete_record',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      costUsd: 0.02,
+      severity: 'high',
+      reason: 'Tool denied by policy',
+      framework: 'eu-ai-act',
+    }),
+    eventFixture({
+      id: 'evt-3',
+      timestamp: baseTime + 120_000,
+      agentId: 'deploy-agent',
+      agentName: 'Deploy Agent',
+      decision: 'REQUIRE_APPROVAL',
+      tool: 'deploy',
+      provider: 'anthropic',
+      model: 'claude-sonnet',
+      costUsd: 0.28,
+      severity: 'medium',
+      reason: 'Deployment requires approval',
+      framework: 'eu-ai-act',
+    }),
+    eventFixture({
+      id: 'evt-4',
+      timestamp: baseTime + 180_000,
+      agentId: 'analyst-agent',
+      agentName: 'Analyst Agent',
+      decision: 'REVISE',
+      tool: 'query_database',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      costUsd: 0.06,
+      severity: 'low',
+      reason: 'Query must revise requested columns',
+      framework: 'nist-ai-rmf',
+    }),
+    eventFixture({
+      id: 'evt-5',
+      timestamp: baseTime + 240_000,
+      agentId: 'analyst-agent',
+      agentName: 'Analyst Agent',
+      decision: 'ALLOW',
+      tool: 'read_report',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      costUsd: 0.04,
+      severity: null,
+      reason: 'Report read allowed',
+      framework: 'eu-ai-act',
+    }),
+  ];
+}
+
+function eventFixture(event: Omit<NewGovernanceEventRow, 'receiptJson' | 'metadataJson'>): NewGovernanceEventRow {
+  return {
+    ...event,
+    receiptJson: JSON.stringify({
+      receipt_id: `receipt-${event.id}`,
+      decision: event.decision,
+      agent_id: event.agentId,
+      tool: event.tool,
+      issued_at: new Date(event.timestamp).toISOString(),
+    }),
+    metadataJson: JSON.stringify({
+      trace_id: `trace-${event.id}`,
+      source: 'test',
+    }),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["scripts/**/*.ts"]
+  "include": ["scripts/**/*.ts", "api/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Closes #180

## Summary
- Adds a Fastify governance events API with the required `/api/v1` endpoints for events, agents, cost, security, compliance, SSE, and health.
- Adds Drizzle/libSQL SQLite persistence for phase 1, including indexed governance event storage, pagination, filtering, sorting, and reason search.
- Adds Zod request/response validation and generated OpenAPI output at `/api/v1/openapi.json`.
- Adds API tests covering endpoint availability, pagination, filters, OpenAPI, health checks, full TEEC receipt retrieval, compliance reporting, cost analytics, security events, and SSE response handling.

## Validation
- `npm run build`
- `npm run test:api`
- `npm run test:policy-validator`
- `git diff --check`