### PR TITLE
fix: bind stream server to 0.0.0.0 and add SIGTERM/SIGINT handlers

### DIFF
--- a/api/governance-events/index.ts
+++ b/api/governance-events/index.ts
@@ -11,6 +11,12 @@ async function main(): Promise<void> {
   });
 
   await app.listen({ port, host });
+
+  const shutdown = (): void => {
+    app.close().then(() => process.exit(0)).catch(() => process.exit(1));
+  };
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
 }
 
 main().catch((error) => {

--- a/api/governance-stream/index.ts
+++ b/api/governance-stream/index.ts
@@ -15,13 +15,19 @@ export type {
 
 if (require.main === module) {
   const port = Number(process.env.PORT ?? 8787);
-  const host = process.env.HOST ?? '127.0.0.1';
+  const host = process.env.HOST ?? '0.0.0.0';
   const server = createGovernanceStreamServer();
 
   server.start(port, host)
     .then(({ wsUrl, httpUrl }) => {
       console.log(`Governance event WebSocket listening at ${wsUrl}/ws/events`);
       console.log(`SSE fallback listening at ${httpUrl}/sse/events`);
+
+      const shutdown = (): void => {
+        server.stop().then(() => process.exit(0)).catch(() => process.exit(1));
+      };
+      process.once('SIGTERM', shutdown);
+      process.once('SIGINT', shutdown);
     })
     .catch((error) => {
       console.error(error);


### PR DESCRIPTION
## Summary

Two Linux/container deployment defects in the server entry points.

---

### Fix 1 — Stream server binds to `127.0.0.1` by default ([governance-stream/index.ts](api/governance-stream/index.ts))

The WebSocket/SSE stream server defaulted `HOST` to `'127.0.0.1'` (localhost only). On any Linux server, VM, or Docker container this makes the `/ws/events` and `/sse/events` endpoints completely unreachable from outside the host — the server silently accepts the bind but all external connection attempts fail.

The governance-events API server already defaults to `'0.0.0.0'`. This brings the stream server in line.

**Fix:** change default from `'127.0.0.1'` → `'0.0.0.0'`.

---

### Fix 2 — No SIGTERM/SIGINT handler in either server ([governance-stream/index.ts](api/governance-stream/index.ts), [governance-events/index.ts](api/governance-events/index.ts))

Linux (and Docker in particular) sends `SIGTERM` when stopping a container. Without a registered handler Node.js exits immediately, leaving:
- Open WebSocket connections terminated without a close frame
- The WAL unflushed (events not yet written to the DB are lost)
- libsql connections not cleanly closed

Both entry points now register `SIGTERM` and `SIGINT` handlers that call the server's shutdown method (`server.stop()` / `app.close()`) before exiting.

---

## Test plan

- [x] Both files compile cleanly (no new imports needed)
- [x] `SIGTERM` handler wired after server is confirmed listening (avoids calling stop before start)
- [x] Uses `process.once` so repeated signals don't double-invoke shutdown