### PR TITLE
Add README 60-second quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,33 @@ Open source. TypeScript + Python. Works with any provider.
 
 ---
 
+## ⚡ 60-second quickstart
+
+Install: `npm install tealtiger` or `pip install tealtiger`, then wrap one existing OpenAI call:
+
+```typescript
+import { TealOpenAI } from 'tealtiger';
+const client = new TealOpenAI({ apiKey: process.env.OPENAI_API_KEY, guardrails: { promptInjection: true } });
+const res = await client.chat.completions.create({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'Hello!' }] });
+console.log(res.security?.decision ?? 'ALLOW');
+```
+
+```python
+import os
+from tealtiger import TealOpenAI
+client = TealOpenAI(api_key=os.environ["OPENAI_API_KEY"], guardrails={"prompt_injection": True})
+print(client.chat.completions.create(model="gpt-4o-mini", messages=[{"role": "user", "content": "Hello!"}]).security.decision)
+```
+
+```text
+ALLOW
+Governance receipt emitted; cost and guardrails tracked.
+```
+
+Next: [full Quick Start](#-quick-start) and [examples](./examples).
+
+---
+
 ## What is TealTiger?
 
 TealTiger is an open-source SDK that provides **deterministic governance** for AI agents. It enforces security policies, tracks costs, and produces structured evidence — all at runtime, with no infrastructure required.


### PR DESCRIPTION
## Summary

- add a prominent 60-second quickstart section near the top of the README, before the detailed overview
- include minimum TypeScript and Python examples for wrapping an OpenAI chat completion with TealTiger governance
- show expected terminal output so new visitors can see the immediate result
- link readers to the full Quick Start section and examples directory for next steps

## Validation

- Confirmed the new section is 26 lines, under the 30-line acceptance limit
- Reviewed the README placement directly after the intro/badges and before `What is TealTiger?`

Refs #159
