### PR TITLE
feat: add international phone PII patterns

### DIFF
--- a/packages/camelai-tealtiger/README.md
+++ b/packages/camelai-tealtiger/README.md
@@ -230,7 +230,7 @@ Every evaluation produces a structured audit entry:
 
 Built-in pattern detection for:
 - Email addresses
-- US phone numbers
+- US, UK, EU, and India phone numbers
 - Social Security Numbers (SSN)
 - Credit card numbers
 - IP addresses

--- a/packages/camelai-tealtiger/src/camelai_tealtiger/agent_hook.py
+++ b/packages/camelai-tealtiger/src/camelai_tealtiger/agent_hook.py
@@ -25,6 +25,13 @@ _PII_PATTERNS: Dict[str, re.Pattern[str]] = {
     "phone_us": re.compile(
         r"\b(?:\+1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b"
     ),
+    "phone_uk": re.compile(
+        r"(?<!\w)\+44[-.\s]?(?:\d{2,4}[-.\s]?)?\d{3,4}[-.\s]?\d{3,4}\b"
+    ),
+    "phone_eu": re.compile(
+        r"(?<!\w)(?:\+49[-.\s]?\d{2,4}[-.\s]?\d{5,8}|\+33[-.\s]?\d(?:[-.\s]?\d{2}){4})\b"
+    ),
+    "phone_in": re.compile(r"(?<!\w)\+91[-.\s]?[6-9]\d{4}[-.\s]?\d{5}\b"),
     "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     "credit_card": re.compile(r"\b(?:\d{4}[-\s]?){3}\d{4}\b"),
     "ip_address": re.compile(

--- a/packages/camelai-tealtiger/tests/test_agent_hook.py
+++ b/packages/camelai-tealtiger/tests/test_agent_hook.py
@@ -146,6 +146,24 @@ class TestPIIDetection:
         assert len(pii) >= 1
         assert any(p["type"] == "phone_us" for p in pii)
 
+    @pytest.mark.parametrize(
+        ("step_content", "pii_type"),
+        [
+            ("London office: +44 20 7946 0958", "phone_uk"),
+            ("Berlin office: +49 30 12345678", "phone_eu"),
+            ("Paris office: +33 1 23 45 67 89", "phone_eu"),
+            ("Mumbai office: +91 98765 43210", "phone_in"),
+        ],
+    )
+    def test_detects_international_phone(self, step_content: str, pii_type: str) -> None:
+        """Detects UK, EU, and India phone numbers in step content."""
+        hook = TealTigerAgentHook()
+        decision = hook.pre_step(agent_id="agent-1", step_content=step_content)
+
+        pii = decision["pii_detected"]
+        assert len(pii) >= 1
+        assert any(p["type"] == pii_type for p in pii)
+
     def test_detects_ip_address(self) -> None:
         """Detects IP addresses in step content."""
         hook = TealTigerAgentHook()

--- a/packages/haystack-tealtiger/README.md
+++ b/packages/haystack-tealtiger/README.md
@@ -143,7 +143,7 @@ Every evaluation produces a structured audit entry:
 
 Built-in pattern detection for:
 - Email addresses
-- US phone numbers
+- US, UK, EU, and India phone numbers
 - Social Security Numbers (SSN)
 - Credit card numbers
 - IP addresses

--- a/packages/haystack-tealtiger/src/haystack_integrations/components/connectors/tealtiger/governance_component.py
+++ b/packages/haystack-tealtiger/src/haystack_integrations/components/connectors/tealtiger/governance_component.py
@@ -28,6 +28,13 @@ _PII_PATTERNS: Dict[str, re.Pattern[str]] = {
     "phone_us": re.compile(
         r"\b(?:\+1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b"
     ),
+    "phone_uk": re.compile(
+        r"(?<!\w)\+44[-.\s]?(?:\d{2,4}[-.\s]?)?\d{3,4}[-.\s]?\d{3,4}\b"
+    ),
+    "phone_eu": re.compile(
+        r"(?<!\w)(?:\+49[-.\s]?\d{2,4}[-.\s]?\d{5,8}|\+33[-.\s]?\d(?:[-.\s]?\d{2}){4})\b"
+    ),
+    "phone_in": re.compile(r"(?<!\w)\+91[-.\s]?[6-9]\d{4}[-.\s]?\d{5}\b"),
     "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     "credit_card": re.compile(r"\b(?:\d{4}[-\s]?){3}\d{4}\b"),
     "ip_address": re.compile(

--- a/packages/haystack-tealtiger/tests/test_governance_component.py
+++ b/packages/haystack-tealtiger/tests/test_governance_component.py
@@ -149,6 +149,33 @@ class TestPIIDetection:
         assert len(pii) >= 1
         assert any(p["type"] == "credit_card" for p in pii)
 
+    def test_detects_phone(self) -> None:
+        """Detects US phone numbers in input."""
+        gov = TealTigerGovernanceComponent()
+        result = gov.run(text="Call me at (555) 123-4567")
+
+        pii = result["decision"]["pii_detected"]
+        assert len(pii) >= 1
+        assert any(p["type"] == "phone_us" for p in pii)
+
+    @pytest.mark.parametrize(
+        ("text", "pii_type"),
+        [
+            ("London office: +44 20 7946 0958", "phone_uk"),
+            ("Berlin office: +49 30 12345678", "phone_eu"),
+            ("Paris office: +33 1 23 45 67 89", "phone_eu"),
+            ("Mumbai office: +91 98765 43210", "phone_in"),
+        ],
+    )
+    def test_detects_international_phone(self, text: str, pii_type: str) -> None:
+        """Detects UK, EU, and India phone numbers in input."""
+        gov = TealTigerGovernanceComponent()
+        result = gov.run(text=text)
+
+        pii = result["decision"]["pii_detected"]
+        assert len(pii) >= 1
+        assert any(p["type"] == pii_type for p in pii)
+
     def test_detects_multiple_pii(self) -> None:
         """Detects multiple PII types in a single input."""
         gov = TealTigerGovernanceComponent()

--- a/packages/pydanticai-tealtiger/src/pydanticai_tealtiger/guard.py
+++ b/packages/pydanticai-tealtiger/src/pydanticai_tealtiger/guard.py
@@ -24,6 +24,13 @@ _PII_PATTERNS: Dict[str, re.Pattern[str]] = {
     "phone_us": re.compile(
         r"\b(?:\+1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b"
     ),
+    "phone_uk": re.compile(
+        r"(?<!\w)\+44[-.\s]?(?:\d{2,4}[-.\s]?)?\d{3,4}[-.\s]?\d{3,4}\b"
+    ),
+    "phone_eu": re.compile(
+        r"(?<!\w)(?:\+49[-.\s]?\d{2,4}[-.\s]?\d{5,8}|\+33[-.\s]?\d(?:[-.\s]?\d{2}){4})\b"
+    ),
+    "phone_in": re.compile(r"(?<!\w)\+91[-.\s]?[6-9]\d{4}[-.\s]?\d{5}\b"),
     "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     "credit_card": re.compile(r"\b(?:\d{4}[-\s]?){3}\d{4}\b"),
     "ip_address": re.compile(

--- a/packages/pydanticai-tealtiger/tests/test_guard.py
+++ b/packages/pydanticai-tealtiger/tests/test_guard.py
@@ -156,6 +156,24 @@ class TestPIIDetection:
         assert len(pii) >= 1
         assert any(p["type"] == "phone_us" for p in pii)
 
+    @pytest.mark.parametrize(
+        ("number", "pii_type"),
+        [
+            ("+44 20 7946 0958", "phone_uk"),
+            ("+49 30 12345678", "phone_eu"),
+            ("+33 1 23 45 67 89", "phone_eu"),
+            ("+91 98765 43210", "phone_in"),
+        ],
+    )
+    def test_detects_international_phone(self, number: str, pii_type: str) -> None:
+        """Detects UK, EU, and India phone numbers in tool args."""
+        guard = TealTigerGuard()
+        decision = guard.evaluate(tool="call", args={"number": number})
+
+        pii = decision["pii_detected"]
+        assert len(pii) >= 1
+        assert any(p["type"] == pii_type for p in pii)
+
     def test_detects_ip_address(self) -> None:
         """Detects IP addresses in tool args."""
         guard = TealTigerGuard()


### PR DESCRIPTION
Fixes #231.

## Summary
- add country-code-specific phone PII patterns for UK (`+44`), EU examples (`+49` Germany and `+33` France), and India (`+91`) across the Haystack, CamelAI, and PydanticAI adapters
- use `(?<!\w)` before leading `+` numbers instead of `\b`, because a word boundary does not match before `+` when preceded by whitespace
- add adapter tests for UK, Germany, France, India, and keep/extend US phone coverage
- update adapter docs that previously said only US phone numbers were detected

## Validation
- `uv run --extra dev pytest tests/test_governance_component.py -q` in `packages/haystack-tealtiger` — 37 passed
- `uv run --extra dev pytest tests/test_agent_hook.py -q` in `packages/camelai-tealtiger` — 65 passed
- `uv run --extra dev pytest tests/test_guard.py -q` in `packages/pydanticai-tealtiger` — 60 passed
- `git diff --check` — passed

## Notes
- I also tried package-local Ruff checks on the touched adapter files. They currently fail on existing repo style issues such as deprecated `typing.Dict`/`List`, unused imports in tests, and existing complexity warnings; I left those out of scope to keep this PR focused on the requested PII patterns.