### PR TITLE
feat: add OpenSSF Scorecard GitHub Action and security badges

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Open source. TypeScript + Python. Works with any provider.
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/X2ePf8QAj)
 [![GitHub stars](https://img.shields.io/github/stars/agentguard-ai/tealtiger?style=social)](https://github.com/agentguard-ai/tealtiger)
 [![Governed by TealTiger](./assets/badges/governed-by-tealtiger.svg)](https://github.com/agentguard-ai/tealtiger)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/agentguard-ai/tealtiger/badge)](https://securityscorecards.dev/viewer/?uri=github.com/agentguard-ai/tealtiger)
 
 <br>
 
@@ -347,6 +348,19 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines.
 - **Blog**: [blogs.tealtiger.ai](https://blogs.tealtiger.ai)
 - **Playground**: [playground.tealtiger.ai](https://playground.tealtiger.ai)
 - **Email**: reachout@tealtiger.ai
+
+---
+
+## 🔒 Security
+
+TealTiger is committed to responsible open-source security practices.
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/agentguard-ai/tealtiger/badge)](https://securityscorecards.dev/viewer/?uri=github.com/agentguard-ai/tealtiger)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10824/badge)](https://www.bestpractices.dev/projects/10824)
+[![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/agentguard-ai/tealtiger/security/dependabot)
+[![CodeQL](https://github.com/agentguard-ai/tealtiger/actions/workflows/codeql.yml/badge.svg)](https://github.com/agentguard-ai/tealtiger/actions/workflows/codeql.yml)
+
+For vulnerability reports, see our [Security Policy](./SECURITY.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #202

- Adds `.github/workflows/scorecard.yml` — runs the [ossf/scorecard-action](https://github.com/ossf/scorecard-action) weekly (Mondays 01:30 UTC) and on every push/PR to `main`. Results are uploaded as SARIF to GitHub code scanning.
- Adds the OpenSSF Scorecard badge to the top README badge row for immediate visibility.
- Adds a new **🔒 Security** section to README with four badges: OpenSSF Scorecard, OpenSSF Best Practices, Dependabot, and CodeQL, plus a link to `SECURITY.md`.

## Test plan

- [ ] Confirm workflow file YAML is valid (can run `gh workflow list` after merge)
- [ ] Verify Scorecard badge renders correctly in README preview
- [ ] Confirm no existing workflows are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)