### PR TITLE
Add governance event ingestion pipeline

### DIFF
--- a/api/governance-ingestion/database-writer.ts
+++ b/api/governance-ingestion/database-writer.ts
@@ -1,0 +1,106 @@
+import { dirname } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+import { createClient, type Client } from '@libsql/client';
+
+import type { BatchWriteResult, GovernanceEventWriter, NormalizedGovernanceEvent } from './types';
+
+type SqlArg = string | number | null;
+
+export class InMemoryGovernanceEventWriter implements GovernanceEventWriter {
+  readonly records = new Map<string, NormalizedGovernanceEvent>();
+  readonly batchSizes: number[] = [];
+
+  async writeBatch(events: NormalizedGovernanceEvent[]): Promise<BatchWriteResult> {
+    this.batchSizes.push(events.length);
+    let inserted = 0;
+    let duplicates = 0;
+    for (const event of events) {
+      if (this.records.has(event.correlationId)) {
+        duplicates++;
+        continue;
+      }
+      this.records.set(event.correlationId, event);
+      inserted++;
+    }
+    return { inserted, duplicates };
+  }
+}
+
+export class LibSqlGovernanceEventWriter implements GovernanceEventWriter {
+  readonly client: Client;
+
+  constructor(databaseUrl: string) {
+    ensureDatabaseDirectory(databaseUrl);
+    this.client = createClient({ url: databaseUrl });
+  }
+
+  async initialize(): Promise<void> {
+    await this.client.execute(`
+      CREATE TABLE IF NOT EXISTS governance_events (
+        correlation_id TEXT PRIMARY KEY,
+        timestamp TEXT NOT NULL,
+        agent_id TEXT,
+        decision TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        receipt_json TEXT NOT NULL
+      )
+    `);
+    await this.client.execute('CREATE INDEX IF NOT EXISTS idx_ingestion_timestamp ON governance_events(timestamp)');
+    await this.client.execute('CREATE INDEX IF NOT EXISTS idx_ingestion_agent ON governance_events(agent_id)');
+    await this.client.execute('CREATE INDEX IF NOT EXISTS idx_ingestion_decision ON governance_events(decision)');
+  }
+
+  async writeBatch(events: NormalizedGovernanceEvent[]): Promise<BatchWriteResult> {
+    let inserted = 0;
+    let duplicates = 0;
+    for (const event of events) {
+      const result = await this.client.execute({
+        sql: `
+          INSERT OR IGNORE INTO governance_events
+            (correlation_id, timestamp, agent_id, decision, event_type, receipt_json)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `,
+        args: eventToArgs(event),
+      });
+      if (Number(result.rowsAffected) > 0) {
+        inserted++;
+      } else {
+        duplicates++;
+      }
+    }
+    return { inserted, duplicates };
+  }
+
+  async count(): Promise<number> {
+    const result = await this.client.execute('SELECT COUNT(*) AS total FROM governance_events');
+    return Number(result.rows[0]?.total ?? 0);
+  }
+
+  async close(): Promise<void> {
+    this.client.close();
+  }
+}
+
+function eventToArgs(event: NormalizedGovernanceEvent): SqlArg[] {
+  return [
+    event.correlationId,
+    event.timestamp,
+    event.agentId,
+    event.decision,
+    event.eventType,
+    JSON.stringify(event.receipt),
+  ];
+}
+
+function ensureDatabaseDirectory(databaseUrl: string): void {
+  if (!databaseUrl.startsWith('file:') || databaseUrl === 'file::memory:') {
+    return;
+  }
+  const filePath = databaseUrl.replace('file:', '');
+  if (!filePath || filePath.startsWith(':')) {
+    return;
+  }
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+

--- a/api/governance-ingestion/index.ts
+++ b/api/governance-ingestion/index.ts
@@ -1,0 +1,31 @@
+export {
+  InMemoryGovernanceEventWriter,
+  LibSqlGovernanceEventWriter,
+} from './database-writer';
+export {
+  createGovernanceIngestionPipeline,
+  GovernanceIngestionPipeline,
+} from './pipeline';
+export {
+  attachTealEngineIngestion,
+} from './teal-engine-adapter';
+export {
+  decisionFromEvaluationResult,
+  normalizeGovernanceEvent,
+} from './validator';
+export {
+  FileWriteAheadLog,
+  MemoryWriteAheadLog,
+} from './wal';
+export type {
+  BatchWriteResult,
+  GovernanceEventWriter,
+  GovernanceIngestionPipelineOptions,
+  IngestionMetrics,
+  IngestionResult,
+  IngestionWarning,
+  NormalizedGovernanceEvent,
+  TEECReceipt,
+  WriteAheadLog,
+} from './types';
+

--- a/api/governance-ingestion/pipeline.ts
+++ b/api/governance-ingestion/pipeline.ts
@@ -1,0 +1,204 @@
+import { performance } from 'node:perf_hooks';
+
+import { normalizeGovernanceEvent, decisionFromEvaluationResult } from './validator';
+import { MemoryWriteAheadLog } from './wal';
+import type {
+  GovernanceIngestionPipelineOptions,
+  IngestionMetrics,
+  IngestionResult,
+  IngestionWarning,
+  NormalizedGovernanceEvent,
+  TEECReceipt,
+} from './types';
+
+export class GovernanceIngestionPipeline {
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly maxBufferSize: number;
+  private readonly buffer: NormalizedGovernanceEvent[] = [];
+  private readonly metricsState: IngestionMetrics = {
+    accepted: 0,
+    invalid: 0,
+    queued: 0,
+    written: 0,
+    duplicates: 0,
+    dropped: 0,
+    batches: 0,
+    writer_errors: 0,
+    wal_errors: 0,
+    buffer_size: 0,
+    last_flush_duration_ms: null,
+  };
+
+  private flushTimer: NodeJS.Timeout | null = null;
+  private appendQueue: Promise<void> = Promise.resolve();
+  private flushPromise: Promise<void> | null = null;
+
+  constructor(private readonly options: GovernanceIngestionPipelineOptions) {
+    this.batchSize = options.batchSize ?? 100;
+    this.flushIntervalMs = options.flushIntervalMs ?? 1_000;
+    this.maxBufferSize = options.maxBufferSize ?? 10_000;
+    if (this.batchSize < 1 || this.maxBufferSize < 1) {
+      throw new Error('batchSize and maxBufferSize must be positive integers');
+    }
+    this.options.wal ??= new MemoryWriteAheadLog();
+  }
+
+  async start(): Promise<void> {
+    await this.options.writer.initialize?.();
+    await this.options.wal?.initialize?.();
+    const recovered = await this.options.wal?.recover() ?? [];
+    for (const event of recovered) {
+      this.enqueue(event);
+    }
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+    this.flushTimer.unref();
+  }
+
+  async stop(): Promise<void> {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.waitForIdle();
+    await this.options.writer.close?.();
+    await this.options.wal?.close?.();
+  }
+
+  ingest(receipt: TEECReceipt, context: Record<string, unknown> = {}): IngestionResult {
+    const startedAt = performance.now();
+    let event: NormalizedGovernanceEvent;
+    try {
+      event = normalizeGovernanceEvent(receipt, context);
+    } catch (error) {
+      this.metricsState.invalid++;
+      this.warn({
+        code: 'invalid_event',
+        message: error instanceof Error ? error.message : 'Invalid TEEC receipt',
+        error,
+      });
+      return {
+        accepted: false,
+        reason: error instanceof Error ? error.message : 'Invalid TEEC receipt',
+        latencyMs: performance.now() - startedAt,
+      };
+    }
+
+    this.metricsState.accepted++;
+    this.appendQueue = this.appendQueue
+      .then(async () => {
+        await this.options.wal?.append(event);
+        this.enqueue(event);
+        this.options.broadcast?.(event);
+      })
+      .catch((error: unknown) => {
+        this.metricsState.wal_errors++;
+        this.warn({
+          code: 'wal_error',
+          message: 'Failed to append governance event to write-ahead log',
+          correlationId: event.correlationId,
+          error,
+        });
+      });
+
+    return {
+      accepted: true,
+      correlationId: event.correlationId,
+      latencyMs: performance.now() - startedAt,
+    };
+  }
+
+  ingestDecision(decision: unknown, context?: unknown): IngestionResult {
+    return this.ingest(decisionFromEvaluationResult(decision, context), toRecord(context));
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushPromise) {
+      return this.flushPromise;
+    }
+    this.flushPromise = this.drain();
+    try {
+      await this.flushPromise;
+    } finally {
+      this.flushPromise = null;
+    }
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.appendQueue;
+    await this.flush();
+  }
+
+  metrics(): IngestionMetrics {
+    return {
+      ...this.metricsState,
+      buffer_size: this.buffer.length,
+    };
+  }
+
+  private enqueue(event: NormalizedGovernanceEvent): void {
+    if (this.buffer.length >= this.maxBufferSize) {
+      const dropped = this.buffer.shift();
+      if (dropped) {
+        this.metricsState.dropped++;
+        this.metricsState.queued = Math.max(0, this.metricsState.queued - 1);
+        void this.options.wal?.remove([dropped.correlationId]);
+        this.warn({
+          code: 'buffer_overflow',
+          message: 'Governance ingestion buffer is full; dropped oldest event',
+          correlationId: dropped.correlationId,
+        });
+      }
+    }
+
+    this.buffer.push(event);
+    this.metricsState.queued++;
+    if (this.buffer.length >= this.batchSize) {
+      setImmediate(() => {
+        void this.flush();
+      });
+    }
+  }
+
+  private async drain(): Promise<void> {
+    await this.appendQueue;
+    while (this.buffer.length > 0) {
+      const batch = this.buffer.splice(0, this.batchSize);
+      const startedAt = performance.now();
+      try {
+        const result = await this.options.writer.writeBatch(batch);
+        this.metricsState.written += result.inserted;
+        this.metricsState.duplicates += result.duplicates;
+        this.metricsState.batches++;
+        this.metricsState.queued = Math.max(0, this.metricsState.queued - batch.length);
+        this.metricsState.last_flush_duration_ms = performance.now() - startedAt;
+        await this.options.wal?.remove(batch.map((event) => event.correlationId));
+      } catch (error) {
+        this.metricsState.writer_errors++;
+        this.buffer.unshift(...batch);
+        this.warn({
+          code: 'writer_error',
+          message: 'Failed to persist governance event batch',
+          error,
+        });
+        return;
+      }
+    }
+  }
+
+  private warn(warning: IngestionWarning): void {
+    this.options.onWarning?.(warning);
+  }
+}
+
+export function createGovernanceIngestionPipeline(
+  options: GovernanceIngestionPipelineOptions,
+): GovernanceIngestionPipeline {
+  return new GovernanceIngestionPipeline(options);
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}

