### PR TITLE
fix: handle WAL corruption, invalid replay cursors, and dateValue NaN

### DIFF
--- a/api/governance-events/repository.ts
+++ b/api/governance-events/repository.ts
@@ -481,5 +481,6 @@ function dateValue(value: unknown): string | null {
   if (value === null || value === undefined) {
     return null;
   }
-  return new Date(numberValue(value)).toISOString();
+  const ts = numberValue(value);
+  return Number.isNaN(ts) ? null : new Date(ts).toISOString();
 }

--- a/api/governance-ingestion/wal.ts
+++ b/api/governance-ingestion/wal.ts
@@ -59,8 +59,12 @@ export class FileWriteAheadLog implements WriteAheadLog {
         if (!line.trim()) {
           continue;
         }
-        const event = JSON.parse(line) as NormalizedGovernanceEvent;
-        this.records.set(event.correlationId, event);
+        try {
+          const event = JSON.parse(line) as NormalizedGovernanceEvent;
+          this.records.set(event.correlationId, event);
+        } catch {
+          // Skip corrupted lines rather than aborting the entire recovery
+        }
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {

--- a/api/governance-stream/event-stream.ts
+++ b/api/governance-stream/event-stream.ts
@@ -68,6 +68,9 @@ export class GovernanceEventStream {
       return [];
     }
     const sequence = parseCursor(cursor);
+    if (sequence === null) {
+      return [];
+    }
     return this.history.filter((event) => event.sequence > sequence && matchesFilter(event, filter));
   }
 
@@ -89,12 +92,15 @@ export class GovernanceEventStream {
   }
 }
 
-function parseCursor(cursor: string | undefined): number {
+function parseCursor(cursor: string | undefined): number | null {
   if (!cursor) {
-    return 0;
+    return null;
   }
   const parsed = Number(cursor);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return Math.floor(parsed);
 }
 
 function normalizeTimestamp(value: string | number | Date): string {


### PR DESCRIPTION
## Summary

Three independent defects found in the governance API layer.

---

### Fix 1 — WAL recovery aborts on a single corrupted line ([wal.ts](https://github.com/agentguard-ai/tealtiger/blob/main/api/governance-ingestion/wal.ts))

`FileWriteAheadLog.load()` iterated over lines and called `JSON.parse()` without a per-line try-catch. One corrupt line threw a `SyntaxError` that bypassed the outer `ENOENT` guard and re-threw, silently dropping all other valid events.

**Fix:** wrap each `JSON.parse` call in its own try-catch; skip bad lines, recover the rest.

---

### Fix 2 — Malformed reconnect cursor replays entire event history ([event-stream.ts](https://github.com/agentguard-ai/tealtiger/blob/main/api/governance-stream/event-stream.ts))

`parseCursor()` returned `0` for both the valid cursor `"0"` (replay from start) *and* for invalid strings like `"abc"` or `"-1"`. This caused `replayAfter()` to flood a reconnecting client with the full history when an invalid cursor was supplied.

**Fix:** `parseCursor()` now returns `number | null` — `null` for any non-finite or negative input. `replayAfter()` returns `[]` when `null` is returned. A cursor of `"0"` continues to replay all events as intended.

---

### Fix 3 — `dateValue()` throws `RangeError` on non-numeric DB values ([repository.ts](https://github.com/agentguard-ai/tealtiger/blob/main/api/governance-events/repository.ts))

`numberValue()` converts unknown values with `Number()`, which returns `NaN` for non-numeric strings. `new Date(NaN).toISOString()` throws `RangeError: Invalid time value`, crashing any response that contained such a row.

**Fix:** check for `NaN` before calling `toISOString()` and return `null` instead.

---

## Test plan

- [x] All three changes are isolated to their respective files
- [x] No new dependencies introduced
- [x] Existing test suite structure unaffected