### PR TITLE
Add governance event WebSocket stream

### DIFF
--- a/api/governance-stream/client-buffer.ts
+++ b/api/governance-stream/client-buffer.ts
@@ -1,0 +1,31 @@
+export class BoundedEventQueue<T> {
+  private readonly items: T[] = [];
+  private dropped = 0;
+
+  constructor(private readonly limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error('BoundedEventQueue limit must be a positive integer');
+    }
+  }
+
+  push(item: T): void {
+    if (this.items.length >= this.limit) {
+      this.items.shift();
+      this.dropped++;
+    }
+    this.items.push(item);
+  }
+
+  shift(): T | undefined {
+    return this.items.shift();
+  }
+
+  get length(): number {
+    return this.items.length;
+  }
+
+  get droppedCount(): number {
+    return this.dropped;
+  }
+}
+

--- a/api/governance-stream/event-stream.ts
+++ b/api/governance-stream/event-stream.ts
@@ -1,0 +1,109 @@
+import { EventEmitter } from 'node:events';
+
+import { matchesFilter, readAgentId, readDecision, readEventType } from './filters';
+import type {
+  GovernanceEventMessage,
+  PublishOptions,
+  StoredGovernanceEvent,
+  StreamMetrics,
+  SubscriptionFilter,
+  TEECReceipt,
+} from './types';
+
+export interface GovernanceEventStreamOptions {
+  historyLimit?: number;
+}
+
+export class GovernanceEventStream {
+  private readonly emitter = new EventEmitter();
+  private readonly historyLimit: number;
+  private readonly history: StoredGovernanceEvent[] = [];
+  private sequence = 0;
+  private published = 0;
+  private subscriberCount = 0;
+  private droppedForBackpressure = 0;
+
+  constructor(options: GovernanceEventStreamOptions = {}) {
+    this.historyLimit = options.historyLimit ?? 10_000;
+  }
+
+  publish(receipt: TEECReceipt, options: PublishOptions = {}): GovernanceEventMessage {
+    const sequence = ++this.sequence;
+    const timestamp = normalizeTimestamp(options.timestamp ?? receipt.timestamp ?? Date.now());
+    const message: GovernanceEventMessage = {
+      type: 'governance_event',
+      id: options.id ?? `evt_${sequence}`,
+      cursor: String(sequence),
+      timestamp,
+      data: receipt,
+    };
+    const event: StoredGovernanceEvent = {
+      sequence,
+      message,
+      agentId: readAgentId(receipt),
+      decision: readDecision(receipt),
+      eventType: options.eventType ?? readEventType(receipt),
+    };
+
+    this.published++;
+    this.history.push(event);
+    while (this.history.length > this.historyLimit) {
+      this.history.shift();
+    }
+    this.emitter.emit('event', event);
+    return message;
+  }
+
+  subscribe(listener: (event: StoredGovernanceEvent) => void): () => void {
+    this.subscriberCount++;
+    this.emitter.on('event', listener);
+    return () => {
+      this.subscriberCount = Math.max(0, this.subscriberCount - 1);
+      this.emitter.off('event', listener);
+    };
+  }
+
+  replayAfter(cursor: string | undefined, filter: SubscriptionFilter): StoredGovernanceEvent[] {
+    if (!cursor) {
+      return [];
+    }
+    const sequence = parseCursor(cursor);
+    return this.history.filter((event) => event.sequence > sequence && matchesFilter(event, filter));
+  }
+
+  latestCursor(): string {
+    return String(this.sequence);
+  }
+
+  recordBackpressureDrop(count = 1): void {
+    this.droppedForBackpressure += count;
+  }
+
+  metrics(): StreamMetrics {
+    return {
+      published: this.published,
+      retained: this.history.length,
+      subscribers: this.subscriberCount,
+      dropped_for_backpressure: this.droppedForBackpressure,
+    };
+  }
+}
+
+function parseCursor(cursor: string | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  const parsed = Number(cursor);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+function normalizeTimestamp(value: string | number | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'number') {
+    return new Date(value).toISOString();
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? new Date().toISOString() : new Date(parsed).toISOString();
+}

--- a/api/governance-stream/filters.ts
+++ b/api/governance-stream/filters.ts
@@ -1,0 +1,92 @@
+import type { StoredGovernanceEvent, SubscriptionFilter, TEECReceipt } from './types';
+
+export function matchesFilter(event: StoredGovernanceEvent, filter: SubscriptionFilter): boolean {
+  if (filter.agents?.length && (!event.agentId || !filter.agents.includes(event.agentId))) {
+    return false;
+  }
+
+  if (filter.decisions?.length && (!event.decision || !filter.decisions.includes(event.decision))) {
+    return false;
+  }
+
+  if (filter.eventTypes?.length && !filter.eventTypes.includes(event.eventType)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function normalizeFilter(input: SubscriptionFilter): SubscriptionFilter {
+  return {
+    agents: uniqueNonEmpty(input.agents),
+    decisions: uniqueNonEmpty(input.decisions?.map((decision) => decision.toUpperCase())),
+    eventTypes: uniqueNonEmpty(input.eventTypes),
+  };
+}
+
+export function parseFilterParams(searchParams: URLSearchParams): { filter: SubscriptionFilter; cursor?: string } {
+  return {
+    filter: normalizeFilter({
+      agents: splitParam(searchParams.get('agent') ?? searchParams.get('agents')),
+      decisions: splitParam(searchParams.get('decision') ?? searchParams.get('decisions')),
+      eventTypes: splitParam(searchParams.get('event_type') ?? searchParams.get('event_types') ?? searchParams.get('type')),
+    }),
+    cursor: searchParams.get('cursor') ?? undefined,
+  };
+}
+
+export function filterFromSubscribeMessage(message: {
+  agent?: string;
+  agents?: string[];
+  decision?: string;
+  decisions?: string[];
+  event_type?: string;
+  event_types?: string[];
+  eventTypes?: string[];
+}): SubscriptionFilter {
+  return normalizeFilter({
+    agents: arrayFrom(message.agents, message.agent),
+    decisions: arrayFrom(message.decisions, message.decision),
+    eventTypes: arrayFrom(message.eventTypes ?? message.event_types, message.event_type),
+  });
+}
+
+export function readAgentId(receipt: TEECReceipt): string | null {
+  return stringValue(receipt.agent_id)
+    ?? stringValue(receipt.agentId)
+    ?? stringValue((receipt.agent as { id?: unknown } | undefined)?.id);
+}
+
+export function readDecision(receipt: TEECReceipt): string | null {
+  const value = stringValue(receipt.decision)
+    ?? stringValue(receipt.action)
+    ?? stringValue(receipt.decision_action);
+  return value?.toUpperCase() ?? null;
+}
+
+export function readEventType(receipt: TEECReceipt): string {
+  return stringValue(receipt.event_type)
+    ?? stringValue(receipt.eventType)
+    ?? 'governance_event';
+}
+
+function splitParam(value: string | null): string[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return uniqueNonEmpty(value.split(',').map((item) => item.trim()));
+}
+
+function arrayFrom(values?: string[], single?: string): string[] | undefined {
+  return uniqueNonEmpty([...(values ?? []), ...(single ? [single] : [])]);
+}
+
+function uniqueNonEmpty(values?: Array<string | undefined>): string[] | undefined {
+  const result = Array.from(new Set((values ?? []).filter((value): value is string => Boolean(value && value.trim()))));
+  return result.length > 0 ? result : undefined;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+

--- a/api/governance-stream/index.ts
+++ b/api/governance-stream/index.ts
@@ -1,0 +1,31 @@
+import { createGovernanceStreamServer } from './server';
+
+export { BoundedEventQueue } from './client-buffer';
+export { GovernanceEventStream } from './event-stream';
+export { attachTealEngineStreaming, normalizeDecision, publishDecision } from './teal-engine-adapter';
+export { createGovernanceStreamServer, GovernanceStreamServer } from './server';
+export type {
+  GovernanceEventMessage,
+  PublishOptions,
+  StreamMessage,
+  StreamMetrics,
+  SubscriptionFilter,
+  TEECReceipt,
+} from './types';
+
+if (require.main === module) {
+  const port = Number(process.env.PORT ?? 8787);
+  const host = process.env.HOST ?? '127.0.0.1';
+  const server = createGovernanceStreamServer();
+
+  server.start(port, host)
+    .then(({ wsUrl, httpUrl }) => {
+      console.log(`Governance event WebSocket listening at ${wsUrl}/ws/events`);
+      console.log(`SSE fallback listening at ${httpUrl}/sse/events`);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}
+

--- a/api/governance-stream/server.ts
+++ b/api/governance-stream/server.ts
@@ -1,0 +1,399 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+import WebSocket, { WebSocketServer } from 'ws';
+
+import { BoundedEventQueue } from './client-buffer';
+import { matchesFilter, filterFromSubscribeMessage, parseFilterParams } from './filters';
+import { GovernanceEventStream } from './event-stream';
+import type {
+  GovernanceEventMessage,
+  StoredGovernanceEvent,
+  StreamControlMessage,
+  StreamMessage,
+  SubscribeMessage,
+  SubscriptionFilter,
+  TEECReceipt,
+} from './types';
+
+export interface GovernanceStreamServerOptions {
+  stream?: GovernanceEventStream;
+  historyLimit?: number;
+  heartbeatIntervalMs?: number;
+  clientBufferLimit?: number;
+  clientHighWaterMarkBytes?: number;
+}
+
+export interface StartedServer {
+  host: string;
+  port: number;
+  httpUrl: string;
+  wsUrl: string;
+}
+
+interface StreamClient {
+  id: string;
+  socket: WebSocket;
+  filter: SubscriptionFilter;
+  queue: BoundedEventQueue<StreamMessage>;
+  unsubscribe: () => void;
+  isAlive: boolean;
+  isFlushing: boolean;
+  flushRetry: NodeJS.Timeout | null;
+}
+
+const DEFAULT_HEARTBEAT_MS = 30_000;
+const DEFAULT_CLIENT_BUFFER_LIMIT = 1_000;
+const DEFAULT_HIGH_WATER_MARK_BYTES = 512 * 1024;
+
+export class GovernanceStreamServer {
+  readonly stream: GovernanceEventStream;
+
+  private readonly heartbeatIntervalMs: number;
+  private readonly clientBufferLimit: number;
+  private readonly clientHighWaterMarkBytes: number;
+  private readonly clients = new Set<StreamClient>();
+  private readonly httpServer: Server;
+  private readonly wsServer: WebSocketServer;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: GovernanceStreamServerOptions = {}) {
+    this.stream = options.stream ?? new GovernanceEventStream({ historyLimit: options.historyLimit });
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+    this.clientBufferLimit = options.clientBufferLimit ?? DEFAULT_CLIENT_BUFFER_LIMIT;
+    this.clientHighWaterMarkBytes = options.clientHighWaterMarkBytes ?? DEFAULT_HIGH_WATER_MARK_BYTES;
+    this.httpServer = createServer((request, response) => this.handleHttpRequest(request, response));
+    this.wsServer = new WebSocketServer({ noServer: true });
+    this.configureUpgradeHandling();
+  }
+
+  start(port = 0, host = '127.0.0.1'): Promise<StartedServer> {
+    return new Promise((resolve, reject) => {
+      const onError = (error: Error): void => {
+        this.httpServer.off('listening', onListening);
+        reject(error);
+      };
+      const onListening = (): void => {
+        this.httpServer.off('error', onError);
+        const address = this.httpServer.address();
+        const resolvedPort = typeof address === 'object' && address ? address.port : port;
+        this.startHeartbeat();
+        resolve({
+          host,
+          port: resolvedPort,
+          httpUrl: `http://${host}:${resolvedPort}`,
+          wsUrl: `ws://${host}:${resolvedPort}`,
+        });
+      };
+
+      this.httpServer.once('error', onError);
+      this.httpServer.once('listening', onListening);
+      this.httpServer.listen(port, host);
+    });
+  }
+
+  stop(): Promise<void> {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+
+    for (const client of this.clients) {
+      client.unsubscribe();
+      client.socket.close();
+    }
+    this.clients.clear();
+    this.wsServer.close();
+
+    return new Promise((resolve, reject) => {
+      this.httpServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  publish(receipt: TEECReceipt): GovernanceEventMessage {
+    return this.stream.publish(receipt);
+  }
+
+  private configureUpgradeHandling(): void {
+    this.wsServer.on('connection', (socket, request) => this.handleWebSocketConnection(socket, request));
+    this.httpServer.on('upgrade', (request, socket, head) => {
+      const url = new URL(request.url ?? '/', 'http://localhost');
+      if (url.pathname !== '/ws/events') {
+        socket.destroy();
+        return;
+      }
+      this.wsServer.handleUpgrade(request, socket, head, (webSocket) => {
+        this.wsServer.emit('connection', webSocket, request);
+      });
+    });
+  }
+
+  private handleHttpRequest(request: IncomingMessage, response: ServerResponse): void {
+    const url = new URL(request.url ?? '/', 'http://localhost');
+    if (request.method === 'GET' && url.pathname === '/health') {
+      sendJson(response, 200, {
+        status: 'ok',
+        service: 'tealtiger-governance-stream',
+        metrics: this.stream.metrics(),
+      });
+      return;
+    }
+
+    if (
+      request.method === 'GET'
+      && (url.pathname === '/sse/events' || url.pathname === '/api/v1/events/stream')
+    ) {
+      this.handleSseConnection(request, response, url);
+      return;
+    }
+
+    sendJson(response, 404, { error: 'not_found', message: 'Route not found' });
+  }
+
+  private handleWebSocketConnection(socket: WebSocket, request: IncomingMessage): void {
+    const url = new URL(request.url ?? '/', 'http://localhost');
+    const { filter, cursor } = parseFilterParams(url.searchParams);
+    const client = this.createClient(socket, filter);
+
+    client.unsubscribe = this.stream.subscribe((event) => {
+      if (matchesFilter(event, client.filter)) {
+        this.enqueue(client, event.message);
+      }
+    });
+
+    socket.on('pong', () => {
+      client.isAlive = true;
+    });
+    socket.on('message', (payload) => this.handleClientMessage(client, payload));
+    socket.on('close', () => this.removeClient(client));
+    socket.on('error', () => this.removeClient(client));
+
+    this.send(client, controlMessage('connection_ack', {
+      client_id: client.id,
+      cursor: this.stream.latestCursor(),
+    }));
+    this.replay(client, cursor);
+  }
+
+  private handleClientMessage(client: StreamClient, payload: WebSocket.RawData): void {
+    let parsed: SubscribeMessage;
+    try {
+      parsed = JSON.parse(payload.toString()) as SubscribeMessage;
+    } catch {
+      this.send(client, controlMessage('subscription_updated', {
+        ok: false,
+        error: 'invalid_json',
+      }));
+      return;
+    }
+
+    if (parsed.type !== 'subscribe') {
+      this.send(client, controlMessage('subscription_updated', {
+        ok: false,
+        error: 'unsupported_message_type',
+      }));
+      return;
+    }
+
+    client.filter = filterFromSubscribeMessage(parsed);
+    this.send(client, controlMessage('subscription_updated', {
+      ok: true,
+      filter: client.filter,
+    }));
+    this.replay(client, parsed.cursor);
+  }
+
+  private createClient(socket: WebSocket, filter: SubscriptionFilter): StreamClient {
+    const client: StreamClient = {
+      id: `client_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      socket,
+      filter,
+      queue: new BoundedEventQueue<StreamMessage>(this.clientBufferLimit),
+      unsubscribe: () => undefined,
+      isAlive: true,
+      isFlushing: false,
+      flushRetry: null,
+    };
+    this.clients.add(client);
+    return client;
+  }
+
+  private removeClient(client: StreamClient): void {
+    if (!this.clients.has(client)) {
+      return;
+    }
+    client.unsubscribe();
+    if (client.flushRetry) {
+      clearTimeout(client.flushRetry);
+      client.flushRetry = null;
+    }
+    this.clients.delete(client);
+  }
+
+  private replay(client: StreamClient, cursor: string | undefined): void {
+    const events = this.stream.replayAfter(cursor, client.filter);
+    for (const event of events) {
+      this.enqueue(client, event.message);
+    }
+    this.send(client, controlMessage('replay_complete', {
+      cursor: this.stream.latestCursor(),
+      replayed: events.length,
+    }));
+  }
+
+  private enqueue(client: StreamClient, message: StreamMessage): void {
+    const before = client.queue.droppedCount;
+    client.queue.push(message);
+    const dropped = client.queue.droppedCount - before;
+    if (dropped > 0) {
+      this.stream.recordBackpressureDrop(dropped);
+    }
+    this.flush(client);
+  }
+
+  private send(client: StreamClient, message: StreamMessage): void {
+    if (client.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    if (client.queue.length > 0 || client.socket.bufferedAmount > this.clientHighWaterMarkBytes) {
+      this.enqueue(client, message);
+      return;
+    }
+
+    client.socket.send(JSON.stringify(message));
+  }
+
+  private flush(client: StreamClient): void {
+    if (client.isFlushing || client.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    client.isFlushing = true;
+    const flushNext = (): void => {
+      if (client.socket.readyState !== WebSocket.OPEN) {
+        client.isFlushing = false;
+        return;
+      }
+
+      if (client.socket.bufferedAmount > this.clientHighWaterMarkBytes) {
+        client.isFlushing = false;
+        this.scheduleFlush(client);
+        return;
+      }
+
+      const next = client.queue.shift();
+      if (!next) {
+        client.isFlushing = false;
+        return;
+      }
+
+      client.socket.send(JSON.stringify(next), () => setImmediate(flushNext));
+    };
+
+    flushNext();
+  }
+
+  private scheduleFlush(client: StreamClient): void {
+    if (client.flushRetry || client.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    client.flushRetry = setTimeout(() => {
+      client.flushRetry = null;
+      this.flush(client);
+    }, 10);
+    client.flushRetry.unref();
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      for (const client of this.clients) {
+        if (!client.isAlive) {
+          client.unsubscribe();
+          client.socket.terminate();
+          this.clients.delete(client);
+          continue;
+        }
+
+        client.isAlive = false;
+        client.socket.ping();
+        this.send(client, controlMessage('heartbeat', {
+          cursor: this.stream.latestCursor(),
+        }));
+      }
+    }, this.heartbeatIntervalMs);
+    this.heartbeatTimer.unref();
+  }
+
+  private handleSseConnection(request: IncomingMessage, response: ServerResponse, url: URL): void {
+    const { filter, cursor } = parseFilterParams(url.searchParams);
+    response.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    writeSse(response, controlMessage('connection_ack', { cursor: this.stream.latestCursor() }), 'connection_ack');
+
+    const replayed = this.stream.replayAfter(cursor, filter);
+    for (const event of replayed) {
+      writeSse(response, event.message, 'governance_event', event.message.cursor);
+    }
+    writeSse(response, controlMessage('replay_complete', {
+      cursor: this.stream.latestCursor(),
+      replayed: replayed.length,
+    }), 'replay_complete');
+
+    const unsubscribe = this.stream.subscribe((event: StoredGovernanceEvent) => {
+      if (matchesFilter(event, filter)) {
+        writeSse(response, event.message, 'governance_event', event.message.cursor);
+      }
+    });
+    const heartbeat = setInterval(() => {
+      response.write(`: heartbeat ${Date.now()}\n\n`);
+    }, this.heartbeatIntervalMs);
+    heartbeat.unref();
+
+    request.on('close', () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+      response.end();
+    });
+  }
+}
+
+export function createGovernanceStreamServer(
+  options: GovernanceStreamServerOptions = {},
+): GovernanceStreamServer {
+  return new GovernanceStreamServer(options);
+}
+
+function controlMessage(type: StreamControlMessage['type'], data: Record<string, unknown>): StreamControlMessage {
+  return {
+    type,
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: Record<string, unknown>): void {
+  response.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+function writeSse(
+  response: ServerResponse,
+  message: StreamMessage,
+  eventName: string,
+  id?: string,
+): void {
+  if (id) {
+    response.write(`id: ${id}\n`);
+  }
+  response.write(`event: ${eventName}\n`);
+  response.write(`data: ${JSON.stringify(message)}\n\n`);
+}

--- a/api/governance-stream/teal-engine-adapter.ts
+++ b/api/governance-stream/teal-engine-adapter.ts
@@ -1,0 +1,94 @@
+import type { GovernanceEventStream } from './event-stream';
+import type { TEECReceipt } from './types';
+
+type EngineLike = Record<string, unknown>;
+type EngineMethod = (...args: unknown[]) => unknown;
+
+export interface TealEngineStreamOptions {
+  methods?: string[];
+}
+
+export function attachTealEngineStreaming(
+  engine: EngineLike,
+  stream: GovernanceEventStream,
+  options: TealEngineStreamOptions = {},
+): () => void {
+  const methods = options.methods ?? ['evaluateV12', 'evaluateWithMode', 'evaluate'];
+  const originals = new Map<string, EngineMethod>();
+
+  for (const method of methods) {
+    const current = engine[method];
+    if (typeof current !== 'function') {
+      continue;
+    }
+
+    const original = current as EngineMethod;
+    originals.set(method, original);
+    engine[method] = function streamedEvaluation(this: EngineLike, ...args: unknown[]): unknown {
+      const result = original.apply(this, args);
+      if (isPromiseLike(result)) {
+        return result.then((decision) => {
+          publishDecision(stream, decision, args[0]);
+          return decision;
+        });
+      }
+      publishDecision(stream, result, args[0]);
+      return result;
+    };
+  }
+
+  return () => {
+    for (const [method, original] of originals) {
+      engine[method] = original;
+    }
+  };
+}
+
+export function publishDecision(
+  stream: GovernanceEventStream,
+  decision: unknown,
+  context?: unknown,
+): void {
+  const receipt = normalizeDecision(decision, context);
+  stream.publish(receipt);
+}
+
+export function normalizeDecision(decision: unknown, context?: unknown): TEECReceipt {
+  const decisionRecord = objectRecord(decision);
+  const contextRecord = objectRecord(context);
+  const metadata = objectRecord(decisionRecord.metadata);
+  const nhiContext = objectRecord(decisionRecord.nhi_context);
+
+  return {
+    ...decisionRecord,
+    event_type: 'governance_event',
+    agent_id: stringValue(decisionRecord.agent_id)
+      ?? stringValue(decisionRecord.agentId)
+      ?? stringValue(nhiContext.agent_id)
+      ?? stringValue(contextRecord.agentId)
+      ?? stringValue(contextRecord.agent_id),
+    decision: stringValue(decisionRecord.decision)
+      ?? stringValue(decisionRecord.action)
+      ?? stringValue(decisionRecord.decision_action),
+    timestamp: stringValue(decisionRecord.timestamp) ?? new Date().toISOString(),
+    reason: stringValue(decisionRecord.reason),
+    reason_codes: decisionRecord.reason_codes,
+    risk_score: decisionRecord.risk_score,
+    policy_version: decisionRecord.policy_version,
+    correlation_id: decisionRecord.correlation_id,
+    metadata,
+  };
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return Boolean(value && typeof (value as Promise<unknown>).then === 'function');
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+

--- a/api/governance-stream/types.ts
+++ b/api/governance-stream/types.ts
@@ -1,0 +1,66 @@
+export interface TEECReceipt extends Record<string, unknown> {
+  agent_id?: string;
+  agentId?: string;
+  action?: string;
+  decision?: string;
+  decision_action?: string;
+  event_type?: string;
+  eventType?: string;
+  timestamp?: string | number;
+}
+
+export interface GovernanceEventMessage {
+  type: 'governance_event';
+  id: string;
+  cursor: string;
+  timestamp: string;
+  data: TEECReceipt;
+}
+
+export interface StreamControlMessage {
+  type: 'connection_ack' | 'subscription_updated' | 'replay_complete' | 'heartbeat';
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+export type StreamMessage = GovernanceEventMessage | StreamControlMessage;
+
+export interface SubscriptionFilter {
+  agents?: string[];
+  decisions?: string[];
+  eventTypes?: string[];
+}
+
+export interface SubscribeMessage {
+  type: 'subscribe';
+  agent?: string;
+  agents?: string[];
+  decision?: string;
+  decisions?: string[];
+  event_type?: string;
+  event_types?: string[];
+  eventTypes?: string[];
+  cursor?: string;
+}
+
+export interface StoredGovernanceEvent {
+  sequence: number;
+  message: GovernanceEventMessage;
+  agentId: string | null;
+  decision: string | null;
+  eventType: string;
+}
+
+export interface PublishOptions {
+  id?: string;
+  timestamp?: string | number | Date;
+  eventType?: string;
+}
+
+export interface StreamMetrics {
+  published: number;
+  retained: number;
+  subscribers: number;
+  dropped_for_backpressure: number;
+}
+

--- a/package.json
+++ b/package.json
@@ -5,14 +5,25 @@
   "type": "commonjs",
   "description": "Hub repository utilities for TealTiger documentation, schemas, examples, and integrations.",
   "scripts": {
+    "stream:start": "ts-node api/governance-stream/index.ts",
+    "build": "tsc --noEmit",
+    "test:stream": "node --test -r ts-node/register tests/api/governance-stream.test.ts",
     "validate:policy": "ts-node scripts/validate-policy.ts",
     "test:policy-validator": "ts-node scripts/test-validate-policy.ts"
   },
+  "dependencies": {
+    "ws": "^8.18.3"
+  },
   "devDependencies": {
     "@types/node": "^24.10.1",
+    "@types/ws": "^8.18.1",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@types/ws": "^8.18.1",
+    "ws": "^8.21.0"
   }
 }

--- a/tests/api/governance-stream.test.ts
+++ b/tests/api/governance-stream.test.ts
@@ -1,0 +1,271 @@
+import { get } from 'node:http';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import WebSocket from 'ws';
+
+import { BoundedEventQueue } from '../../api/governance-stream/client-buffer';
+import { GovernanceEventStream } from '../../api/governance-stream/event-stream';
+import { attachTealEngineStreaming } from '../../api/governance-stream/teal-engine-adapter';
+import {
+  createGovernanceStreamServer,
+  type GovernanceStreamServer,
+} from '../../api/governance-stream/server';
+import type { StreamMessage } from '../../api/governance-stream/types';
+
+test('WebSocket connects and streams filtered governance events', async (t) => {
+  const { server, started } = await buildServer(t);
+  const client = await WebSocketReader.connect(`${started.wsUrl}/ws/events?agent=checkout-agent&decision=DENY`);
+
+  await client.next('connection_ack');
+  server.publish({
+    agent_id: 'checkout-agent',
+    decision: 'ALLOW',
+    receipt_id: 'receipt-ignored',
+  });
+  server.publish({
+    agent_id: 'checkout-agent',
+    decision: 'DENY',
+    receipt_id: 'receipt-delivered',
+  });
+
+  const event = await client.next('governance_event');
+  assert.equal(event.data.agent_id, 'checkout-agent');
+  assert.equal(event.data.decision, 'DENY');
+  assert.equal(event.data.receipt_id, 'receipt-delivered');
+});
+
+test('WebSocket subscribe messages update filtering by agent and decision type', async (t) => {
+  const { server, started } = await buildServer(t);
+  const client = await WebSocketReader.connect(`${started.wsUrl}/ws/events`);
+
+  await client.next('connection_ack');
+  client.socket.send(JSON.stringify({
+    type: 'subscribe',
+    agents: ['deploy-agent'],
+    decisions: ['ALLOW'],
+    event_types: ['tool_call'],
+  }));
+  await client.next('subscription_updated');
+
+  server.publish({ agent_id: 'deploy-agent', decision: 'DENY', event_type: 'tool_call', receipt_id: 'receipt-denied' });
+  server.publish({ agent_id: 'deploy-agent', decision: 'ALLOW', event_type: 'audit_log', receipt_id: 'receipt-other-type' });
+  server.publish({ agent_id: 'deploy-agent', decision: 'ALLOW', event_type: 'tool_call', receipt_id: 'receipt-allowed' });
+
+  const event = await client.next('governance_event');
+  assert.equal(event.data.receipt_id, 'receipt-allowed');
+});
+
+test('WebSocket reconnect with cursor replays missed events', async (t) => {
+  const { server, started } = await buildServer(t);
+  const first = server.publish({ agent_id: 'replay-agent', decision: 'ALLOW', receipt_id: 'receipt-1' });
+  const second = server.publish({ agent_id: 'replay-agent', decision: 'DENY', receipt_id: 'receipt-2' });
+
+  const client = await WebSocketReader.connect(`${started.wsUrl}/ws/events?agent=replay-agent&cursor=${first.cursor}`);
+  const replayed = await client.next('governance_event');
+  assert.equal(replayed.type, 'governance_event');
+  assert.equal(replayed.id, second.id);
+  assert.equal(replayed.data.receipt_id, 'receipt-2');
+});
+
+test('WebSocket heartbeat sends ping and heartbeat messages', async (t) => {
+  const { started } = await buildServer(t, { heartbeatIntervalMs: 20 });
+  const client = await WebSocketReader.connect(`${started.wsUrl}/ws/events`);
+  const pingReceived = new Promise<void>((resolve) => client.socket.once('ping', () => resolve()));
+
+  await client.next('connection_ack');
+  await pingReceived;
+  const heartbeat = await client.next('heartbeat');
+  assert.equal(heartbeat.type, 'heartbeat');
+});
+
+test('SSE fallback streams matching governance events', async (t) => {
+  const { server, started } = await buildServer(t, { heartbeatIntervalMs: 50 });
+  const bodyPromise = readUntilSseEvent(
+    `${started.httpUrl}/sse/events?agent=sse-agent`,
+    'governance_event',
+    'receipt-sse',
+  );
+
+  setTimeout(() => {
+    server.publish({ agent_id: 'sse-agent', decision: 'ALLOW', receipt_id: 'receipt-sse' });
+  }, 10);
+
+  const body = await bodyPromise;
+  assert.match(body, /event: governance_event/);
+  assert.match(body, /receipt-sse/);
+});
+
+test('WebSocket stream handles more than 100 events per second without dropping', async (t) => {
+  const { server, started } = await buildServer(t, {
+    heartbeatIntervalMs: 1_000,
+    clientBufferLimit: 500,
+  });
+  const client = await WebSocketReader.connect(`${started.wsUrl}/ws/events?agent=load-agent`);
+  await client.next('connection_ack');
+
+  for (let index = 0; index < 125; index++) {
+    server.publish({
+      agent_id: 'load-agent',
+      decision: index % 2 === 0 ? 'ALLOW' : 'DENY',
+      receipt_id: `receipt-${index}`,
+    });
+  }
+
+  const events = await client.nextMany('governance_event', 125, 5_000);
+  assert.equal(events.length, 125);
+  assert.equal(server.stream.metrics().dropped_for_backpressure, 0);
+});
+
+test('bounded client buffer drops oldest events when slow clients exceed capacity', () => {
+  const queue = new BoundedEventQueue<number>(3);
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+  queue.push(4);
+  queue.push(5);
+
+  assert.equal(queue.droppedCount, 2);
+  assert.deepEqual([queue.shift(), queue.shift(), queue.shift()], [3, 4, 5]);
+});
+
+test('TealEngine adapter publishes decisions produced by evaluation methods', async () => {
+  const stream = new GovernanceEventStream();
+  const received = new Promise((resolve) => {
+    const unsubscribe = stream.subscribe((event) => {
+      unsubscribe();
+      resolve(event.message);
+    });
+  });
+  const engine = {
+    evaluateWithMode(context: { agentId: string }) {
+      return {
+        action: 'DENY',
+        reason: 'blocked by policy',
+        correlation_id: 'corr-1',
+        reason_codes: ['POLICY_VIOLATION'],
+        metadata: { source: 'test' },
+        context,
+      };
+    },
+  };
+
+  const detach = attachTealEngineStreaming(engine, stream);
+  engine.evaluateWithMode({ agentId: 'adapter-agent' });
+  const message = await received as { data: Record<string, unknown> };
+  detach();
+
+  assert.equal(message.data.agent_id, 'adapter-agent');
+  assert.equal(message.data.decision, 'DENY');
+  assert.equal(message.data.correlation_id, 'corr-1');
+});
+
+async function buildServer(
+  t: test.TestContext,
+  options: Parameters<typeof createGovernanceStreamServer>[0] = {},
+): Promise<{ server: GovernanceStreamServer; started: Awaited<ReturnType<GovernanceStreamServer['start']>> }> {
+  const server = createGovernanceStreamServer(options);
+  const started = await server.start(0);
+
+  t.after(async () => {
+    await server.stop();
+  });
+
+  return { server, started };
+}
+
+class WebSocketReader {
+  readonly messages: StreamMessage[] = [];
+
+  private waiters: Array<() => boolean> = [];
+
+  private constructor(readonly socket: WebSocket) {
+    socket.on('message', (payload) => {
+      this.messages.push(JSON.parse(payload.toString()) as StreamMessage);
+      this.resolveWaiters();
+    });
+  }
+
+  static connect(url: string): Promise<WebSocketReader> {
+    const socket = new WebSocket(url);
+    const reader = new WebSocketReader(socket);
+    return new Promise((resolve, reject) => {
+      socket.once('open', () => resolve(reader));
+      socket.once('error', reject);
+    });
+  }
+
+  next(type: StreamMessage['type'], timeoutMs = 1_000): Promise<StreamMessage> {
+    const existing = this.take(type);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Timed out waiting for ${type}`));
+      }, timeoutMs);
+      const waiter = (): boolean => {
+        const message = this.take(type);
+        if (!message) {
+          return false;
+        }
+        clearTimeout(timeout);
+        resolve(message);
+        return true;
+      };
+      this.waiters.push(waiter);
+      timeout.unref();
+    });
+  }
+
+  async nextMany(
+    type: StreamMessage['type'],
+    count: number,
+    timeoutMs = 1_000,
+  ): Promise<StreamMessage[]> {
+    const result: StreamMessage[] = [];
+    const deadline = Date.now() + timeoutMs;
+    while (result.length < count) {
+      result.push(await this.next(type, Math.max(1, deadline - Date.now())));
+    }
+    return result;
+  }
+
+  private take(type: StreamMessage['type']): StreamMessage | undefined {
+    const index = this.messages.findIndex((message) => message.type === type);
+    if (index === -1) {
+      return undefined;
+    }
+    const [message] = this.messages.splice(index, 1);
+    return message;
+  }
+
+  private resolveWaiters(): void {
+    this.waiters = this.waiters.filter((waiter) => !waiter());
+  }
+}
+
+function readUntilSseEvent(url: string, eventName: string, containsText: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    const request = get(url, (response) => {
+      response.setEncoding('utf8');
+      response.on('data', (chunk: string) => {
+        body += chunk;
+        if (body.includes(`event: ${eventName}`) && body.includes(containsText)) {
+          request.destroy();
+          resolve(body);
+        }
+      });
+      response.on('error', reject);
+    });
+    request.on('error', (error) => {
+      if (body.includes(`event: ${eventName}`) && body.includes(containsText)) {
+        resolve(body);
+        return;
+      }
+      reject(error);
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["scripts/**/*.ts"]
+  "include": ["scripts/**/*.ts", "api/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Closes #181

## Summary
- Adds a governance event streaming server with WebSocket support at `/ws/events`.
- Adds subscription filtering by agent, decision, and event type, plus cursor-based replay for reconnecting clients.
- Adds heartbeat ping/pong handling, bounded per-client buffering for backpressure, and SSE fallback endpoints at `/sse/events` and `/api/v1/events/stream`.
- Adds a TealEngine streaming adapter so evaluation decisions can be published as governance event messages.
- Adds stream tests covering WebSocket delivery, filtering, cursor replay, heartbeat, SSE fallback, backpressure behavior, TealEngine adapter publishing, and 100+ event bursts without drops.

## Validation
- `npm run build`
- `npm run test:stream`
- `npm run test:policy-validator`