--- a/api/governance-ingestion/teal-engine-adapter.ts
+++ b/api/governance-ingestion/teal-engine-adapter.ts
@@ -1,0 +1,49 @@
+import type { GovernanceIngestionPipeline } from './pipeline';
+
+type EngineLike = Record<string, unknown>;
+type EngineMethod = (...args: unknown[]) => unknown;
+
+export interface TealEngineIngestionOptions {
+  methods?: string[];
+}
+
+export function attachTealEngineIngestion(
+  engine: EngineLike,
+  pipeline: GovernanceIngestionPipeline,
+  options: TealEngineIngestionOptions = {},
+): () => void {
+  const methods = options.methods ?? ['evaluateV12', 'evaluateWithMode', 'evaluate'];
+  const originals = new Map<string, EngineMethod>();
+
+  for (const method of methods) {
+    const current = engine[method];
+    if (typeof current !== 'function') {
+      continue;
+    }
+
+    const original = current as EngineMethod;
+    originals.set(method, original);
+    engine[method] = function ingestedEvaluation(this: EngineLike, ...args: unknown[]): unknown {
+      const result = original.apply(this, args);
+      if (isPromiseLike(result)) {
+        return result.then((decision) => {
+          pipeline.ingestDecision(decision, args[0]);
+          return decision;
+        });
+      }
+      pipeline.ingestDecision(result, args[0]);
+      return result;
+    };
+  }
+
+  return () => {
+    for (const [method, original] of originals) {
+      engine[method] = original;
+    }
+  };
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return Boolean(value && typeof (value as Promise<unknown>).then === 'function');
+}
+

