### PR TITLE
Add Postgres MCP policy pack with SQL deny rules

### DIFF
--- a/policy-packs/postgres-mcp/README.md
+++ b/policy-packs/postgres-mcp/README.md
@@ -1,0 +1,117 @@
+# Postgres MCP Policy Pack
+
+This policy pack governs Postgres MCP tool calls. It classifies common Postgres MCP tools and blocks destructive SQL passed to `execute_sql` before the query reaches the database.
+
+Use it when an agent needs database visibility but should not be able to drop tables, erase data, or change database permissions without review.
+
+## Files
+
+- `tool-catalog.json` lists common Postgres MCP tools and their risk levels.
+- `policy.yaml` contains argument-level regex rules for `execute_sql`.
+- `README.md` explains what is blocked, what requires approval, and how to customize the pack.
+
+## Use
+
+Apply the policy pack to agents that can call Postgres MCP tools:
+
+```bash
+tealtiger policy apply policy-packs/postgres-mcp/policy.yaml --agent <agent-id>
+```
+
+## Tool Classification
+
+Read-only tools are classified as `READ`:
+
+- `list_tables`
+- `list_schemas`
+- `describe_table`
+- `get_table_schema`
+- `list_columns`
+- `list_indexes`
+- `list_constraints`
+- `explain_query`
+
+The raw SQL executor is classified as `DESTRUCTIVE`:
+
+- `execute_sql`
+
+`execute_sql` is high risk because one tool call can read, modify, delete, reconfigure, or grant access depending on the SQL text.
+
+## Blocked Queries
+
+These queries are denied by default:
+
+```sql
+DROP TABLE users;
+DROP SCHEMA analytics;
+TRUNCATE orders;
+DELETE FROM payments;
+ALTER TABLE customers DROP COLUMN email;
+ALTER SYSTEM SET log_statement = 'all';
+COPY users TO PROGRAM 'cat > /tmp/users.csv';
+CREATE EXTENSION file_fdw;
+```
+
+The pack includes more than five regex-based deny rules covering:
+
+- `DROP` statements
+- `TRUNCATE`
+- `DELETE FROM`
+- `ALTER TABLE ... DROP`
+- `ALTER SYSTEM`
+- `COPY ... PROGRAM`
+- `CREATE EXTENSION`
+
+## Queries Requiring Approval
+
+Permission and role-management operations require human approval:
+
+```sql
+GRANT SELECT ON users TO analyst;
+REVOKE ALL ON payments FROM app_user;
+CREATE ROLE reporting_user;
+ALTER ROLE app_user WITH CREATEDB;
+DROP ROLE old_app_user;
+CREATE USER dashboard_user;
+ALTER USER dashboard_user WITH PASSWORD 'new-password';
+DROP USER dashboard_user;
+```
+
+These queries are not always destructive, but they can change who has access to data or administrative capabilities.
+
+## Allowed Queries
+
+Read-only queries are allowed unless your local policy adds stricter controls:
+
+```sql
+SELECT * FROM users LIMIT 10;
+SELECT id, email FROM customers WHERE id = 123;
+SELECT COUNT(*) FROM orders WHERE status = 'pending';
+EXPLAIN SELECT * FROM invoices WHERE created_at > now() - interval '7 days';
+```
+
+## Customization
+
+Edit `policy.yaml` to fit your environment.
+
+Common customizations:
+
+- Narrow `DELETE FROM` to allow deletes only in development databases.
+- Add table-specific deny rules for sensitive tables such as `users`, `payments`, or `audit_logs`.
+- Add `REQUIRE_APPROVAL` rules for `UPDATE`, `INSERT`, or migration commands.
+- Remove `CREATE EXTENSION` from `DENY` if extensions are managed by a separate approval workflow.
+
+Example table-specific rule:
+
+```yaml
+- tool: execute_sql
+  when:
+    args.query:
+      pattern: "(?i)\\bSELECT\\b.*\\bFROM\\s+(users|payments)\\b"
+  action: REQUIRE_APPROVAL
+  reason: "Sensitive table access requires human approval"
+```
+
+## Notes
+
+Regex rules are a deterministic safety layer, not a complete SQL parser. For production systems, combine this policy pack with least-privilege database roles, read-only credentials for analysis agents, backups, and database-level audit logging.

