### PR TITLE
Add real-time governance event feed dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ docker-compose*.yml
 
 # Internal source (monorepo backend — not for public SDK repo)
 src/
+!dashboard/governance-feed/src/
+!dashboard/governance-feed/src/**
 
 # Postman collections
 postman/

--- a/dashboard/governance-feed/README.md
+++ b/dashboard/governance-feed/README.md
@@ -1,0 +1,25 @@
+# Governance Event Feed Dashboard
+
+React dashboard for monitoring TealTiger governance events from the WebSocket stream.
+
+## Run locally
+
+Start a local stream that publishes demo governance decisions:
+
+```sh
+npm run dashboard:mock-stream
+```
+
+In another terminal, start the dashboard:
+
+```sh
+npm run dashboard:dev
+```
+
+The dashboard connects to `ws://127.0.0.1:8787/ws/events` by default. Use `VITE_GOVERNANCE_WS_URL` or the URL input in the UI to point it at another stream.
+
+## Build
+
+```sh
+npm run dashboard:build
+```

--- a/dashboard/governance-feed/index.html
+++ b/dashboard/governance-feed/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TealTiger Governance Feed</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dashboard/governance-feed/mock-stream.ts
+++ b/dashboard/governance-feed/mock-stream.ts
@@ -1,0 +1,94 @@
+import { createGovernanceStreamServer } from '../../api/governance-stream';
+import type { TEECReceipt } from '../../api/governance-stream';
+
+const AGENTS = ['finance-agent', 'support-agent', 'admin-agent', 'code-agent', 'research-agent'];
+const TOOLS = ['stripe.charge', 'delete_user', 'export_data', 'github.merge', 'vector.search', 'crm.update'];
+const DECISIONS = ['ALLOW', 'DENY', 'REVISE', 'REQUIRE_APPROVAL'] as const;
+const REASONS = [
+  'Policy: budget_under_limit',
+  'Tool not in allowlist',
+  'Requires human sign-off',
+  'Output must remove customer identifier',
+  'Risk score above delegated threshold',
+  'Policy: scoped token and audit receipt present',
+];
+
+const host = process.env.HOST ?? '127.0.0.1';
+const port = Number(process.env.PORT ?? 8787);
+const eventsPerSecond = Number(process.env.EVENTS_PER_SECOND ?? 125);
+const intervalMs = 100;
+const eventsPerTick = Math.max(1, Math.round(eventsPerSecond / (1000 / intervalMs)));
+
+let sequence = 0;
+
+const server = createGovernanceStreamServer({
+  historyLimit: 20_000,
+  heartbeatIntervalMs: 10_000,
+});
+
+server.start(port, host)
+  .then(({ wsUrl, httpUrl }) => {
+    console.log(`Dashboard mock stream publishing ${eventsPerTick * (1000 / intervalMs)} events/sec`);
+    console.log(`Governance event WebSocket listening at ${wsUrl}/ws/events`);
+    console.log(`SSE fallback listening at ${httpUrl}/sse/events`);
+
+    const publisher = setInterval(() => {
+      for (let index = 0; index < eventsPerTick; index += 1) {
+        server.publish(createReceipt(sequence++));
+      }
+    }, intervalMs);
+
+    const shutdown = async (): Promise<void> => {
+      clearInterval(publisher);
+      await server.stop();
+      process.exit(0);
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+
+function createReceipt(index: number): TEECReceipt {
+  const decision = DECISIONS[index % DECISIONS.length];
+  const agent = AGENTS[index % AGENTS.length];
+  const tool = TOOLS[(index * 5) % TOOLS.length];
+  const latency = 0.8 + ((index * 17) % 70) / 10;
+  const riskScore = Number((((index * 13) % 100) / 100).toFixed(2));
+  const timestamp = new Date().toISOString();
+
+  return {
+    schema_version: '1.0.0',
+    event_id: `demo-${index}`,
+    event_type: 'governance.decision',
+    source: 'tealtiger-dashboard-demo',
+    timestamp,
+    correlation_id: `corr-${Math.floor(index / 8)}`,
+    agent_id: agent,
+    tool,
+    action: tool,
+    decision,
+    reason: REASONS[index % REASONS.length],
+    latency_ms: latency,
+    risk_score: riskScore,
+    policy_version: 'dashboard-preview-v1',
+    teec_receipt: {
+      receipt_id: `teec-${index}`,
+      issued_at: timestamp,
+      subject: agent,
+      action: tool,
+      decision,
+      evidence_hash: `sha256:${(index * 2654435761).toString(16).padStart(16, '0')}`,
+      verifier: 'tealtiger-governance-stream',
+    },
+    metadata: {
+      environment: index % 3 === 0 ? 'production' : 'sandbox',
+      latency_ms: latency,
+      tool,
+      trace_id: `trace-${index}`,
+    },
+  };
+}

--- a/dashboard/governance-feed/src/App.tsx
+++ b/dashboard/governance-feed/src/App.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
-import { List, type ListImperativeAPI } from 'react-window';
+import { FixedSizeList, type ListChildComponentProps } from 'react-window';
 
 import {
   decisionLabel,
@@ -38,7 +38,7 @@ const EMPTY_FILTERS: EventFilters = {
 };
 
 export default function App(): JSX.Element {
-  const listRef = useRef<ListImperativeAPI>(null);
+  const listRef = useRef<FixedSizeList<RowData> | null>(null);
   const pausedRef = useRef(false);
   const incomingBufferRef = useRef<FeedEvent[]>([]);
   const flushFrameRef = useRef<number | null>(null);
@@ -79,7 +79,7 @@ export default function App(): JSX.Element {
     setEvents((current) => trimEvents([...newestFirst, ...current], MAX_EVENTS));
     if (autoFollow) {
       requestAnimationFrame(() => {
-        listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'auto' });
+        listRef.current?.scrollToItem(0, 'start');
       });
     }
   }, [autoFollow]);
@@ -130,13 +130,13 @@ export default function App(): JSX.Element {
     setPaused(false);
     setAutoFollow(true);
     requestAnimationFrame(() => {
-      listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'smooth' });
+      listRef.current?.scrollToItem(0, 'start');
     });
   }, []);
 
   const jumpToLatest = useCallback(() => {
     setAutoFollow(true);
-    listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'smooth' });
+    listRef.current?.scrollToItem(0, 'start');
   }, []);
 
   const reconnect = useCallback((event: React.FormEvent<HTMLFormElement>) => {
@@ -275,16 +275,18 @@ export default function App(): JSX.Element {
 
           <div className="list-frame">
             {filteredEvents.length > 0 ? (
-              <List
-                listRef={listRef}
-                rowComponent={EventRow}
-                rowCount={filteredEvents.length}
-                rowHeight={78}
-                rowProps={rowProps}
+              <FixedSizeList
+                ref={listRef}
+                itemCount={filteredEvents.length}
+                itemSize={78}
+                itemData={rowProps}
                 overscanCount={24}
-                onRowsRendered={({ startIndex }) => setAutoFollow(startIndex <= 2)}
-                style={{ height: '100%', width: '100%' }}
-              />
+                onItemsRendered={({ visibleStartIndex }) => setAutoFollow(visibleStartIndex <= 2)}
+                height="100%"
+                width="100%"
+              >
+                {EventRow}
+              </FixedSizeList>
             ) : (
               <div className="empty-state">No events match the current filters.</div>
             )}
@@ -297,25 +299,18 @@ export default function App(): JSX.Element {
   );
 }
 
-function EventRow({
-  ariaAttributes,
-  index,
-  style,
-  events,
-  selectedId,
-  onSelect,
-}: {
-  ariaAttributes: {
-    'aria-posinset': number;
-    'aria-setsize': number;
-    role: 'listitem';
-  };
-  index: number;
-  style: CSSProperties;
+interface RowData {
   events: FeedEvent[];
   selectedId: string | null;
   onSelect: (id: string) => void;
-}): JSX.Element | null {
+}
+
+function EventRow({
+  index,
+  style,
+  data,
+}: ListChildComponentProps<RowData>): JSX.Element | null {
+  const { events, selectedId, onSelect } = data;
   const event = events[index];
   if (!event) {
     return null;
@@ -324,7 +319,7 @@ function EventRow({
   const isSelected = event.id === selectedId;
 
   return (
-    <div className="event-row-shell" style={style} {...ariaAttributes}>
+    <div className="event-row-shell" style={style as CSSProperties}>
       <button
         className={`event-row decision-${event.decision.toLowerCase().replace('_', '-')}${isSelected ? ' selected' : ''}`}
         type="button"

--- a/dashboard/governance-feed/src/App.tsx
+++ b/dashboard/governance-feed/src/App.tsx
@@ -1,0 +1,420 @@
+import {
+  Activity,
+  ArrowDownToLine,
+  Braces,
+  Clock3,
+  Filter,
+  Pause,
+  Play,
+  Search,
+  Wifi,
+  WifiOff,
+  X,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { List, type ListImperativeAPI } from 'react-window';
+
+import {
+  decisionLabel,
+  eventMatchesFilters,
+  formatLatency,
+  formatTime,
+  uniqueValues,
+} from './event-utils';
+import { useGovernanceSocket } from './useGovernanceSocket';
+import type { EventFilters, FeedEvent, StreamState } from './types';
+
+const DEFAULT_WS_URL = import.meta.env.VITE_GOVERNANCE_WS_URL ?? 'ws://127.0.0.1:8787/ws/events';
+const MAX_EVENTS = 7_500;
+const MAX_PENDING_EVENTS = 5_000;
+
+const EMPTY_FILTERS: EventFilters = {
+  agent: '',
+  decision: '',
+  tool: '',
+  from: '',
+  to: '',
+  search: '',
+};
+
+export default function App(): JSX.Element {
+  const listRef = useRef<ListImperativeAPI>(null);
+  const pausedRef = useRef(false);
+  const incomingBufferRef = useRef<FeedEvent[]>([]);
+  const flushFrameRef = useRef<number | null>(null);
+  const arrivalTimesRef = useRef<number[]>([]);
+
+  const [events, setEvents] = useState<FeedEvent[]>([]);
+  const [pendingEvents, setPendingEvents] = useState<FeedEvent[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [autoFollow, setAutoFollow] = useState(true);
+  const [eventsPerSecond, setEventsPerSecond] = useState(0);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [filters, setFilters] = useState<EventFilters>(EMPTY_FILTERS);
+  const [draftUrl, setDraftUrl] = useState(DEFAULT_WS_URL);
+  const [activeUrl, setActiveUrl] = useState(DEFAULT_WS_URL);
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  const flushIncoming = useCallback(() => {
+    flushFrameRef.current = null;
+    const batch = incomingBufferRef.current.splice(0);
+    if (batch.length === 0) {
+      return;
+    }
+
+    const now = performance.now();
+    arrivalTimesRef.current.push(...batch.map(() => now));
+    arrivalTimesRef.current = arrivalTimesRef.current.filter((time) => now - time <= 1000);
+    setEventsPerSecond(arrivalTimesRef.current.length);
+
+    const newestFirst = [...batch].reverse();
+    if (pausedRef.current) {
+      setPendingEvents((current) => trimEvents([...newestFirst, ...current], MAX_PENDING_EVENTS));
+      return;
+    }
+
+    setEvents((current) => trimEvents([...newestFirst, ...current], MAX_EVENTS));
+    if (autoFollow) {
+      requestAnimationFrame(() => {
+        listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'auto' });
+      });
+    }
+  }, [autoFollow]);
+
+  const receiveEvent = useCallback((event: FeedEvent) => {
+    incomingBufferRef.current.push(event);
+    if (flushFrameRef.current === null) {
+      flushFrameRef.current = requestAnimationFrame(flushIncoming);
+    }
+  }, [flushIncoming]);
+
+  const streamState = useGovernanceSocket(activeUrl, receiveEvent);
+
+  useEffect(() => {
+    if (!selectedId && events[0]) {
+      setSelectedId(events[0].id);
+    }
+  }, [events, selectedId]);
+
+  const filteredEvents = useMemo(
+    () => events.filter((event) => eventMatchesFilters(event, filters)),
+    [events, filters],
+  );
+
+  const agentOptions = useMemo(() => uniqueValues(events, 'agent'), [events]);
+  const toolOptions = useMemo(() => uniqueValues(events, 'tool'), [events]);
+  const selectedEvent = useMemo(
+    () => events.find((event) => event.id === selectedId) ?? filteredEvents[0] ?? null,
+    [events, filteredEvents, selectedId],
+  );
+  const activeSelectedId = selectedEvent?.id ?? null;
+
+  const updateFilter = useCallback(<Key extends keyof EventFilters>(key: Key, value: EventFilters[Key]) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  }, []);
+
+  const pauseFeed = useCallback(() => {
+    setPaused(true);
+  }, []);
+
+  const resumeFeed = useCallback(() => {
+    setPendingEvents((pending) => {
+      if (pending.length > 0) {
+        setEvents((current) => trimEvents([...pending, ...current], MAX_EVENTS));
+      }
+      return [];
+    });
+    setPaused(false);
+    setAutoFollow(true);
+    requestAnimationFrame(() => {
+      listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'smooth' });
+    });
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    setAutoFollow(true);
+    listRef.current?.scrollToRow({ index: 0, align: 'start', behavior: 'smooth' });
+  }, []);
+
+  const reconnect = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextUrl = draftUrl.trim();
+    if (nextUrl) {
+      setActiveUrl(nextUrl);
+    }
+  }, [draftUrl]);
+
+  const rowProps = useMemo(() => ({
+    events: filteredEvents,
+    selectedId: activeSelectedId,
+    onSelect: setSelectedId,
+  }), [activeSelectedId, filteredEvents]);
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <div className="brand-block">
+          <div className="brand-mark">TT</div>
+          <div>
+            <h1>Governance Events</h1>
+            <StatusLine state={streamState} url={activeUrl} />
+          </div>
+        </div>
+
+        <div className="top-actions">
+          <Metric icon={<Activity size={16} />} label="Events/sec" value={String(eventsPerSecond)} />
+          <Metric icon={<Clock3 size={16} />} label="Buffered" value={String(events.length)} />
+          {paused ? (
+            <button className="primary-button" type="button" onClick={resumeFeed}>
+              <Play size={16} />
+              Resume
+              {pendingEvents.length > 0 && <span className="unread-badge">{pendingEvents.length}</span>}
+            </button>
+          ) : (
+            <button className="secondary-button" type="button" onClick={pauseFeed}>
+              <Pause size={16} />
+              Pause
+            </button>
+          )}
+          <button className="secondary-button" type="button" onClick={jumpToLatest}>
+            <ArrowDownToLine size={16} />
+            Jump to latest
+          </button>
+        </div>
+      </header>
+
+      <section className="connection-strip">
+        <form className="connection-form" onSubmit={reconnect}>
+          <label htmlFor="ws-url">WebSocket URL</label>
+          <input
+            id="ws-url"
+            type="text"
+            value={draftUrl}
+            onChange={(event) => setDraftUrl(event.target.value)}
+          />
+          <button className="secondary-button" type="submit">Connect</button>
+        </form>
+      </section>
+
+      <main className="workspace">
+        <section className="feed-panel" aria-label="Governance event feed">
+          <div className="filter-bar">
+            <div className="filter-title">
+              <Filter size={16} />
+              Filters
+            </div>
+            <label>
+              Agent
+              <select value={filters.agent} onChange={(event) => updateFilter('agent', event.target.value)}>
+                <option value="">All agents</option>
+                {agentOptions.map((agent) => (
+                  <option key={agent} value={agent}>{agent}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Decision
+              <select value={filters.decision} onChange={(event) => updateFilter('decision', event.target.value)}>
+                <option value="">All decisions</option>
+                <option value="ALLOW">ALLOW</option>
+                <option value="DENY">DENY</option>
+                <option value="REVISE">REVISE</option>
+                <option value="REQUIRE_APPROVAL">REQUIRE APPROVAL</option>
+              </select>
+            </label>
+            <label>
+              Tool
+              <select value={filters.tool} onChange={(event) => updateFilter('tool', event.target.value)}>
+                <option value="">All tools</option>
+                {toolOptions.map((tool) => (
+                  <option key={tool} value={tool}>{tool}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              From
+              <input
+                type="datetime-local"
+                value={filters.from}
+                onChange={(event) => updateFilter('from', event.target.value)}
+              />
+            </label>
+            <label>
+              To
+              <input
+                type="datetime-local"
+                value={filters.to}
+                onChange={(event) => updateFilter('to', event.target.value)}
+              />
+            </label>
+            <label className="search-field">
+              Reason search
+              <span>
+                <Search size={15} />
+                <input
+                  type="search"
+                  placeholder="budget, allowlist, sign-off"
+                  value={filters.search}
+                  onChange={(event) => updateFilter('search', event.target.value)}
+                />
+              </span>
+            </label>
+            <button className="icon-button" type="button" aria-label="Clear filters" onClick={() => setFilters(EMPTY_FILTERS)}>
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="feed-summary">
+            <span>{filteredEvents.length.toLocaleString()} visible events</span>
+            <span>{events.length.toLocaleString()} retained</span>
+            {paused && <span className="paused-chip">Paused: {pendingEvents.length.toLocaleString()} unread</span>}
+          </div>
+
+          <div className="list-frame">
+            {filteredEvents.length > 0 ? (
+              <List
+                listRef={listRef}
+                rowComponent={EventRow}
+                rowCount={filteredEvents.length}
+                rowHeight={78}
+                rowProps={rowProps}
+                overscanCount={24}
+                onRowsRendered={({ startIndex }) => setAutoFollow(startIndex <= 2)}
+                style={{ height: '100%', width: '100%' }}
+              />
+            ) : (
+              <div className="empty-state">No events match the current filters.</div>
+            )}
+          </div>
+        </section>
+
+        <ReceiptPanel event={selectedEvent} />
+      </main>
+    </div>
+  );
+}
+
+function EventRow({
+  ariaAttributes,
+  index,
+  style,
+  events,
+  selectedId,
+  onSelect,
+}: {
+  ariaAttributes: {
+    'aria-posinset': number;
+    'aria-setsize': number;
+    role: 'listitem';
+  };
+  index: number;
+  style: CSSProperties;
+  events: FeedEvent[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}): JSX.Element | null {
+  const event = events[index];
+  if (!event) {
+    return null;
+  }
+
+  const isSelected = event.id === selectedId;
+
+  return (
+    <div className="event-row-shell" style={style} {...ariaAttributes}>
+      <button
+        className={`event-row decision-${event.decision.toLowerCase().replace('_', '-')}${isSelected ? ' selected' : ''}`}
+        type="button"
+        aria-expanded={isSelected}
+        onClick={() => onSelect(event.id)}
+      >
+        <span className="event-time">{formatTime(event.timestamp)}</span>
+        <span className="event-main">
+          <span className="event-route">
+            <strong>{event.agent}</strong>
+            <span>{event.tool}</span>
+          </span>
+          <span className="event-reason">{event.reason}</span>
+        </span>
+        <span className="decision-pill">{decisionLabel(event.decision)}</span>
+        <span className="latency-pill">{formatLatency(event.latencyMs)}</span>
+      </button>
+    </div>
+  );
+}
+
+function ReceiptPanel({ event }: { event: FeedEvent | null }): JSX.Element {
+  return (
+    <aside className="receipt-panel" aria-label="TEEC receipt JSON">
+      <div className="receipt-header">
+        <div>
+          <span><Braces size={16} /> TEEC receipt JSON</span>
+          <h2>{event ? event.id : 'No event selected'}</h2>
+        </div>
+        {event && <span className={`decision-pill decision-${event.decision.toLowerCase().replace('_', '-')}`}>{decisionLabel(event.decision)}</span>}
+      </div>
+
+      {event ? (
+        <>
+          <dl className="receipt-facts">
+            <div>
+              <dt>Timestamp</dt>
+              <dd>{new Date(event.timestamp).toLocaleString()}</dd>
+            </div>
+            <div>
+              <dt>Agent</dt>
+              <dd>{event.agent}</dd>
+            </div>
+            <div>
+              <dt>Tool</dt>
+              <dd>{event.tool}</dd>
+            </div>
+            <div>
+              <dt>Latency</dt>
+              <dd>{formatLatency(event.latencyMs)}</dd>
+            </div>
+          </dl>
+          <pre className="receipt-json">{JSON.stringify(event.receipt, null, 2)}</pre>
+        </>
+      ) : (
+        <div className="empty-state">Select an event to inspect the full receipt.</div>
+      )}
+    </aside>
+  );
+}
+
+function StatusLine({ state, url }: { state: StreamState; url: string }): JSX.Element {
+  const connected = state.status === 'connected';
+  const Icon = connected ? Wifi : WifiOff;
+  const label = state.status === 'connected'
+    ? 'Live'
+    : state.status === 'reconnecting'
+      ? `Reconnecting ${state.reconnectAttempt}`
+      : state.status;
+
+  return (
+    <p className="status-line">
+      <span className={`status-dot ${state.status}`} />
+      <Icon size={14} />
+      <span>{label}</span>
+      <code>{url}</code>
+    </p>
+  );
+}
+
+function Metric({ icon, label, value }: { icon: JSX.Element; label: string; value: string }): JSX.Element {
+  return (
+    <div className="metric">
+      {icon}
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function trimEvents(events: FeedEvent[], limit: number): FeedEvent[] {
+  return events.length > limit ? events.slice(0, limit) : events;
+}

--- a/dashboard/governance-feed/src/event-utils.ts
+++ b/dashboard/governance-feed/src/event-utils.ts
@@ -1,0 +1,137 @@
+import type { Decision, EventFilters, FeedEvent, StreamMessage } from './types';
+
+const DECISIONS: Decision[] = ['ALLOW', 'DENY', 'REVISE', 'REQUIRE_APPROVAL'];
+
+export function normalizeEvent(message: StreamMessage): FeedEvent | null {
+  if (message.type !== 'governance_event') {
+    return null;
+  }
+
+  const receipt = objectRecord(message.data);
+  const metadata = objectRecord(receipt.metadata);
+  const decision = normalizeDecision(
+    readString(receipt.decision)
+      ?? readString(receipt.action)
+      ?? readString(receipt.decision_action)
+      ?? readString(metadata.decision),
+  );
+
+  return {
+    id: message.id ?? readString(receipt.event_id) ?? `evt_${message.cursor ?? Date.now()}`,
+    cursor: message.cursor ?? '',
+    timestamp: normalizeTimestamp(message.timestamp ?? receipt.timestamp),
+    agent: readString(receipt.agent_id)
+      ?? readString(receipt.agentId)
+      ?? readString(metadata.agent_id)
+      ?? 'unknown-agent',
+    tool: readString(receipt.tool)
+      ?? readString(receipt.tool_name)
+      ?? readString(receipt.action)
+      ?? readString(metadata.tool)
+      ?? 'unknown.tool',
+    decision,
+    reason: readString(receipt.reason)
+      ?? readString(receipt.message)
+      ?? readString(metadata.reason)
+      ?? 'No decision reason provided',
+    latencyMs: normalizeLatency(
+      receipt.latency_ms
+        ?? receipt.latencyMs
+        ?? metadata.latency_ms
+        ?? metadata.latencyMs,
+    ),
+    receipt,
+  };
+}
+
+export function eventMatchesFilters(event: FeedEvent, filters: EventFilters): boolean {
+  if (filters.agent && event.agent !== filters.agent) {
+    return false;
+  }
+
+  if (filters.decision && event.decision !== filters.decision) {
+    return false;
+  }
+
+  if (filters.tool && event.tool !== filters.tool) {
+    return false;
+  }
+
+  if (filters.from && Date.parse(event.timestamp) < Date.parse(filters.from)) {
+    return false;
+  }
+
+  if (filters.to && Date.parse(event.timestamp) > Date.parse(filters.to)) {
+    return false;
+  }
+
+  const query = filters.search.trim().toLowerCase();
+  if (query && !event.reason.toLowerCase().includes(query)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function uniqueValues(events: FeedEvent[], key: 'agent' | 'tool'): string[] {
+  return [...new Set(events.map((event) => event[key]))].sort((a, b) => a.localeCompare(b));
+}
+
+export function formatTime(timestamp: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(timestamp));
+}
+
+export function formatLatency(latencyMs: number): string {
+  return `${latencyMs.toFixed(latencyMs >= 10 ? 0 : 1)}ms`;
+}
+
+export function decisionLabel(decision: Decision): string {
+  return decision === 'REQUIRE_APPROVAL' ? 'REQUIRE APPROVAL' : decision;
+}
+
+function normalizeDecision(value: string | undefined): Decision {
+  const normalized = value?.toUpperCase().replace(/[\s-]+/g, '_');
+  return DECISIONS.includes(normalized as Decision) ? normalized as Decision : 'REVISE';
+}
+
+function normalizeTimestamp(value: unknown): string {
+  if (typeof value === 'number') {
+    return new Date(value).toISOString();
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+
+  return new Date().toISOString();
+}
+
+function normalizeLatency(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/dashboard/governance-feed/src/main.tsx
+++ b/dashboard/governance-feed/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/dashboard/governance-feed/src/styles.css
+++ b/dashboard/governance-feed/src/styles.css
@@ -1,0 +1,602 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f4f6f2;
+  color: #17201c;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --surface: #ffffff;
+  --surface-muted: #f8faf6;
+  --border: #d9dfd7;
+  --text-muted: #66716a;
+  --text-soft: #89938a;
+  --green: #18794e;
+  --green-bg: #e8f6ef;
+  --red: #bf2f35;
+  --red-bg: #fdebec;
+  --yellow: #9b6b00;
+  --yellow-bg: #fff4cf;
+  --blue: #1f68b3;
+  --blue-bg: #e9f2ff;
+  --shadow: 0 14px 45px rgba(31, 42, 34, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(244, 246, 242, 0.96)),
+    #f4f6f2;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.brand-block,
+.top-actions,
+.status-line,
+.metric,
+.filter-title,
+.receipt-header span,
+.search-field span {
+  display: flex;
+  align-items: center;
+}
+
+.brand-block {
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: #17201c;
+  color: #f7fff8;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.status-line {
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.status-line code {
+  color: #3b453f;
+  background: #eef2ed;
+  border: 1px solid #dce3da;
+  border-radius: 6px;
+  padding: 2px 6px;
+  word-break: break-all;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-soft);
+}
+
+.status-dot.connected {
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(24, 121, 78, 0.12);
+}
+
+.status-dot.reconnecting,
+.status-dot.connecting {
+  background: var(--yellow);
+  box-shadow: 0 0 0 4px rgba(155, 107, 0, 0.14);
+}
+
+.top-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.metric,
+.primary-button,
+.secondary-button,
+.icon-button {
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.metric {
+  gap: 7px;
+  padding: 0 10px;
+  color: var(--text-muted);
+  background: var(--surface-muted);
+  font-size: 12px;
+}
+
+.metric strong {
+  color: #17201c;
+  font-size: 13px;
+}
+
+.primary-button,
+.secondary-button,
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 12px;
+  color: #17201c;
+  background: #ffffff;
+}
+
+.primary-button {
+  color: #ffffff;
+  border-color: #17201c;
+  background: #17201c;
+}
+
+.unread-badge {
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  color: #17201c;
+  background: #fff3bc;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.connection-strip {
+  padding: 10px 20px 0;
+}
+
+.connection-form {
+  display: grid;
+  grid-template-columns: auto minmax(260px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  max-width: 860px;
+}
+
+.connection-form label,
+.filter-bar label {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.connection-form input,
+.filter-bar input,
+.filter-bar select {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 10px;
+  color: #17201c;
+  background: #ffffff;
+  outline: none;
+}
+
+.workspace {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 430px);
+  gap: 16px;
+  padding: 16px 20px 20px;
+}
+
+.feed-panel,
+.receipt-panel {
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.feed-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+  background: #fbfcfa;
+}
+
+.filter-title {
+  align-self: center;
+  gap: 6px;
+  min-height: 34px;
+  color: #28342d;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.filter-bar label {
+  flex: 1 1 142px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.search-field span {
+  gap: 7px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #ffffff;
+}
+
+.search-field input {
+  border: 0;
+  padding: 0;
+  height: 30px;
+}
+
+.search-field {
+  flex: 2 1 260px;
+}
+
+.icon-button {
+  width: 34px;
+  padding: 0;
+  flex: 0 0 34px;
+}
+
+.feed-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 9px 14px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.paused-chip {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+  border: 1px solid #f0d985;
+  border-radius: 999px;
+  padding: 3px 8px;
+}
+
+.list-frame {
+  flex: 1;
+  min-height: 390px;
+}
+
+.event-row-shell {
+  padding: 4px 10px;
+}
+
+.event-row {
+  width: 100%;
+  height: 70px;
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr) 154px 72px;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid transparent;
+  border-left-width: 4px;
+  border-radius: 8px;
+  padding: 0 12px 0 10px;
+  background: #ffffff;
+  color: #17201c;
+  text-align: left;
+}
+
+.event-row:hover,
+.event-row.selected {
+  border-color: #cbd5cc;
+  background: #f9fbf8;
+}
+
+.event-row.selected {
+  box-shadow: inset 0 0 0 1px #9cb6a3;
+}
+
+.event-time {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.event-main {
+  min-width: 0;
+}
+
+.event-route {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: #26312b;
+  font-size: 13px;
+}
+
+.event-route strong,
+.event-route span,
+.event-reason {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-route span {
+  color: var(--text-muted);
+}
+
+.event-reason {
+  display: block;
+  margin-top: 5px;
+  color: #4d5a52;
+  font-size: 12px;
+}
+
+.decision-pill,
+.latency-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 26px;
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.latency-pill {
+  color: #4c584f;
+  background: #eef2ed;
+}
+
+.decision-allow {
+  border-left-color: var(--green);
+}
+
+.decision-deny {
+  border-left-color: var(--red);
+}
+
+.decision-revise {
+  border-left-color: var(--blue);
+}
+
+.decision-require-approval {
+  border-left-color: var(--yellow);
+}
+
+.decision-allow .decision-pill,
+.decision-pill.decision-allow {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.decision-deny .decision-pill,
+.decision-pill.decision-deny {
+  color: var(--red);
+  background: var(--red-bg);
+}
+
+.decision-revise .decision-pill,
+.decision-pill.decision-revise {
+  color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.decision-require-approval .decision-pill,
+.decision-pill.decision-require-approval {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.receipt-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.receipt-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+  background: #fbfcfa;
+}
+
+.receipt-header span {
+  gap: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.receipt-header h2 {
+  margin-top: 5px;
+  max-width: 260px;
+  overflow-wrap: anywhere;
+  color: #17201c;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.receipt-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin: 0;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.receipt-facts div {
+  min-width: 0;
+}
+
+.receipt-facts dt {
+  color: var(--text-soft);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.receipt-facts dd {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: #2e3831;
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.receipt-json {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  color: #d7efe3;
+  background: #17201c;
+  font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  min-height: 240px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+@media (max-width: 1180px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .receipt-panel {
+    min-height: 540px;
+  }
+
+  .filter-title {
+    width: 100%;
+  }
+}
+
+@media (max-width: 780px) {
+  .topbar,
+  .connection-form {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    flex-direction: column;
+  }
+
+  .brand-block,
+  .top-actions {
+    width: 100%;
+  }
+
+  .top-actions {
+    justify-content: flex-start;
+  }
+
+  .workspace {
+    padding: 12px;
+  }
+
+  .connection-strip {
+    padding: 10px 12px 0;
+  }
+
+  .filter-bar label,
+  .search-field {
+    flex-basis: 100%;
+  }
+
+  .event-row {
+    grid-template-columns: 70px minmax(0, 1fr);
+    height: 104px;
+    align-content: center;
+  }
+
+  .decision-pill,
+  .latency-pill {
+    justify-self: start;
+  }
+
+  .receipt-facts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/dashboard/governance-feed/src/types.ts
+++ b/dashboard/governance-feed/src/types.ts
@@ -1,0 +1,36 @@
+export type Decision = 'ALLOW' | 'DENY' | 'REVISE' | 'REQUIRE_APPROVAL';
+
+export interface StreamMessage {
+  type: 'connection_ack' | 'governance_event' | 'heartbeat' | 'replay_complete' | 'subscription_updated';
+  id?: string;
+  cursor?: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+export interface FeedEvent {
+  id: string;
+  cursor: string;
+  timestamp: string;
+  agent: string;
+  tool: string;
+  decision: Decision;
+  reason: string;
+  latencyMs: number;
+  receipt: Record<string, unknown>;
+}
+
+export interface EventFilters {
+  agent: string;
+  decision: string;
+  tool: string;
+  from: string;
+  to: string;
+  search: string;
+}
+
+export interface StreamState {
+  status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+  lastMessageAt: number | null;
+  reconnectAttempt: number;
+}

--- a/dashboard/governance-feed/src/useGovernanceSocket.ts
+++ b/dashboard/governance-feed/src/useGovernanceSocket.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { normalizeEvent } from './event-utils';
+import type { FeedEvent, StreamMessage, StreamState } from './types';
+
+const INITIAL_STATE: StreamState = {
+  status: 'connecting',
+  lastMessageAt: null,
+  reconnectAttempt: 0,
+};
+
+export function useGovernanceSocket(
+  url: string,
+  onEvent: (event: FeedEvent) => void,
+): StreamState {
+  const onEventRef = useRef(onEvent);
+  const cursorRef = useRef('');
+  const [state, setState] = useState<StreamState>(INITIAL_STATE);
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    let closed = false;
+    let socket: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+
+    const connect = (): void => {
+      if (closed) {
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        status: attempt === 0 ? 'connecting' : 'reconnecting',
+        reconnectAttempt: attempt,
+      }));
+
+      const reconnectUrl = withCursor(url, cursorRef.current);
+      socket = new WebSocket(reconnectUrl);
+
+      socket.addEventListener('open', () => {
+        attempt = 0;
+        setState({
+          status: 'connected',
+          lastMessageAt: Date.now(),
+          reconnectAttempt: 0,
+        });
+      });
+
+      socket.addEventListener('message', (event) => {
+        const message = parseMessage(event.data);
+        if (!message) {
+          return;
+        }
+
+        setState((current) => ({
+          ...current,
+          lastMessageAt: Date.now(),
+        }));
+
+        const feedEvent = normalizeEvent(message);
+        if (!feedEvent) {
+          return;
+        }
+
+        if (feedEvent.cursor) {
+          cursorRef.current = feedEvent.cursor;
+        }
+        onEventRef.current(feedEvent);
+      });
+
+      socket.addEventListener('close', () => {
+        if (closed) {
+          return;
+        }
+        attempt += 1;
+        setState((current) => ({
+          ...current,
+          status: 'reconnecting',
+          reconnectAttempt: attempt,
+        }));
+        reconnectTimer = setTimeout(connect, Math.min(5000, 400 * attempt));
+      });
+
+      socket.addEventListener('error', () => {
+        socket?.close();
+      });
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      socket?.close();
+      setState((current) => ({
+        ...current,
+        status: 'disconnected',
+      }));
+    };
+  }, [url]);
+
+  return state;
+}
+
+function withCursor(rawUrl: string, cursor: string): string {
+  if (!cursor) {
+    return rawUrl;
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    url.searchParams.set('cursor', cursor);
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+function parseMessage(value: unknown): StreamMessage | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as StreamMessage;
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/governance-feed/tsconfig.json
+++ b/dashboard/governance-feed/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/dashboard/governance-feed/vite.config.ts
+++ b/dashboard/governance-feed/vite.config.ts
@@ -1,0 +1,18 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [react()],
+  server: {
+    port: 5175,
+    strictPort: false,
+  },
+  preview: {
+    port: 4175,
+  },
+  build: {
+    outDir: '../../dist/governance-feed',
+    emptyOutDir: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
     "@libsql/client": "^0.17.3",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
-    "lucide-react": "^1.17.0",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
-    "react-window": "^2.2.7",
     "ws": "^8.18.3",
     "zod": "^4.4.3"
   },
@@ -37,6 +33,10 @@
     "@vitejs/plugin-react": "^6.0.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "lucide-react": "^1.17.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "react-window": "^1.8.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vite": "^8.0.14"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "api:start": "ts-node api/governance-events/index.ts",
     "stream:start": "ts-node api/governance-stream/index.ts",
+    "dashboard:dev": "vite --host 127.0.0.1 --config dashboard/governance-feed/vite.config.ts",
+    "dashboard:build": "vite build --config dashboard/governance-feed/vite.config.ts",
+    "dashboard:mock-stream": "node -r ts-node/register dashboard/governance-feed/mock-stream.ts",
     "build": "tsc --noEmit",
     "test:api": "node --test -r ts-node/register tests/api/governance-api.test.ts",
     "test:stream": "node --test -r ts-node/register tests/api/governance-stream.test.ts",
@@ -19,15 +22,23 @@
     "@libsql/client": "^0.17.3",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
+    "lucide-react": "^1.17.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "react-window": "^2.2.7",
     "ws": "^8.18.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",
+    "@vitejs/plugin-react": "^6.0.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vite": "^8.0.14"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,10 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["scripts/**/*.ts", "api/**/*.ts", "tests/**/*.ts"]
+  "include": [
+    "scripts/**/*.ts",
+    "api/**/*.ts",
+    "tests/**/*.ts",
+    "dashboard/governance-feed/mock-stream.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #175.

This adds a dedicated React/Vite governance event feed dashboard for operators to monitor TealTiger decisions as they happen. The dashboard connects to the existing governance WebSocket stream, renders incoming events in a virtualized list, and exposes the filters and receipt inspection workflow described in the issue.

## Details

- Added `dashboard/governance-feed` as a standalone Vite app with scripts for local development and production build.
- Implemented a WebSocket client with cursor-aware reconnect behavior so the UI can resume from the latest known event after disconnects.
- Normalized governance stream messages into dashboard rows that show timestamp, agent, tool, decision, reason, latency, and the full TEEC receipt payload.
- Added filtering by agent, decision, tool, time range, and full-text reason search.
- Added pause/resume behavior with unread event buffering and a badge while the live feed is paused.
- Added a virtualized event list using `react-window` so high-throughput streams can be displayed without rendering every retained event.
- Added a side receipt panel that shows the selected event metadata and full JSON receipt.
- Added a local mock stream publisher that uses the project WebSocket server and publishes more than 100 events per second for dashboard preview and stress testing.
- Added a scoped `.gitignore` exception so the dashboard app source is tracked while preserving the existing root `src/` ignore behavior.

## Validation

- `npm run dashboard:build`
- `npm run build`
- `npm run test:stream`
- Verified the dashboard locally against the mock WebSocket stream.