--- a/api/governance-ingestion/types.ts
+++ b/api/governance-ingestion/types.ts
@@ -1,0 +1,80 @@
+export interface TEECReceipt extends Record<string, unknown> {
+  correlation_id?: string;
+  correlationId?: string;
+  receipt_id?: string;
+  agent_id?: string;
+  agentId?: string;
+  action?: string;
+  decision?: string;
+  decision_action?: string;
+  event_type?: string;
+  eventType?: string;
+  timestamp?: string | number;
+}
+
+export interface NormalizedGovernanceEvent {
+  correlationId: string;
+  timestamp: string;
+  agentId: string | null;
+  decision: string;
+  eventType: string;
+  receipt: TEECReceipt;
+}
+
+export interface BatchWriteResult {
+  inserted: number;
+  duplicates: number;
+}
+
+export interface GovernanceEventWriter {
+  initialize?(): Promise<void>;
+  writeBatch(events: NormalizedGovernanceEvent[]): Promise<BatchWriteResult>;
+  close?(): Promise<void>;
+}
+
+export interface WriteAheadLog {
+  initialize?(): Promise<void>;
+  append(event: NormalizedGovernanceEvent): Promise<void>;
+  remove(correlationIds: string[]): Promise<void>;
+  recover(): Promise<NormalizedGovernanceEvent[]>;
+  close?(): Promise<void>;
+}
+
+export interface IngestionWarning {
+  code: 'invalid_event' | 'buffer_overflow' | 'wal_error' | 'writer_error';
+  message: string;
+  correlationId?: string;
+  error?: unknown;
+}
+
+export interface IngestionMetrics {
+  accepted: number;
+  invalid: number;
+  queued: number;
+  written: number;
+  duplicates: number;
+  dropped: number;
+  batches: number;
+  writer_errors: number;
+  wal_errors: number;
+  buffer_size: number;
+  last_flush_duration_ms: number | null;
+}
+
+export interface IngestionResult {
+  accepted: boolean;
+  correlationId?: string;
+  reason?: string;
+  latencyMs: number;
+}
+
+export interface GovernanceIngestionPipelineOptions {
+  writer: GovernanceEventWriter;
+  wal?: WriteAheadLog;
+  batchSize?: number;
+  flushIntervalMs?: number;
+  maxBufferSize?: number;
+  onWarning?: (warning: IngestionWarning) => void;
+  broadcast?: (event: NormalizedGovernanceEvent) => void;
+}
+