--- a/policy-packs/postgres-mcp/policy.yaml
+++ b/policy-packs/postgres-mcp/policy.yaml
@@ -1,0 +1,106 @@
+# TealTiger Policy Pack - Postgres MCP Server
+#
+# Blocks destructive SQL patterns passed to execute_sql and requires approval
+# for permission and role-management operations.
+#
+# To use this pack in your policy:
+#   tealtiger policy apply policy-packs/postgres-mcp/policy.yaml --agent <agent-id>
+
+name: postgres-mcp
+version: "1.0.0"
+description: "Policy pack for the Postgres MCP server. Classifies Postgres MCP tools and blocks destructive SQL patterns before execution."
+
+tools:
+  # READ - metadata inspection and query planning
+  - name: list_tables
+    risk: READ
+
+  - name: list_schemas
+    risk: READ
+
+  - name: describe_table
+    risk: READ
+
+  - name: get_table_schema
+    risk: READ
+
+  - name: list_columns
+    risk: READ
+
+  - name: list_indexes
+    risk: READ
+
+  - name: list_constraints
+    risk: READ
+
+  - name: explain_query
+    risk: READ
+
+  # DESTRUCTIVE - arbitrary SQL can mutate, delete, or reconfigure the database
+  - name: execute_sql
+    risk: DESTRUCTIVE
+
+rules:
+  # DROP statements can remove tables, schemas, databases, views, indexes, or functions.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bDROP\\s+(TABLE|DATABASE|SCHEMA|VIEW|MATERIALIZED\\s+VIEW|INDEX|FUNCTION|PROCEDURE|TRIGGER)\\b"
+    action: DENY
+    reason: "Destructive SQL blocked by governance policy"
+
+  # TRUNCATE removes all rows from a table and is often irreversible in practice.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bTRUNCATE\\b"
+    action: DENY
+    reason: "TRUNCATE removes table data and is blocked by governance policy"
+
+  # DELETE FROM can remove production data. Teams can narrow this rule if they allow scoped deletes.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bDELETE\\s+FROM\\b"
+    action: DENY
+    reason: "DELETE FROM is blocked to prevent data loss"
+
+  # ALTER TABLE ... DROP removes columns or constraints and can break applications.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bALTER\\s+TABLE\\b.*\\bDROP\\b"
+    action: DENY
+    reason: "ALTER TABLE DROP operations are blocked by governance policy"
+
+  # ALTER SYSTEM changes Postgres server configuration.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bALTER\\s+SYSTEM\\b"
+    action: DENY
+    reason: "Postgres system configuration changes are blocked"
+
+  # COPY ... PROGRAM can execute an OS command from the database server context.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bCOPY\\b.*\\bPROGRAM\\b"
+    action: DENY
+    reason: "COPY PROGRAM can execute server-side commands and is blocked"
+
+  # Unsafe extension creation can expand database capabilities beyond approved controls.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\bCREATE\\s+EXTENSION\\b"
+    action: DENY
+    reason: "CREATE EXTENSION is blocked unless explicitly approved outside this policy"
+
+  # Permission and role changes are not always destructive, but they change blast radius.
+  - tool: execute_sql
+    when:
+      args.query:
+        pattern: "(?i)\\b(GRANT|REVOKE|CREATE\\s+ROLE|ALTER\\s+ROLE|DROP\\s+ROLE|CREATE\\s+USER|ALTER\\s+USER|DROP\\s+USER)\\b"
+    action: REQUIRE_APPROVAL
+    reason: "Permission changes require human approval"

--- a/policy-packs/postgres-mcp/tool-catalog.json
+++ b/policy-packs/postgres-mcp/tool-catalog.json
@@ -1,0 +1,59 @@
+{
+  "name": "postgres-mcp",
+  "version": "1.0.0",
+  "description": "Tool catalog for the Postgres MCP server. Classifies common Postgres MCP tools by their governance risk.",
+  "protocol": "mcp",
+  "database": "postgres",
+  "riskLevels": {
+    "READ": "Read-only metadata or query inspection with no database side effects.",
+    "MUTATING": "Changes database state or session behavior but is not inherently destructive.",
+    "DESTRUCTIVE": "Can execute arbitrary SQL or perform high-impact database operations."
+  },
+  "tools": [
+    {
+      "name": "list_tables",
+      "risk": "READ",
+      "description": "Lists tables available to the connected Postgres role."
+    },
+    {
+      "name": "list_schemas",
+      "risk": "READ",
+      "description": "Lists database schemas available to the connected Postgres role."
+    },
+    {
+      "name": "describe_table",
+      "risk": "READ",
+      "description": "Returns columns, indexes, constraints, and metadata for a table."
+    },
+    {
+      "name": "get_table_schema",
+      "risk": "READ",
+      "description": "Returns schema details for a specific table."
+    },
+    {
+      "name": "list_columns",
+      "risk": "READ",
+      "description": "Lists columns for a table or view."
+    },
+    {
+      "name": "list_indexes",
+      "risk": "READ",
+      "description": "Lists indexes defined on a table."
+    },
+    {
+      "name": "list_constraints",
+      "risk": "READ",
+      "description": "Lists primary key, foreign key, unique, and check constraints."
+    },
+    {
+      "name": "explain_query",
+      "risk": "READ",
+      "description": "Returns a query execution plan without modifying data."
+    },
+    {
+      "name": "execute_sql",
+      "risk": "DESTRUCTIVE",
+      "description": "Executes raw SQL against Postgres. Governed by argument-level SQL regex rules in policy.yaml."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Postgres MCP policy pack that classifies common Postgres MCP tools and blocks destructive SQL patterns passed to `execute_sql`.

## Changes

- Added `policy-packs/postgres-mcp/tool-catalog.json`
- Added `policy-packs/postgres-mcp/policy.yaml`
- Added `policy-packs/postgres-mcp/README.md`
- Classified common Postgres MCP tools by risk level
- Added regex-based `DENY` rules for destructive SQL patterns
- Added `REQUIRE_APPROVAL` for permission and role-management SQL

## Blocked SQL patterns

The pack denies patterns such as:

- `DROP TABLE`
- `TRUNCATE`
- `DELETE FROM`
- `ALTER TABLE ... DROP`
- `ALTER SYSTEM`
- `COPY ... PROGRAM`
- `CREATE EXTENSION`

## Approval-required SQL patterns

The pack requires approval for:

- `GRANT`
- `REVOKE`
- `CREATE ROLE`
- `ALTER ROLE`
- `DROP ROLE`
- `CREATE USER`
- `ALTER USER`
- `DROP USER`

## Testing

- Reviewed policy pack files manually
- Confirmed the pack includes more than five regex-based deny rules
- Confirmed README includes blocked, approval-required, and allowed query examples

Closes #265 