### PR TITLE
docs(readme): add contributor avatar grid section [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,14 @@ Built with ❤️ by the TealTiger team and [contributors](./CONTRIBUTORS.md).
 
 ---
 
+## 👥 Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=agentguard-ai/tealtiger)](https://github.com/agentguard-ai/tealtiger/graphs/contributors)
+
+Want to contribute? Check out our [CONTRIBUTING.md](./CONTRIBUTING.md) guide!
+
+---
+
 <div align="center">
 
 **⭐ Star this repo if you believe AI agents need governance, not just guardrails.**


### PR DESCRIPTION
## Summary
Adds a Contributors section to README.md with auto-updating avatar grid via contrib.rocks, as described in issue #158.

## Changes
- **README.md** (+8 lines): Add Contributors section after Acknowledgments
  -  badge
  - Links to GitHub contributors page
  - CTA linking to CONTRIBUTING.md

## Acceptance Criteria (from issue #158)
- [x] Contributor avatars visible in README
- [x] Auto-updates when new contributors merge PRs (via contrib.rocks)
- [x] Links to contributor profiles
- [x] CTA to CONTRIBUTING.md

## Notes
- Single commit, no external dependencies
- No behavior change, only documentation

Closes #158