--- a/api/governance-ingestion/validator.ts
+++ b/api/governance-ingestion/validator.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto';
+
+import type { NormalizedGovernanceEvent, TEECReceipt } from './types';
+
+let generatedCorrelationSequence = 0;
+
+export function normalizeGovernanceEvent(
+  receipt: TEECReceipt,
+  context: Record<string, unknown> = {},
+): NormalizedGovernanceEvent {
+  if (!receipt || typeof receipt !== 'object') {
+    throw new Error('TEEC receipt must be an object');
+  }
+
+  const decision = readDecision(receipt);
+  if (!decision) {
+    throw new Error('TEEC receipt must include a decision/action');
+  }
+
+  const correlationId = readString(receipt.correlation_id)
+    ?? readString(receipt.correlationId)
+    ?? readString(receipt.receipt_id)
+    ?? readString(receipt.id)
+    ?? readString(context.correlation_id)
+    ?? readString(context.correlationId)
+    ?? generatedCorrelationId();
+
+  return {
+    correlationId,
+    timestamp: normalizeTimestamp(receipt.timestamp ?? Date.now()),
+    agentId: readString(receipt.agent_id)
+      ?? readString(receipt.agentId)
+      ?? readString(context.agent_id)
+      ?? readString(context.agentId)
+      ?? null,
+    decision,
+    eventType: readString(receipt.event_type) ?? readString(receipt.eventType) ?? 'governance_event',
+    receipt,
+  };
+}
+
+export function decisionFromEvaluationResult(
+  decision: unknown,
+  context: unknown,
+): TEECReceipt {
+  const decisionRecord = toRecord(decision);
+  const contextRecord = toRecord(context);
+  const metadata = toRecord(decisionRecord.metadata);
+  return {
+    ...decisionRecord,
+    correlation_id: readString(decisionRecord.correlation_id)
+      ?? readString(decisionRecord.correlationId)
+      ?? readString(contextRecord.correlation_id)
+      ?? readString(contextRecord.correlationId),
+    agent_id: readString(decisionRecord.agent_id)
+      ?? readString(decisionRecord.agentId)
+      ?? readString(contextRecord.agent_id)
+      ?? readString(contextRecord.agentId),
+    decision: readString(decisionRecord.decision)
+      ?? readString(decisionRecord.action)
+      ?? (typeof decisionRecord.allowed === 'boolean' ? decisionRecord.allowed ? 'ALLOW' : 'DENY' : undefined),
+    event_type: readString(decisionRecord.event_type) ?? 'governance_event',
+    timestamp: timestampValue(decisionRecord.timestamp),
+    reason: decisionRecord.reason,
+    reason_codes: decisionRecord.reason_codes,
+    risk_score: decisionRecord.risk_score,
+    policy_version: decisionRecord.policy_version,
+    metadata,
+  };
+}
+
+function readDecision(receipt: TEECReceipt): string | null {
+  const value = readString(receipt.decision)
+    ?? readString(receipt.action)
+    ?? readString(receipt.decision_action);
+  return value?.toUpperCase() ?? null;
+}
+
+function normalizeTimestamp(value: unknown): string {
+  if (typeof value === 'number') {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+  return new Date().toISOString();
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function timestampValue(value: unknown): string | number {
+  return typeof value === 'string' || typeof value === 'number' ? value : Date.now();
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function generatedCorrelationId(): string {
+  generatedCorrelationSequence++;
+  return `generated_${Date.now()}_${generatedCorrelationSequence}_${randomUUID()}`;
+}

--- a/api/governance-ingestion/wal.ts
+++ b/api/governance-ingestion/wal.ts
@@ -1,0 +1,81 @@
+import { mkdir, readFile, writeFile, appendFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import type { NormalizedGovernanceEvent, WriteAheadLog } from './types';
+
+export class MemoryWriteAheadLog implements WriteAheadLog {
+  private readonly records = new Map<string, NormalizedGovernanceEvent>();
+
+  async append(event: NormalizedGovernanceEvent): Promise<void> {
+    this.records.set(event.correlationId, event);
+  }
+
+  async remove(correlationIds: string[]): Promise<void> {
+    for (const correlationId of correlationIds) {
+      this.records.delete(correlationId);
+    }
+  }
+
+  async recover(): Promise<NormalizedGovernanceEvent[]> {
+    return [...this.records.values()];
+  }
+}
+
+export class FileWriteAheadLog implements WriteAheadLog {
+  private readonly records = new Map<string, NormalizedGovernanceEvent>();
+
+  constructor(private readonly path: string) {}
+
+  async initialize(): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    await this.load();
+  }
+
+  async append(event: NormalizedGovernanceEvent): Promise<void> {
+    this.records.set(event.correlationId, event);
+    await appendFile(this.path, `${JSON.stringify(event)}\n`, 'utf8');
+  }
+
+  async remove(correlationIds: string[]): Promise<void> {
+    let changed = false;
+    for (const correlationId of correlationIds) {
+      changed = this.records.delete(correlationId) || changed;
+    }
+    if (changed) {
+      await this.rewrite();
+    }
+  }
+
+  async recover(): Promise<NormalizedGovernanceEvent[]> {
+    await this.load();
+    return [...this.records.values()];
+  }
+
+  private async load(): Promise<void> {
+    this.records.clear();
+    try {
+      const content = await readFile(this.path, 'utf8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) {
+          continue;
+        }
+        const event = JSON.parse(line) as NormalizedGovernanceEvent;
+        this.records.set(event.correlationId, event);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        await writeFile(this.path, '', 'utf8');
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async rewrite(): Promise<void> {
+    const content = [...this.records.values()]
+      .map((event) => JSON.stringify(event))
+      .join('\n');
+    await writeFile(this.path, content ? `${content}\n` : '', 'utf8');
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   "type": "commonjs",
   "description": "Hub repository utilities for TealTiger documentation, schemas, examples, and integrations.",
   "scripts": {
+    "build": "tsc --noEmit",
+    "test:ingestion": "node --test -r ts-node/register tests/api/governance-ingestion.test.ts",
     "validate:policy": "ts-node scripts/validate-policy.ts",
     "test:policy-validator": "ts-node scripts/test-validate-policy.ts"
+  },
+  "dependencies": {
+    "@libsql/client": "^0.17.3"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/tests/api/governance-ingestion.test.ts
+++ b/tests/api/governance-ingestion.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  attachTealEngineIngestion,
+  createGovernanceIngestionPipeline,
+  FileWriteAheadLog,
+  InMemoryGovernanceEventWriter,
+  LibSqlGovernanceEventWriter,
+  MemoryWriteAheadLog,
+  type BatchWriteResult,
+  type GovernanceEventWriter,
+  type IngestionWarning,
+  type NormalizedGovernanceEvent,
+} from '../../api/governance-ingestion';
+
+test('events flow from TealEngine evaluations to SQLite database', async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'tealtiger-ingestion-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  const writer = new LibSqlGovernanceEventWriter(`file:${join(directory, 'events.sqlite')}`);
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    wal: new MemoryWriteAheadLog(),
+    batchSize: 1,
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  const engine = {
+    evaluateWithMode(context: { agentId: string; correlation_id: string }) {
+      return {
+        action: 'DENY',
+        reason: 'blocked by policy',
+        correlation_id: context.correlation_id,
+        reason_codes: ['POLICY_VIOLATION'],
+      };
+    },
+  };
+  const detach = attachTealEngineIngestion(engine, pipeline);
+
+  engine.evaluateWithMode({ agentId: 'checkout-agent', correlation_id: 'corr-sqlite-1' });
+  await pipeline.waitForIdle();
+  detach();
+
+  assert.equal(await writer.count(), 1);
+  assert.equal(pipeline.metrics().written, 1);
+});
+
+test('batched writes reduce I/O with configurable batch size', async (t) => {
+  const writer = new InMemoryGovernanceEventWriter();
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    batchSize: 3,
+    flushIntervalMs: 60_000,
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  for (let index = 0; index < 3; index++) {
+    pipeline.ingest(receipt(`batch-${index}`));
+  }
+
+  await pipeline.waitForIdle();
+  assert.deepEqual(writer.batchSizes, [3]);
+  assert.equal(writer.records.size, 3);
+});
+
+test('ingestion does not block the governance evaluation path', async (t) => {
+  const writer = new DelayedWriter(50);
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    batchSize: 500,
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  const start = performance.now();
+  for (let index = 0; index < 500; index++) {
+    const result = pipeline.ingest(receipt(`latency-${index}`));
+    assert.equal(result.accepted, true);
+  }
+  const averageMs = (performance.now() - start) / 500;
+
+  assert.ok(averageMs < 1, `expected <1ms average ingestion latency, got ${averageMs}`);
+  assert.equal(writer.records.size, 0);
+  await pipeline.waitForIdle();
+  assert.equal(writer.records.size, 500);
+});
+
+test('pipeline handles 1000+ events/sec sustained without dropping when buffer is sized', async (t) => {
+  const writer = new InMemoryGovernanceEventWriter();
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    batchSize: 100,
+    maxBufferSize: 2_000,
+    flushIntervalMs: 1_000,
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  const start = performance.now();
+  for (let index = 0; index < 1_250; index++) {
+    pipeline.ingest(receipt(`throughput-${index}`));
+  }
+  await pipeline.waitForIdle();
+
+  assert.equal(writer.records.size, 1_250);
+  assert.equal(pipeline.metrics().dropped, 0);
+  assert.ok(performance.now() - start < 1_000);
+});
+
+test('deduplication treats repeated correlation IDs as idempotent inserts', async (t) => {
+  const writer = new InMemoryGovernanceEventWriter();
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    batchSize: 10,
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  pipeline.ingest(receipt('dedupe-1'));
+  pipeline.ingest(receipt('dedupe-1'));
+  await pipeline.waitForIdle();
+
+  assert.equal(writer.records.size, 1);
+  assert.equal(pipeline.metrics().duplicates, 1);
+});
+
+test('buffer overflow drops oldest events and reports a warning', async (t) => {
+  const warnings: IngestionWarning[] = [];
+  const writer = new InMemoryGovernanceEventWriter();
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    batchSize: 100,
+    flushIntervalMs: 60_000,
+    maxBufferSize: 3,
+    onWarning: (warning) => warnings.push(warning),
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  for (let index = 0; index < 5; index++) {
+    pipeline.ingest(receipt(`overflow-${index}`));
+  }
+
+  await pipeline.waitForIdle();
+  assert.equal(writer.records.size, 3);
+  assert.equal(pipeline.metrics().dropped, 2);
+  assert.equal(warnings.filter((warning) => warning.code === 'buffer_overflow').length, 2);
+  assert.equal(writer.records.has('overflow-0'), false);
+  assert.equal(writer.records.has('overflow-1'), false);
+});
+
+test('invalid TEEC receipts are rejected before persistence', async (t) => {
+  const warnings: IngestionWarning[] = [];
+  const writer = new InMemoryGovernanceEventWriter();
+  const pipeline = createGovernanceIngestionPipeline({
+    writer,
+    onWarning: (warning) => warnings.push(warning),
+  });
+  await pipeline.start();
+  t.after(async () => {
+    await pipeline.stop();
+  });
+
+  const result = pipeline.ingest({ correlation_id: 'invalid-without-decision' });
+  await pipeline.waitForIdle();
+
+  assert.equal(result.accepted, false);
+  assert.equal(writer.records.size, 0);
+  assert.equal(pipeline.metrics().invalid, 1);
+  assert.equal(warnings[0]?.code, 'invalid_event');
+});
+
+test('write-ahead log recovers events after a failed database write', async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'tealtiger-wal-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const walPath = join(directory, 'events.wal');
+  const warnings: IngestionWarning[] = [];
+
+  const failingPipeline = createGovernanceIngestionPipeline({
+    writer: new FailingWriter(),
+    wal: new FileWriteAheadLog(walPath),
+    batchSize: 1,
+    onWarning: (warning) => warnings.push(warning),
+  });
+  await failingPipeline.start();
+  failingPipeline.ingest(receipt('recover-1'));
+  await failingPipeline.waitForIdle();
+  await failingPipeline.stop();
+
+  const recoveredWriter = new InMemoryGovernanceEventWriter();
+  const recoveredPipeline = createGovernanceIngestionPipeline({
+    writer: recoveredWriter,
+    wal: new FileWriteAheadLog(walPath),
+    batchSize: 1,
+  });
+  await recoveredPipeline.start();
+  await recoveredPipeline.waitForIdle();
+  await recoveredPipeline.stop();
+
+  assert.equal(warnings.some((warning) => warning.code === 'writer_error'), true);
+  assert.equal(recoveredWriter.records.size, 1);
+  assert.equal(recoveredWriter.records.has('recover-1'), true);
+});
+
+function receipt(correlationId: string): Record<string, unknown> {
+  return {
+    correlation_id: correlationId,
+    agent_id: 'agent-1',
+    decision: 'ALLOW',
+    event_type: 'governance_event',
+    timestamp: '2026-05-30T10:30:01.000Z',
+    reason_codes: ['POLICY_COMPLIANT'],
+  };
+}
+
+class DelayedWriter extends InMemoryGovernanceEventWriter {
+  constructor(private readonly delayMs: number) {
+    super();
+  }
+
+  override async writeBatch(events: NormalizedGovernanceEvent[]): Promise<BatchWriteResult> {
+    await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    return super.writeBatch(events);
+  }
+}
+
+class FailingWriter implements GovernanceEventWriter {
+  async writeBatch(): Promise<BatchWriteResult> {
+    throw new Error('database unavailable');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["scripts/**/*.ts"]
+  "include": ["scripts/**/*.ts", "api/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Closes #183

## Summary
- Adds an async governance event ingestion pipeline that accepts TEEC receipts from TealEngine without waiting on database writes.
- Adds configurable batch writes, flush intervals, max buffer size, and overflow warnings for backpressure handling.
- Adds write-ahead log implementations for in-memory and file-backed recovery, plus idempotent libSQL persistence keyed by correlation ID.
- Adds schema normalization/validation for TEEC-like receipts and a TealEngine adapter that publishes evaluation results into the pipeline.
- Adds tests covering TealEngine-to-database flow, batching, non-blocking ingestion latency, 1000+ event throughput, deduplication, overflow behavior, validation, and WAL recovery.

## Validation
- `npm run build`
- `npm run test:ingestion`
- `npm run test:policy-validator`