### PR TITLE
feat: add ag2-tealtiger governance adapter package

### DIFF
--- a/packages/ag2-tealtiger/examples/governed_groupchat.py
+++ b/packages/ag2-tealtiger/examples/governed_groupchat.py
@@ -1,0 +1,225 @@
+"""Example: GovernedGroupChat with Speaker Selection.
+
+Demonstrates how GovernedGroupChat applies governance policies to speaker
+selection in multi-agent conversations. In a governed group chat:
+- Frozen agents are skipped without invoking TealEngine
+- Over-budget agents are skipped without invoking TealEngine
+- Remaining candidates are evaluated via TealEngine before getting a turn
+- If all speakers are denied, the round terminates with ALL_SPEAKERS_DENIED
+- REFER decisions suspend an agent while others continue
+
+This is the pattern for multi-agent orchestration with governance guardrails.
+
+Requirements:
+    pip install ag2-tealtiger
+
+Usage:
+    python governed_groupchat.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ─── Inline mocks so the example runs without real AG2/TealEngine ────────────
+
+
+class MockConversableAgent:
+    """Minimal AG2 ConversableAgent stub for demonstration."""
+
+    def __init__(self, name: str, **kwargs):
+        self.name = name
+        self._reply_funcs: list[dict] = []
+
+    def register_reply(self, trigger=None, reply_func=None, position=0, **kwargs):
+        self._reply_funcs.insert(position, {
+            "trigger": trigger,
+            "reply_func": reply_func,
+        })
+
+    def __repr__(self) -> str:
+        return f"Agent({self.name})"
+
+
+class MockTealEngine:
+    """Mock TealEngine with per-agent speaker selection policies.
+
+    Simulates governance evaluation for speaker candidacy. In production,
+    replace with a real TealEngine and configure policies that determine
+    which agents can speak based on role, context, or risk level.
+
+        from tealtiger import TealEngine
+        engine = TealEngine(policies=[speaker_policy, role_policy, ...])
+    """
+
+    def __init__(self, denied_speakers: list[str] | None = None):
+        """
+        Args:
+            denied_speakers: List of agent names that should be denied
+                when evaluated for speaker candidacy.
+        """
+        self.denied_speakers = denied_speakers or []
+        self.evaluation_count = 0
+
+    def evaluate(
+        self,
+        tool_name: str = "",
+        tool_args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Evaluate a speaker candidacy or tool call."""
+        self.evaluation_count += 1
+        agent_id = (context or {}).get("agent_id", "")
+
+        if agent_id in self.denied_speakers:
+            return {
+                "action": "DENY",
+                "reason": f"Agent '{agent_id}' not authorized to speak in this round",
+                "reason_codes": ["SPEAKER_DENIED", "ROLE_RESTRICTION"],
+                "risk_score": 60,
+            }
+
+        return {
+            "action": "ALLOW",
+            "reason": "Agent authorized for this conversation round",
+            "reason_codes": ["SPEAKER_ALLOWED"],
+            "risk_score": 0,
+        }
+
+
+# ─── Example: GovernedGroupChat Speaker Selection ────────────────────────────
+
+
+def main() -> None:
+    """Demonstrate GovernedGroupChat with governance-enforced speaker selection."""
+    from ag2_tealtiger import TealTigerGuard, GovernedGroupChat, GovernanceMode
+
+    print("=" * 65)
+    print("  ag2-tealtiger: GovernedGroupChat Speaker Selection")
+    print("=" * 65)
+
+    # ── Setup: Create agents for a coding team ────────────────────────────
+    planner = MockConversableAgent(name="planner")
+    coder = MockConversableAgent(name="coder")
+    reviewer = MockConversableAgent(name="reviewer")
+    executor = MockConversableAgent(name="executor")
+
+    # Create engine that denies the executor from speaking (role restriction)
+    engine = MockTealEngine(denied_speakers=["executor"])
+
+    # Create guard in ENFORCE mode
+    guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+    # Attach guard to all agents (for tool call governance)
+    for agent in [planner, coder, reviewer, executor]:
+        guard.attach(agent)
+
+    # Create the governed group chat
+    group_chat = GovernedGroupChat(
+        agents=[planner, coder, reviewer, executor],
+        guard=guard,
+        max_round=10,
+        speaker_selection_method="round_robin",
+    )
+
+    # ── Scenario 1: Normal speaker selection with policy filtering ────────
+    print("\n--- Scenario 1: Policy-based speaker selection ---\n")
+
+    selected = group_chat.select_speaker(last_speaker=planner)
+    print(f"  After planner spoke → selected: {selected}")
+    print(f"  (executor is denied by policy, so it gets skipped)")
+
+    selected = group_chat.select_speaker(last_speaker=coder)
+    print(f"  After coder spoke   → selected: {selected}")
+
+    # ── Scenario 2: Frozen agent is skipped without engine call ───────────
+    print("\n--- Scenario 2: Frozen agent skipped ---\n")
+
+    guard.freeze("coder")
+    print(f"  Froze 'coder' — is_frozen: {guard.is_frozen('coder')}")
+
+    # Engine should NOT be called for frozen agents
+    engine.evaluation_count = 0
+    selected = group_chat.select_speaker(last_speaker=planner)
+    print(f"  Selected speaker: {selected}")
+    print(f"  Engine evaluations: {engine.evaluation_count} (frozen agent skipped)")
+
+    guard.unfreeze("coder")
+    print(f"  Unfroze 'coder'")
+
+    # ── Scenario 3: Over-budget agent is skipped ──────────────────────────
+    print("\n--- Scenario 3: Over-budget agent skipped ---\n")
+
+    # Set a low budget for reviewer and exceed it
+    guard.set_budget("reviewer", limit=0.0001)
+    # Simulate cost accumulation to exceed budget
+    guard._budget_manager.track_cost("reviewer", 0.001)
+
+    engine.evaluation_count = 0
+    selected = group_chat.select_speaker(last_speaker=planner)
+    print(f"  Selected speaker: {selected}")
+    print(f"  (reviewer over budget, executor denied by policy)")
+
+    # Check the speaker selection audit
+    audit = group_chat.speaker_selection_audit
+    latest = audit[-1] if audit else None
+    if latest:
+        print(f"\n  Speaker selection audit (last round):")
+        for candidate in latest.candidates_evaluated:
+            print(
+                f"    {candidate['agent_id']:<10} → "
+                f"{candidate['decision']:<6} "
+                f"reason={candidate.get('reason', 'N/A')}"
+            )
+
+    # ── Scenario 4: All speakers denied → round terminates ───────────────
+    print("\n--- Scenario 4: All speakers denied ---\n")
+
+    # Freeze everyone except executor (who is policy-denied)
+    guard.freeze("planner")
+    guard.freeze("coder")
+    # reviewer is already over budget
+
+    selected = group_chat.select_speaker(last_speaker=planner)
+    print(f"  Selected speaker: {selected}")
+    print(f"  (All agents either frozen, over-budget, or policy-denied)")
+
+    # Check the termination audit entry
+    audit = group_chat.speaker_selection_audit
+    latest = audit[-1] if audit else None
+    if latest:
+        print(f"  Reason codes: {latest.reason_codes}")
+
+    # Clean up freezes
+    guard.unfreeze("planner")
+    guard.unfreeze("coder")
+    guard.reset_budget("reviewer")
+
+    # ── Scenario 5: Full audit trail across selection rounds ──────────────
+    print("\n--- Speaker Selection Audit Trail ---\n")
+
+    all_audits = group_chat.speaker_selection_audit
+    print(f"  Total selection rounds: {len(all_audits)}")
+    for i, entry in enumerate(all_audits, 1):
+        print(
+            f"  Round {i}: selected={entry.selected_speaker or 'NONE':<10} "
+            f"candidates={len(entry.candidates_evaluated)} "
+            f"codes={entry.reason_codes}"
+        )
+
+    # ── Key takeaways ─────────────────────────────────────────────────────
+    print("\n" + "=" * 65)
+    print("  Key points:")
+    print("  • GovernedGroupChat evaluates speakers against policies")
+    print("  • Frozen/over-budget agents skipped without engine calls")
+    print("  • Policy-denied agents skipped, next candidate evaluated")
+    print("  • ALL_SPEAKERS_DENIED terminates the round safely")
+    print("  • Full speaker selection audit trail per round")
+    print("  • Per-agent governance isolation in multi-agent groups")
+    print("=" * 65)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ag2-tealtiger/examples/policy_enforcement.py
+++ b/packages/ag2-tealtiger/examples/policy_enforcement.py
@@ -1,0 +1,234 @@
+"""Example: Policy Enforcement Mode with ag2-tealtiger.
+
+Demonstrates how to use TealTigerGuard in ENFORCE mode with a TealEngine
+to block unauthorized tool calls. In this mode:
+- TealEngine evaluates each tool call against configured policies
+- DENY decisions block the tool call and return a visible denial message
+- ALLOW decisions pass through transparently
+- Engine errors trigger fail-closed behavior (deny by default)
+- Per-agent freeze kills all actions immediately
+
+This is the production pattern: define policies, set ENFORCE mode,
+and let governance block violations automatically.
+
+Requirements:
+    pip install ag2-tealtiger
+
+Usage:
+    python policy_enforcement.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ─── Inline mocks so the example runs without real AG2/TealEngine ────────────
+
+
+class MockConversableAgent:
+    """Minimal AG2 ConversableAgent stub for demonstration."""
+
+    def __init__(self, name: str, **kwargs):
+        self.name = name
+        self._reply_funcs: list[dict] = []
+
+    def register_reply(self, trigger=None, reply_func=None, position=0, **kwargs):
+        self._reply_funcs.insert(position, {
+            "trigger": trigger,
+            "reply_func": reply_func,
+        })
+
+    def simulate_tool_call(self, tool_name: str, arguments: dict) -> str | None:
+        """Simulate a tool call flowing through the governance pipeline."""
+        messages = [{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": f"call_{tool_name}",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments,
+                },
+            }],
+        }]
+
+        for entry in self._reply_funcs:
+            reply_func = entry["reply_func"]
+            should_terminate, reply = reply_func(
+                recipient=self,
+                messages=messages,
+                sender=self,
+                config=None,
+            )
+            if should_terminate:
+                return reply
+        return None
+
+
+class MockTealEngine:
+    """Mock TealEngine that evaluates tool calls against a simple policy.
+
+    In production, replace this with the real TealEngine:
+        from tealtiger import TealEngine
+        engine = TealEngine(policies=[...])
+
+    This mock demonstrates the interface TealTigerGuard expects:
+    - engine.evaluate(tool_name, args, context) -> dict with action, reason, etc.
+    """
+
+    def __init__(self, blocked_tools: list[str] | None = None):
+        self.blocked_tools = blocked_tools or []
+        self._call_count = 0
+
+    def evaluate(
+        self,
+        tool_name: str = "",
+        tool_args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Evaluate a tool call against configured policies."""
+        self._call_count += 1
+
+        if tool_name in self.blocked_tools:
+            return {
+                "action": "DENY",
+                "reason": f"Tool '{tool_name}' is not on the approved allowlist",
+                "reason_codes": ["TOOL_NOT_ALLOWED", "POLICY_VIOLATION"],
+                "risk_score": 85,
+            }
+
+        return {
+            "action": "ALLOW",
+            "reason": "Tool call compliant with all configured policies",
+            "reason_codes": ["POLICY_COMPLIANT"],
+            "risk_score": 0,
+        }
+
+
+# ─── Example: Policy Enforcement ────────────────────────────────────────────
+
+
+def main() -> None:
+    """Demonstrate ENFORCE mode with TealEngine policy evaluation."""
+    from ag2_tealtiger import TealTigerGuard, GovernanceMode
+
+    print("=" * 65)
+    print("  ag2-tealtiger: Policy Enforcement Mode")
+    print("=" * 65)
+
+    # ── Setup: Create engine with a blocked-tools policy ──────────────────
+    # Block dangerous tools: shell execution and file deletion
+    engine = MockTealEngine(blocked_tools=["execute_shell", "delete_file", "rm_rf"])
+
+    # Create guard in ENFORCE mode — denials BLOCK tool execution
+    guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+    # Create and attach agents
+    coder = MockConversableAgent(name="coder")
+    executor = MockConversableAgent(name="executor")
+    guard.attach(coder)
+    guard.attach(executor)
+
+    # ── Scenario 1: Allowed tool calls pass through ───────────────────────
+    print("\n--- Scenario 1: Allowed tool calls ---\n")
+
+    result = coder.simulate_tool_call("write_code", {"language": "python", "task": "sort list"})
+    print(f"  write_code → {'PASSED (None)' if result is None else 'BLOCKED'}")
+
+    result = coder.simulate_tool_call("read_file", {"path": "/src/main.py"})
+    print(f"  read_file  → {'PASSED (None)' if result is None else 'BLOCKED'}")
+
+    # ── Scenario 2: Denied tool calls are blocked with visible message ────
+    print("\n--- Scenario 2: Denied tool calls (ENFORCE blocks) ---\n")
+
+    result = executor.simulate_tool_call("execute_shell", {"command": "rm -rf /"})
+    print(f"  execute_shell → BLOCKED")
+    print(f"    Reply: {result}")
+
+    result = executor.simulate_tool_call("delete_file", {"path": "/etc/passwd"})
+    print(f"  delete_file   → BLOCKED")
+    print(f"    Reply: {result}")
+
+    # Allowed tool still works after denials
+    result = executor.simulate_tool_call("read_file", {"path": "/tmp/safe.txt"})
+    print(f"\n  read_file (after denials) → {'PASSED (None)' if result is None else 'BLOCKED'}")
+
+    # ── Scenario 3: Per-agent freeze kill switch ──────────────────────────
+    print("\n--- Scenario 3: Freeze kill switch ---\n")
+
+    # Freeze the executor mid-conversation
+    guard.freeze("executor")
+    print(f"  executor frozen: {guard.is_frozen('executor')}")
+
+    # All tool calls blocked for frozen agent
+    result = executor.simulate_tool_call("read_file", {"path": "/tmp/harmless.txt"})
+    print(f"  executor.read_file → BLOCKED (frozen)")
+    print(f"    Reply: {result}")
+
+    # Coder still works — freeze is per-agent
+    result = coder.simulate_tool_call("write_code", {"task": "hello world"})
+    print(f"  coder.write_code   → {'PASSED (None)' if result is None else 'BLOCKED'}")
+
+    # Unfreeze restores normal governance
+    guard.unfreeze("executor")
+    print(f"\n  executor unfrozen: {not guard.is_frozen('executor')}")
+    result = executor.simulate_tool_call("read_file", {"path": "/tmp/data.csv"})
+    print(f"  executor.read_file → {'PASSED (None)' if result is None else 'BLOCKED'}")
+
+    # ── Scenario 4: Budget enforcement ────────────────────────────────────
+    print("\n--- Scenario 4: Budget enforcement ---\n")
+
+    # Set a tight budget for the executor
+    guard.set_budget("executor", limit=0.001)  # $0.001 budget
+
+    # Pre-load some cost to approach the limit, then trigger denial
+    guard._budget_manager.track_cost("executor", 0.0009)  # Near the limit
+    budget = guard.get_budget_state("executor")
+    print(f"  Pre-loaded cost: spent=${budget.current_spend:.6f} / limit=${budget.budget_limit:.6f}")
+
+    # This call should push over the limit
+    result = executor.simulate_tool_call("analyze_data", {"dataset": "large_batch" * 200})
+    budget = guard.get_budget_state("executor")
+    status = "BLOCKED" if result else "PASSED"
+    print(f"  call 1: {status} | spent=${budget.current_spend:.6f} / limit=${budget.budget_limit:.6f}")
+
+    # Now budget is exceeded — next call should be denied
+    result = executor.simulate_tool_call("analyze_data", {"dataset": "another_batch"})
+    budget = guard.get_budget_state("executor")
+    status = "BLOCKED" if result else "PASSED"
+    print(f"  call 2: {status} | spent=${budget.current_spend:.6f} / limit=${budget.budget_limit:.6f}")
+    if result:
+        print(f"    Reply: {result[:80]}...")
+
+    # ── Audit trail shows full governance history ─────────────────────────
+    print("\n--- Audit Trail Summary ---\n")
+
+    allows = sum(1 for e in guard.audit_trail if e.action == "ALLOW")
+    denies = sum(1 for e in guard.audit_trail if e.action == "DENY")
+    print(f"  Total evaluations: {len(guard.audit_trail)}")
+    print(f"  Allowed: {allows}")
+    print(f"  Denied:  {denies}")
+    print(f"\n  Last 3 entries:")
+    for entry in guard.audit_trail[-3:]:
+        print(
+            f"    [{entry.agent_id:<10}] {entry.action:<5} "
+            f"tool={entry.tool_name or 'N/A':<14} "
+            f"codes={entry.reason_codes}"
+        )
+
+    # ── Key takeaways ─────────────────────────────────────────────────────
+    print("\n" + "=" * 65)
+    print("  Key points:")
+    print("  • ENFORCE mode blocks denied tool calls with visible messages")
+    print("  • Freeze is a per-agent kill switch (mode-independent)")
+    print("  • Budget enforcement denies calls when limit exceeded")
+    print("  • Independent governance per agent — same guard, isolated state")
+    print("  • Full audit trail with correlation IDs for every evaluation")
+    print("=" * 65)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ag2-tealtiger/examples/zero_config_observe.py
+++ b/packages/ag2-tealtiger/examples/zero_config_observe.py
@@ -1,0 +1,209 @@
+"""Example: Zero-Config Observe Mode with ag2-tealtiger.
+
+Demonstrates how to add governance to AG2 agents with zero configuration.
+In observe mode, TealTiger:
+- Tracks cumulative cost estimates per agent
+- Detects PII in tool call arguments
+- Records all tool names, call counts, and argument summaries
+- Produces structured audit entries with TEEC correlation
+- Never blocks — all tool calls and messages pass through
+- Adds <5ms latency per evaluation
+
+This is the easiest way to get started: just create a TealTigerGuard()
+with no engine and attach it to any agent.
+
+Requirements:
+    pip install ag2-tealtiger
+
+Usage:
+    python zero_config_observe.py
+"""
+
+from __future__ import annotations
+
+
+# ─── Inline mocks so the example runs without AG2 installed ──────────────────
+
+
+class MockConversableAgent:
+    """Minimal AG2 ConversableAgent stub for demonstration."""
+
+    def __init__(self, name: str, **kwargs):
+        self.name = name
+        self._reply_funcs: list[dict] = []
+
+    def register_reply(self, trigger=None, reply_func=None, position=0, **kwargs):
+        self._reply_funcs.insert(position, {
+            "trigger": trigger,
+            "reply_func": reply_func,
+        })
+
+    def simulate_tool_call(self, tool_name: str, arguments: dict) -> str | None:
+        """Simulate a tool call message flowing through the reply pipeline."""
+        messages = [{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": f"call_{tool_name}",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments,
+                },
+            }],
+        }]
+
+        # Trigger the first reply hook (the governance interceptor)
+        for entry in self._reply_funcs:
+            reply_func = entry["reply_func"]
+            should_terminate, reply = reply_func(
+                recipient=self,
+                messages=messages,
+                sender=self,
+                config=None,
+            )
+            if should_terminate:
+                return reply
+        return None
+
+    def simulate_message(self, content: str) -> str | None:
+        """Simulate a message flowing through the reply pipeline."""
+        messages = [{
+            "role": "assistant",
+            "content": content,
+        }]
+
+        for entry in self._reply_funcs:
+            reply_func = entry["reply_func"]
+            should_terminate, reply = reply_func(
+                recipient=self,
+                messages=messages,
+                sender=self,
+                config=None,
+            )
+            if should_terminate:
+                return reply
+        return None
+
+
+# ─── Example: Zero-Config Observe Mode ──────────────────────────────────────
+
+
+def main() -> None:
+    """Demonstrate zero-config observe mode with TealTigerGuard."""
+    from ag2_tealtiger import TealTigerGuard, TealTigerAuditAgent
+
+    print("=" * 65)
+    print("  ag2-tealtiger: Zero-Config Observe Mode")
+    print("=" * 65)
+
+    # ── Option A: Attach guard to an existing agent ───────────────────────
+    print("\n--- Option A: Attach TealTigerGuard to existing agent ---\n")
+
+    agent = MockConversableAgent(name="code_executor")
+    guard = TealTigerGuard()  # No engine = observe mode
+    guard.attach(agent)
+
+    # Simulate tool calls
+    agent.simulate_tool_call("run_python", {"code": "print('hello world')"})
+    agent.simulate_tool_call("web_search", {"query": "Python asyncio tutorial"})
+    agent.simulate_tool_call("write_file", {"path": "/tmp/out.txt", "content": "data"})
+
+    # Simulate a message with PII
+    agent.simulate_tool_call("send_email", {
+        "to": "alice@example.com",
+        "body": "Call me at 555-123-4567, my SSN is 123-45-6789",
+    })
+
+    # Check the audit trail
+    print(f"Total audit entries: {len(guard.audit_trail)}")
+    print()
+
+    for entry in guard.audit_trail:
+        pii_count = len(entry.pii_detected)
+        print(
+            f"  [{entry.teec.decision_id[:8]}...] "
+            f"tool={entry.tool_name or 'message':<14} "
+            f"action={entry.action:<6} "
+            f"cost=${entry.cost_tracked:.6f} "
+            f"PII={pii_count} "
+            f"time={entry.evaluation_time_ms:.2f}ms"
+        )
+
+    # Budget state (tracked even without explicit limits)
+    budget = guard.get_budget_state("code_executor")
+    print(f"\n  Cumulative cost for 'code_executor': ${budget.current_spend:.6f}")
+
+    # ── Option B: Use TealTigerAuditAgent convenience class ───────────────
+    print("\n\n--- Option B: TealTigerAuditAgent (zero-config) ---\n")
+
+    audit_agent = TealTigerAuditAgent(name="researcher")
+
+    # Simulate some tool calls through the audit agent
+    messages_with_tools = [{
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": {"query": "latest AI papers 2026"},
+            },
+        }],
+    }]
+
+    # Trigger the reply hook directly (simulating AG2's internal flow)
+    for entry in audit_agent._reply_funcs:
+        entry["reply_func"](
+            recipient=audit_agent,
+            messages=messages_with_tools,
+            sender=audit_agent,
+            config=None,
+        )
+
+    messages_with_tools_2 = [{
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_2",
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": {"query": "TealTiger governance framework"},
+            },
+        }],
+    }]
+    for entry in audit_agent._reply_funcs:
+        entry["reply_func"](
+            recipient=audit_agent,
+            messages=messages_with_tools_2,
+            sender=audit_agent,
+            config=None,
+        )
+
+    # Access the summary
+    summary = audit_agent.summary
+    print(f"  Total calls: {summary['total_calls']}")
+    print(f"  Total cost:  ${summary['total_cost']:.6f}")
+    print(f"  Tools used:")
+    for tool, stats in summary["tools"].items():
+        print(f"    {tool}: {stats['calls']} calls, ${stats['cost']:.6f}")
+
+    print(f"\n  Audit trail length: {len(audit_agent.audit_trail)}")
+    print(f"  All decisions: {set(e.action for e in audit_agent.audit_trail)}")
+    print(f"  Reason codes:  {audit_agent.audit_trail[0].reason_codes}")
+
+    # ── Key takeaways ─────────────────────────────────────────────────────
+    print("\n" + "=" * 65)
+    print("  Key points:")
+    print("  • No engine needed — just TealTigerGuard() and attach()")
+    print("  • All tool calls pass through (ALLOW + OBSERVE_PASSTHROUGH)")
+    print("  • Cost, PII, and tool usage tracked automatically")
+    print("  • Structured audit trail with TEEC correlation IDs")
+    print("  • Sub-5ms overhead per evaluation")
+    print("=" * 65)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ag2-tealtiger/pyproject.toml
+++ b/packages/ag2-tealtiger/pyproject.toml
@@ -1,0 +1,99 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ag2-tealtiger"
+version = "0.1.0"
+description = "Deterministic governance adapter for AG2 (AutoGen fork) — policy enforcement, PII detection, cost tracking, per-agent kill switch, governed speaker selection, and structured audit evidence. No LLM in the governance path."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "TealTiger Team", email = "reachout@tealtiger.ai"},
+]
+keywords = [
+    "ag2",
+    "autogen",
+    "ai-agents",
+    "multi-agent",
+    "governance",
+    "security",
+    "guardrails",
+    "policy",
+    "tealtiger",
+    "llm",
+    "deterministic",
+    "pii",
+    "audit",
+    "kill-switch",
+    "cost-tracking",
+    "groupchat",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "ag2>=0.4.0",
+    "tealtiger>=1.3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+    "hypothesis>=6.0.0",
+    "mypy>=1.5.0",
+    "ruff>=0.4.0",
+]
+
+[project.urls]
+Homepage = "https://tealtiger.ai"
+Documentation = "https://docs.tealtiger.ai/integrations/ag2"
+Repository = "https://github.com/agentguard-ai/tealtiger"
+Issues = "https://github.com/agentguard-ai/tealtiger/issues"
+Changelog = "https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/CHANGELOG.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ag2_tealtiger"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v --cov=ag2_tealtiger --cov-report=term-missing"
+markers = [
+    "property: Property-based tests using Hypothesis",
+    "slow: Tests that take longer to run",
+]
+
+[tool.hypothesis]
+# Default profile: 100 examples per property test
+default_settings = {max_examples = 100, deadline = 5000}
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+strict = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "C", "B", "UP"]
+ignore = ["E501"]

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/__init__.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/__init__.py
@@ -1,0 +1,88 @@
+"""TealTiger Governance Adapter for AG2 (AutoGen fork).
+
+Add deterministic governance to any AG2 ConversableAgent or GroupChat:
+
+    from ag2_tealtiger import TealTigerGuard, TealTigerAuditAgent, GovernedGroupChat
+
+    # Zero-config observe mode — track cost, PII, and tool usage
+    guard = TealTigerGuard()
+    guard.attach(my_agent)
+
+    # Or use the convenience subclass
+    agent = TealTigerAuditAgent(name="coder")
+
+    # Policy enforcement with TealEngine
+    from tealtiger import TealEngine
+
+    engine = TealEngine(policies=[...])
+    guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+    guard.attach(my_agent)
+
+    # Governed speaker selection in GroupChat
+    group_chat = GovernedGroupChat(agents=[agent1, agent2], guard=guard)
+
+No LLM in the governance path. All policy evaluation is deterministic, targeting <5ms latency.
+"""
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.audit_agent import TealTigerAuditAgent
+from ag2_tealtiger.governed_groupchat import GovernedGroupChat
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    BudgetState,
+    DecisionReceipt,
+    DecisionSource,
+    DenialMessage,
+    EscalationReceipt,
+    GovernanceAction,
+    GovernanceMode,
+    RevalidationCondition,
+    SpeakerSelectionAuditEntry,
+    TEECContext,
+)
+from ag2_tealtiger.exceptions import (
+    AG2TealTigerError,
+    AgentFrozenError,
+    BudgetExceededError,
+    DecisionExpiredError,
+    EscalationPendingError,
+    GovernanceDenyError,
+)
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.budget_manager import BudgetCheckResult, BudgetStateManager
+from ag2_tealtiger.idempotency import compute_params_hash, derive_idempotency_key
+
+__all__ = [
+    # Core components
+    "TealTigerGuard",
+    "TealTigerAuditAgent",
+    "GovernedGroupChat",
+    # Managers
+    "DecisionReceiptManager",
+    "BudgetStateManager",
+    "BudgetCheckResult",
+    # Data types and enums
+    "GovernanceAction",
+    "GovernanceMode",
+    "ActionKind",
+    "DecisionSource",
+    "TEECContext",
+    "AuditEntry",
+    "DecisionReceipt",
+    "RevalidationCondition",
+    "EscalationReceipt",
+    "BudgetState",
+    "SpeakerSelectionAuditEntry",
+    "DenialMessage",
+    # Exceptions
+    "AG2TealTigerError",
+    "GovernanceDenyError",
+    "DecisionExpiredError",
+    "BudgetExceededError",
+    "AgentFrozenError",
+    "EscalationPendingError",
+    # Utilities
+    "compute_params_hash",
+    "derive_idempotency_key",
+]

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/audit_agent.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/audit_agent.py
@@ -1,0 +1,209 @@
+"""TealTigerAuditAgent — ConversableAgent subclass with built-in governance.
+
+A convenience class that automatically sets up TealTiger governance on
+initialization. Extends AG2's ConversableAgent to provide:
+
+- Automatic TealTigerGuard registration during __init__
+- Zero-config observe mode when no TealEngine provided
+- Built-in audit_trail, summary, and guard properties
+- Optional per-agent budget_limit
+
+Requirements covered: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    AuditEntry,
+    GovernanceMode,
+)
+
+# Conditional import of AG2's ConversableAgent.
+# If ag2 is not installed (e.g. in test environments), we fall back to
+# a minimal base class that provides the interface TealTigerGuard expects.
+try:
+    from autogen import ConversableAgent as _BaseAgent  # type: ignore[import-untyped]
+except ImportError:
+    try:
+        from ag2 import ConversableAgent as _BaseAgent  # type: ignore[import-untyped]
+    except ImportError:
+        # Fallback for environments without AG2 installed.
+        # Provides the minimal interface needed by TealTigerGuard.
+        class _BaseAgent:  # type: ignore[no-redef]
+            """Minimal ConversableAgent stub for environments without AG2."""
+
+            def __init__(self, name: str, **kwargs: Any) -> None:
+                self.name = name
+                self._reply_funcs: list[dict[str, Any]] = []
+                # Store kwargs so subclass can access them
+                self._init_kwargs = kwargs
+
+            def register_reply(
+                self,
+                trigger: Any,
+                reply_func: Any,
+                position: int = 0,
+                config: Any = None,
+                reset_config: Any = None,
+                **kwargs: Any,
+            ) -> None:
+                """Register a reply function — mirrors AG2's ConversableAgent API."""
+                self._reply_funcs.insert(
+                    position,
+                    {
+                        "trigger": trigger,
+                        "reply_func": reply_func,
+                        "config": config,
+                        "reset_config": reset_config,
+                    },
+                )
+
+
+class TealTigerAuditAgent(_BaseAgent):
+    """ConversableAgent with built-in TealTiger governance.
+
+    Automatically registers TealTigerGuard during __init__.
+    Operates in observe mode when no engine is provided (zero-config).
+
+    Accepts all ConversableAgent kwargs without modifying their behavior —
+    they are passed through to the parent class.
+
+    Usage:
+        # Zero-config observe mode
+        agent = TealTigerAuditAgent(name="coder")
+
+        # With policy engine
+        agent = TealTigerAuditAgent(
+            name="executor",
+            engine=my_engine,
+            mode=GovernanceMode.ENFORCE,
+            budget_limit=1.0,
+        )
+
+        # Access governance state
+        print(agent.guard.is_frozen("executor"))
+        print(agent.audit_trail)
+        print(agent.summary)
+
+    Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+    """
+
+    def __init__(
+        self,
+        name: str,
+        engine: Any | None = None,
+        mode: GovernanceMode = GovernanceMode.OBSERVE,
+        budget_limit: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the TealTigerAuditAgent.
+
+        Creates the underlying ConversableAgent with all provided kwargs,
+        then attaches a TealTigerGuard instance for governance.
+
+        Args:
+            name: The agent's identity name. Used for governance tracking
+                and passed to ConversableAgent.
+            engine: Optional TealEngine instance for policy evaluation.
+                If None, the agent operates in zero-config observe mode.
+            mode: Governance operating mode (ENFORCE, MONITOR, or OBSERVE).
+                Defaults to OBSERVE for zero-config usage.
+            budget_limit: Optional per-agent cost ceiling. When exceeded,
+                subsequent tool calls are denied in ENFORCE mode. If provided,
+                calls guard.set_budget(name, budget_limit) during init.
+            **kwargs: All additional keyword arguments are passed directly
+                to ConversableAgent.__init__ without modification.
+        """
+        # Pass name and all kwargs through to ConversableAgent
+        super().__init__(name=name, **kwargs)
+
+        # Create and attach the TealTigerGuard interceptor
+        self._guard = TealTigerGuard(
+            engine=engine,
+            mode=mode,
+        )
+        self._guard.attach(self)
+
+        # Set per-agent budget if specified
+        if budget_limit is not None:
+            self._guard.set_budget(self.name, budget_limit)
+
+    @property
+    def guard(self) -> TealTigerGuard:
+        """Return the attached TealTigerGuard instance.
+
+        Provides access to the full guard API including freeze/unfreeze,
+        budget management, and decision resolution.
+
+        Returns:
+            The TealTigerGuard governing this agent.
+
+        Requirements: 2.1
+        """
+        return self._guard
+
+    @property
+    def audit_trail(self) -> list[AuditEntry]:
+        """Return the ordered list of AuditEntry objects for this agent.
+
+        Delegates to the guard's audit_trail, which contains entries
+        for all governance evaluations on this agent (tool calls,
+        messages, freeze/unfreeze events, budget operations).
+
+        Returns:
+            Ordered list of AuditEntry objects.
+
+        Requirements: 2.4
+        """
+        return self._guard.audit_trail
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        """Return cost and call statistics grouped by tool name.
+
+        Aggregates the audit trail into a summary dict containing:
+        - "tools": dict mapping tool names to {"calls": int, "cost": float}
+        - "total_cost": float total cost across all tools
+        - "total_calls": int total number of tool call evaluations
+
+        Returns:
+            A dict with structure:
+            {
+                "tools": {
+                    "run_code": {"calls": 5, "cost": 0.03},
+                    "web_search": {"calls": 3, "cost": 0.01},
+                    ...
+                },
+                "total_cost": 0.15,
+                "total_calls": 12,
+            }
+
+        Requirements: 2.5
+        """
+        tools: dict[str, dict[str, Any]] = {}
+        total_cost: float = 0.0
+        total_calls: int = 0
+
+        for entry in self._guard.audit_trail:
+            # Only count tool_call action kinds for summary
+            if entry.action_kind != "tool_call":
+                continue
+
+            tool_name = entry.tool_name or "unknown"
+            total_calls += 1
+            total_cost += entry.cost_tracked
+
+            if tool_name not in tools:
+                tools[tool_name] = {"calls": 0, "cost": 0.0}
+
+            tools[tool_name]["calls"] += 1
+            tools[tool_name]["cost"] += entry.cost_tracked
+
+        return {
+            "tools": tools,
+            "total_cost": total_cost,
+            "total_calls": total_calls,
+        }

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/budget_manager.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/budget_manager.py
@@ -1,0 +1,220 @@
+"""BudgetStateManager — per-agent budget tracking and enforcement.
+
+Tracks cumulative cost per agent identity with configurable budget limits.
+Emits BUDGET_WARNING when an agent's spend crosses 80% of its limit.
+Maintains the invariant: remaining_budget = budget_limit - current_spend.
+
+Requirements covered: 18.1, 18.2, 18.4, 18.5
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from ag2_tealtiger.types import BudgetState
+
+
+@dataclass
+class BudgetCheckResult:
+    """Result of a budget check for an agent.
+
+    Attributes:
+        exceeded: Whether the agent's budget limit has been exceeded.
+        remaining: Remaining budget (None if no limit configured).
+        warning: Whether the 80% threshold warning was triggered.
+    """
+
+    exceeded: bool
+    remaining: float | None
+    warning: bool
+
+
+# Type alias for budget warning callbacks
+BudgetWarningCallback = Callable[[str, float, float], None]
+
+
+class BudgetStateManager:
+    """Per-agent budget tracking and enforcement.
+
+    Tracks cumulative cost per agent with configurable budget limits.
+    Emits a BUDGET_WARNING (via callback or returned flag) when
+    cumulative_cost crosses 80% of the configured budget_limit.
+
+    The core invariant maintained:
+        remaining_budget = budget_limit - current_spend
+
+    Usage:
+        manager = BudgetStateManager()
+        manager.set_limit("agent-1", 10.0)
+        manager.track_cost("agent-1", 2.5)
+        state = manager.get_state("agent-1")
+        # state.remaining_budget == 7.5
+    """
+
+    # Warning threshold: emit BUDGET_WARNING at 80% of limit
+    WARNING_THRESHOLD: float = 0.80
+
+    def __init__(
+        self,
+        on_budget_warning: BudgetWarningCallback | None = None,
+    ) -> None:
+        """Initialize the budget state manager.
+
+        Args:
+            on_budget_warning: Optional callback invoked when an agent's spend
+                crosses 80% of its limit. Receives (agent_id, current_spend, budget_limit).
+        """
+        self._states: dict[str, BudgetState] = {}
+        self._on_budget_warning = on_budget_warning
+
+    def _ensure_state(self, agent_id: str) -> BudgetState:
+        """Get or create the BudgetState for an agent."""
+        if agent_id not in self._states:
+            self._states[agent_id] = BudgetState(
+                agent_id=agent_id,
+                budget_limit=None,
+                current_spend=0.0,
+                remaining_budget=None,
+                warning_emitted=False,
+            )
+        return self._states[agent_id]
+
+    def _compute_remaining(self, state: BudgetState) -> float | None:
+        """Compute remaining budget. Returns None if no limit set."""
+        if state.budget_limit is None:
+            return None
+        return state.budget_limit - state.current_spend
+
+    def track_cost(self, agent_id: str, cost: float) -> BudgetCheckResult:
+        """Accumulate cost for an agent and check budget status.
+
+        Adds the given cost to the agent's cumulative spend and checks
+        whether the 80% warning threshold has been crossed.
+
+        Args:
+            agent_id: The identity of the agent incurring cost.
+            cost: The cost amount to add (must be >= 0).
+
+        Returns:
+            BudgetCheckResult with current exceeded/warning status.
+
+        Raises:
+            ValueError: If cost is negative.
+        """
+        if cost < 0:
+            raise ValueError(f"Cost must be non-negative, got {cost}")
+
+        state = self._ensure_state(agent_id)
+        state.current_spend += cost
+        state.remaining_budget = self._compute_remaining(state)
+
+        # Check warning threshold
+        warning = False
+        if state.budget_limit is not None and not state.warning_emitted:
+            threshold_amount = state.budget_limit * self.WARNING_THRESHOLD
+            if state.current_spend >= threshold_amount:
+                state.warning_emitted = True
+                warning = True
+                if self._on_budget_warning is not None:
+                    self._on_budget_warning(
+                        agent_id, state.current_spend, state.budget_limit
+                    )
+
+        # Check exceeded
+        exceeded = False
+        if state.budget_limit is not None:
+            exceeded = state.current_spend > state.budget_limit
+
+        return BudgetCheckResult(
+            exceeded=exceeded,
+            remaining=state.remaining_budget,
+            warning=warning,
+        )
+
+    def get_state(self, agent_id: str) -> BudgetState:
+        """Return current budget state for an agent.
+
+        The returned BudgetState maintains the invariant:
+            remaining_budget = budget_limit - current_spend
+
+        If no budget limit is configured, remaining_budget is None.
+
+        Args:
+            agent_id: The identity of the agent.
+
+        Returns:
+            BudgetState with current spend, limit, and remaining budget.
+        """
+        state = self._ensure_state(agent_id)
+        state.remaining_budget = self._compute_remaining(state)
+        return state
+
+    def check_budget(self, agent_id: str) -> BudgetCheckResult:
+        """Check if an agent's budget has been exceeded.
+
+        Does NOT modify state or emit warnings — use track_cost for that.
+
+        Args:
+            agent_id: The identity of the agent.
+
+        Returns:
+            BudgetCheckResult indicating exceeded status and remaining budget.
+        """
+        state = self._ensure_state(agent_id)
+        remaining = self._compute_remaining(state)
+
+        exceeded = False
+        if state.budget_limit is not None:
+            exceeded = state.current_spend > state.budget_limit
+
+        # Report warning status (whether it was already emitted)
+        warning = state.warning_emitted
+
+        return BudgetCheckResult(
+            exceeded=exceeded,
+            remaining=remaining,
+            warning=warning,
+        )
+
+    def set_limit(self, agent_id: str, limit: float) -> None:
+        """Configure a budget limit for an agent.
+
+        Args:
+            agent_id: The identity of the agent.
+            limit: The budget limit to set (must be > 0).
+
+        Raises:
+            ValueError: If limit is not positive.
+        """
+        if limit <= 0:
+            raise ValueError(f"Budget limit must be positive, got {limit}")
+
+        state = self._ensure_state(agent_id)
+        state.budget_limit = limit
+        state.remaining_budget = self._compute_remaining(state)
+
+        # Re-check warning threshold with new limit
+        # (warning might need re-emission if limit was lowered)
+        if not state.warning_emitted:
+            threshold_amount = state.budget_limit * self.WARNING_THRESHOLD
+            if state.current_spend >= threshold_amount:
+                state.warning_emitted = True
+                if self._on_budget_warning is not None:
+                    self._on_budget_warning(
+                        agent_id, state.current_spend, state.budget_limit
+                    )
+
+    def reset(self, agent_id: str) -> None:
+        """Reset an agent's spend to zero.
+
+        Preserves the configured budget_limit but resets current_spend
+        and warning_emitted state.
+
+        Args:
+            agent_id: The identity of the agent to reset.
+        """
+        state = self._ensure_state(agent_id)
+        state.current_spend = 0.0
+        state.warning_emitted = False
+        state.remaining_budget = self._compute_remaining(state)

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/decision_manager.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/decision_manager.py
@@ -1,0 +1,197 @@
+"""DecisionReceiptManager — manages governance decision receipts with expiry and revalidation.
+
+Handles the lifecycle of governance decisions including:
+- Creating receipts with expiry timestamps and revalidation conditions
+- Validating whether a receipt is still valid (not expired)
+- Evaluating revalidation conditions against current context
+- Manually expiring receipts with a reason
+
+Requirements: 16.1, 16.2, 16.3, 16.4, 16.5, 16.7
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from ag2_tealtiger.types import DecisionReceipt, GovernanceAction, RevalidationCondition
+
+
+class DecisionReceiptManager:
+    """Manages governance decision receipts with expiry and revalidation.
+
+    Stores receipts in an internal dict keyed by decision_id. Supports
+    configurable default expiry when expires_at is not specified by policy.
+
+    Args:
+        default_expiry_seconds: Default expiry duration in seconds applied
+            to ALLOW decisions when expires_at is not specified. Defaults to 3600 (1 hour).
+    """
+
+    def __init__(self, default_expiry_seconds: int = 3600) -> None:
+        self.default_expiry_seconds = default_expiry_seconds
+        self._receipts: dict[str, DecisionReceipt] = {}
+
+    def create_receipt(
+        self,
+        decision_id: str,
+        action: GovernanceAction,
+        expires_at: datetime | None = None,
+        revalidate_if: list[RevalidationCondition] | None = None,
+    ) -> DecisionReceipt:
+        """Create and store a decision receipt.
+
+        If expires_at is not provided, a default expiry is applied based on
+        the configured default_expiry_seconds from the current UTC time.
+
+        Args:
+            decision_id: Unique identifier for this governance decision.
+            action: The governance action (ALLOW, DENY, MODIFY, REFER).
+            expires_at: Optional ISO 8601 expiry timestamp. If None, default
+                expiry is applied.
+            revalidate_if: Optional list of conditions that trigger re-evaluation.
+
+        Returns:
+            The created DecisionReceipt instance.
+        """
+        now = datetime.now(timezone.utc)
+
+        if expires_at is None:
+            expires_at = now + timedelta(seconds=self.default_expiry_seconds)
+
+        receipt = DecisionReceipt(
+            decision_id=decision_id,
+            action=action,
+            issued_at=now,
+            expires_at=expires_at,
+            revalidate_if=revalidate_if if revalidate_if is not None else [],
+            is_expired=False,
+        )
+
+        self._receipts[decision_id] = receipt
+        return receipt
+
+    def is_valid(self, decision_id: str) -> bool:
+        """Check whether a decision receipt is still valid (not expired).
+
+        A receipt is valid if:
+        - It exists in the store
+        - It has not been manually expired
+        - The current time has not exceeded its expires_at timestamp
+
+        Args:
+            decision_id: The decision identifier to check.
+
+        Returns:
+            True if the receipt is valid, False otherwise.
+        """
+        receipt = self._receipts.get(decision_id)
+        if receipt is None:
+            return False
+
+        if receipt.is_expired:
+            return False
+
+        now = datetime.now(timezone.utc)
+        if receipt.expires_at is not None and now >= receipt.expires_at:
+            # Mark as expired for future checks
+            receipt.is_expired = True
+            return False
+
+        return True
+
+    def check_revalidation(self, decision_id: str, current_context: dict) -> bool:
+        """Evaluate revalidation conditions against current context.
+
+        Checks each RevalidationCondition attached to the receipt. If any
+        condition is met, returns True indicating re-evaluation is needed.
+
+        Supported condition types:
+        - "cost_exceeded": Triggered when current_context["cost"] >= threshold
+        - "time_elapsed": Triggered when current_context["elapsed_seconds"] >= threshold
+        - "context_changed": Triggered when current_context["context_hash"] != threshold
+            (threshold holds the original context hash)
+
+        Args:
+            decision_id: The decision identifier to check revalidation for.
+            current_context: Dict containing current state values to evaluate
+                conditions against.
+
+        Returns:
+            True if any revalidation condition is met (re-evaluation needed),
+            False if no conditions are met or the receipt doesn't exist.
+        """
+        receipt = self._receipts.get(decision_id)
+        if receipt is None:
+            return False
+
+        if not receipt.revalidate_if:
+            return False
+
+        for condition in receipt.revalidate_if:
+            if self._evaluate_condition(condition, current_context):
+                return True
+
+        return False
+
+    def expire(self, decision_id: str, reason: str) -> None:
+        """Manually expire a decision receipt.
+
+        Marks the receipt as expired and records the reason in the
+        execution_outcome field.
+
+        Args:
+            decision_id: The decision identifier to expire.
+            reason: The reason for manual expiry (e.g., "RECEIPT_EXPIRED",
+                "REVALIDATION_TRIGGERED").
+
+        Raises:
+            KeyError: If the decision_id is not found in the store.
+        """
+        receipt = self._receipts.get(decision_id)
+        if receipt is None:
+            raise KeyError(f"Decision receipt not found: {decision_id}")
+
+        receipt.is_expired = True
+        receipt.execution_outcome = reason
+
+    def get_receipt(self, decision_id: str) -> DecisionReceipt | None:
+        """Retrieve a receipt by decision_id.
+
+        Args:
+            decision_id: The decision identifier to look up.
+
+        Returns:
+            The DecisionReceipt if found, None otherwise.
+        """
+        return self._receipts.get(decision_id)
+
+    def _evaluate_condition(
+        self, condition: RevalidationCondition, current_context: dict
+    ) -> bool:
+        """Evaluate a single revalidation condition against current context.
+
+        Args:
+            condition: The revalidation condition to evaluate.
+            current_context: Dict with current state values.
+
+        Returns:
+            True if the condition is met, False otherwise.
+        """
+        condition_type = condition.condition_type
+
+        if condition_type == "cost_exceeded":
+            cost = current_context.get("cost")
+            if cost is not None and cost >= condition.threshold:
+                return True
+
+        elif condition_type == "time_elapsed":
+            elapsed = current_context.get("elapsed_seconds")
+            if elapsed is not None and elapsed >= condition.threshold:
+                return True
+
+        elif condition_type == "context_changed":
+            context_hash = current_context.get("context_hash")
+            if context_hash is not None and context_hash != condition.threshold:
+                return True
+
+        return False

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/exceptions.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/exceptions.py
@@ -1,0 +1,59 @@
+"""Exception hierarchy for ag2-tealtiger.
+
+Provides typed exceptions for governance denials, budget enforcement,
+freeze operations, and escalation states.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ag2_tealtiger.types import EscalationReceipt
+
+
+class AG2TealTigerError(Exception):
+    """Base exception for ag2-tealtiger package."""
+
+    pass
+
+
+class GovernanceDenyError(AG2TealTigerError):
+    """Raised when a governance policy denies the request in ENFORCE mode.
+
+    Contains the full decision dict including reason, risk_score,
+    reason_codes, and correlation_id for audit trail lookup.
+    """
+
+    def __init__(self, decision: dict[str, Any]) -> None:
+        self.decision = decision
+        super().__init__(f"Governance DENY: {decision.get('reason', 'Policy violation')}")
+
+
+class DecisionExpiredError(AG2TealTigerError):
+    """Raised when a cached decision receipt has expired."""
+
+    def __init__(self, decision_id: str, expired_at: str) -> None:
+        self.decision_id = decision_id
+        self.expired_at = expired_at
+        super().__init__(f"Decision {decision_id} expired at {expired_at}")
+
+
+class BudgetExceededError(GovernanceDenyError):
+    """Raised when an agent's budget limit is exceeded in ENFORCE mode."""
+
+    pass
+
+
+class AgentFrozenError(GovernanceDenyError):
+    """Raised when a frozen agent attempts an operation in ENFORCE mode."""
+
+    pass
+
+
+class EscalationPendingError(AG2TealTigerError):
+    """Raised when an action is suspended pending REFER resolution."""
+
+    def __init__(self, escalation_receipt: EscalationReceipt) -> None:
+        self.escalation_receipt = escalation_receipt
+        super().__init__(f"Action suspended: REFER {escalation_receipt.decision_id}")

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/governed_groupchat.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/governed_groupchat.py
@@ -1,0 +1,339 @@
+"""GovernedGroupChat — GroupChat extension with governance-enforced speaker selection.
+
+Wraps AG2's GroupChat to apply governance policies to speaker selection.
+Frozen agents, over-budget agents, and policy-denied agents are skipped
+during speaker selection without disrupting the conversation flow.
+
+Each selection round is recorded in a SpeakerSelectionAuditEntry for
+full auditability of who was considered, what decision was made for each
+candidate, and who was ultimately selected.
+
+Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 15.1, 15.3, 18.6
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    SpeakerSelectionAuditEntry,
+)
+
+
+class GovernedGroupChat:
+    """GroupChat with governance-enforced speaker selection.
+
+    Wraps the standard speaker selection strategy to evaluate
+    candidates against TealEngine policies before granting turns.
+
+    Speaker selection proceeds through candidates in order:
+    1. Frozen agents are skipped without TealEngine invocation (AGENT_FROZEN)
+    2. Over-budget agents are skipped without TealEngine invocation (BUDGET_EXCEEDED)
+    3. Remaining candidates are evaluated via TealEngine:
+       - ALLOW: agent is selected as speaker
+       - DENY: agent is skipped
+       - REFER: agent action is suspended, continue with others
+    4. If no candidate is eligible, the round terminates with ALL_SPEAKERS_DENIED
+
+    Each selection round produces a SpeakerSelectionAuditEntry recording
+    the full evaluation trace.
+    """
+
+    def __init__(
+        self,
+        agents: list[Any] | None = None,
+        guard: Any | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        max_round: int = 10,
+        speaker_selection_method: str = "auto",
+        group_chat_id: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize GovernedGroupChat.
+
+        Args:
+            agents: List of ConversableAgent instances participating in the group.
+            guard: TealTigerGuard instance for governance evaluation.
+            messages: Initial messages for the group chat.
+            max_round: Maximum number of conversation rounds.
+            speaker_selection_method: AG2 speaker selection strategy (auto, round_robin, etc.)
+            group_chat_id: Optional explicit group chat ID. Auto-generated if not provided.
+            **kwargs: Additional kwargs passed to parent GroupChat.
+        """
+        self.agents = agents or []
+        self.guard = guard
+        self.messages = messages or []
+        self.max_round = max_round
+        self.speaker_selection_method = speaker_selection_method
+        self.group_chat_id = group_chat_id or str(uuid.uuid4())
+        self._speaker_selection_audit: list[SpeakerSelectionAuditEntry] = []
+        self._kwargs = kwargs
+
+    @property
+    def speaker_selection_audit(self) -> list[SpeakerSelectionAuditEntry]:
+        """Return the ordered list of speaker selection audit entries.
+
+        Each entry records one selection round including:
+        - All candidates evaluated with their decisions
+        - The final selected speaker (or None if all denied)
+        - Reason codes summarizing the round outcome
+
+        Returns:
+            Ordered list of SpeakerSelectionAuditEntry objects.
+
+        Requirements: 3.4
+        """
+        return list(self._speaker_selection_audit)
+
+    def select_speaker(
+        self,
+        last_speaker: Any = None,
+        selector: Any = None,
+    ) -> Any | None:
+        """Select the next speaker with governance evaluation.
+
+        Evaluates each candidate agent against governance policies:
+        1. Skip frozen agents (AGENT_FROZEN) - no TealEngine call
+        2. Skip over-budget agents (BUDGET_EXCEEDED) - no TealEngine call
+        3. Evaluate via TealEngine for remaining candidates
+        4. Select first ALLOW candidate
+        5. Terminate with ALL_SPEAKERS_DENIED if none eligible
+
+        Records a SpeakerSelectionAuditEntry for each round.
+
+        Args:
+            last_speaker: The agent who spoke last (used for round-robin, etc.)
+            selector: The agent performing the selection (GroupChatManager).
+
+        Returns:
+            The selected ConversableAgent, or None if all candidates denied.
+
+        Requirements: 3.1, 3.2, 3.3, 3.5, 15.1, 15.3, 18.6
+        """
+        round_id = str(uuid.uuid4())
+        timestamp_ms = time.time() * 1000
+        candidates_evaluated: list[dict[str, Any]] = []
+        selected_speaker: str | None = None
+        selected_agent: Any | None = None
+        round_reason_codes: list[str] = []
+
+        # Get candidate ordering (exclude last_speaker if applicable)
+        candidates = self._get_candidates(last_speaker)
+
+        for agent in candidates:
+            agent_id = self._get_agent_id(agent)
+
+            # Step 1: Check frozen state — skip without TealEngine call
+            if self.guard and self.guard.is_frozen(agent_id):
+                candidates_evaluated.append({
+                    "agent_id": agent_id,
+                    "decision": GovernanceAction.DENY.value,
+                    "reason": "AGENT_FROZEN",
+                })
+                if "AGENT_FROZEN" not in round_reason_codes:
+                    round_reason_codes.append("AGENT_FROZEN")
+                continue
+
+            # Step 2: Check budget state — skip without TealEngine call
+            if self.guard and self._is_over_budget(agent_id):
+                candidates_evaluated.append({
+                    "agent_id": agent_id,
+                    "decision": GovernanceAction.DENY.value,
+                    "reason": "BUDGET_EXCEEDED",
+                })
+                if "BUDGET_EXCEEDED" not in round_reason_codes:
+                    round_reason_codes.append("BUDGET_EXCEEDED")
+                continue
+
+            # Step 3: Evaluate via TealEngine (if available and in policy mode)
+            if self.guard and self._has_engine():
+                decision = self._evaluate_candidate(agent_id)
+                action = decision.get("action", GovernanceAction.ALLOW.value)
+                reason = decision.get("reason", "")
+                reason_codes = decision.get("reason_codes", [])
+
+                if action == GovernanceAction.ALLOW.value:
+                    candidates_evaluated.append({
+                        "agent_id": agent_id,
+                        "decision": GovernanceAction.ALLOW.value,
+                        "reason": reason or "SPEAKER_ALLOWED",
+                    })
+                    selected_speaker = agent_id
+                    selected_agent = agent
+                    break
+
+                elif action == GovernanceAction.DENY.value:
+                    deny_reason = reason_codes[0] if reason_codes else "POLICY_DENIED"
+                    candidates_evaluated.append({
+                        "agent_id": agent_id,
+                        "decision": GovernanceAction.DENY.value,
+                        "reason": deny_reason,
+                    })
+                    if "POLICY_DENIED" not in round_reason_codes:
+                        round_reason_codes.append("POLICY_DENIED")
+                    continue
+
+                elif action == GovernanceAction.REFER.value:
+                    candidates_evaluated.append({
+                        "agent_id": agent_id,
+                        "decision": GovernanceAction.REFER.value,
+                        "reason": reason or "REQUIRES_REVIEW",
+                    })
+                    if "REFER_SUSPENDED" not in round_reason_codes:
+                        round_reason_codes.append("REFER_SUSPENDED")
+                    continue
+
+                else:
+                    # Unknown action — treat as deny for safety
+                    candidates_evaluated.append({
+                        "agent_id": agent_id,
+                        "decision": GovernanceAction.DENY.value,
+                        "reason": f"UNKNOWN_ACTION_{action}",
+                    })
+                    continue
+            else:
+                # No engine / observe mode — allow the candidate
+                candidates_evaluated.append({
+                    "agent_id": agent_id,
+                    "decision": GovernanceAction.ALLOW.value,
+                    "reason": "NO_ENGINE_PASSTHROUGH",
+                })
+                selected_speaker = agent_id
+                selected_agent = agent
+                break
+
+        # If no speaker selected, all candidates were denied
+        if selected_speaker is None:
+            if "ALL_SPEAKERS_DENIED" not in round_reason_codes:
+                round_reason_codes.append("ALL_SPEAKERS_DENIED")
+
+        # Record the speaker selection audit entry
+        audit_entry = SpeakerSelectionAuditEntry(
+            round_id=round_id,
+            timestamp_ms=timestamp_ms,
+            candidates_evaluated=candidates_evaluated,
+            selected_speaker=selected_speaker,
+            reason_codes=round_reason_codes,
+            group_chat_id=self.group_chat_id,
+        )
+        self._speaker_selection_audit.append(audit_entry)
+
+        return selected_agent
+
+    def _get_candidates(self, last_speaker: Any = None) -> list[Any]:
+        """Get the candidate agents for speaker selection.
+
+        Filters based on the speaker_selection_method. For simplicity,
+        returns all agents except the last speaker when in round_robin
+        or auto mode.
+
+        Args:
+            last_speaker: The agent who spoke last.
+
+        Returns:
+            Ordered list of candidate agents.
+        """
+        if last_speaker is None:
+            return list(self.agents)
+
+        # Exclude last speaker from candidates (standard GroupChat behavior)
+        last_id = self._get_agent_id(last_speaker)
+        return [a for a in self.agents if self._get_agent_id(a) != last_id]
+
+    def _get_agent_id(self, agent: Any) -> str:
+        """Extract agent identity string from an agent object.
+
+        Supports both AG2 ConversableAgent (has .name) and
+        mock agents used in testing.
+
+        Args:
+            agent: Agent object with a name attribute or string identity.
+
+        Returns:
+            Agent identity string.
+        """
+        if hasattr(agent, "name"):
+            return agent.name
+        return str(agent)
+
+    def _has_engine(self) -> bool:
+        """Check if the guard has a TealEngine configured.
+
+        Returns:
+            True if the guard has an engine (policy mode), False otherwise.
+        """
+        if self.guard is None:
+            return False
+        return getattr(self.guard, "engine", None) is not None
+
+    def _is_over_budget(self, agent_id: str) -> bool:
+        """Check if an agent has exceeded its budget limit.
+
+        Args:
+            agent_id: The agent identity to check.
+
+        Returns:
+            True if the agent's cumulative cost exceeds its budget limit.
+        """
+        if self.guard is None:
+            return False
+        budget_state = self.guard.get_budget_state(agent_id)
+        if budget_state.budget_limit is None:
+            return False
+        return budget_state.current_spend >= budget_state.budget_limit
+
+    def _evaluate_candidate(self, agent_id: str) -> dict[str, Any]:
+        """Evaluate a candidate speaker against TealEngine policies.
+
+        Calls the guard's engine to evaluate whether this agent is
+        permitted to speak next.
+
+        Args:
+            agent_id: The candidate agent identity.
+
+        Returns:
+            Decision dict with action, reason, reason_codes, risk_score.
+        """
+        if self.guard is None or not self._has_engine():
+            return {"action": GovernanceAction.ALLOW.value, "reason": "no_engine"}
+
+        engine = getattr(self.guard, "engine", None)
+        if engine is None:
+            return {"action": GovernanceAction.ALLOW.value, "reason": "no_engine"}
+
+        try:
+            result = engine.evaluate(
+                tool_name=None,
+                args=None,
+                context={
+                    "agent_id": agent_id,
+                    "action_kind": "speaker_selection",
+                    "group_chat_id": self.group_chat_id,
+                    "framework": "ag2",
+                },
+            )
+            return result
+        except Exception:
+            # On engine error, apply guard's fail behavior
+            from ag2_tealtiger.types import GovernanceMode
+
+            mode = getattr(self.guard, "mode", GovernanceMode.OBSERVE)
+            if mode == GovernanceMode.ENFORCE:
+                # Fail-closed in ENFORCE mode
+                return {
+                    "action": GovernanceAction.DENY.value,
+                    "reason": "Engine error during speaker evaluation",
+                    "reason_codes": ["ENGINE_ERROR", "FAIL_CLOSED"],
+                    "risk_score": 100,
+                }
+            else:
+                # Fail-open in MONITOR/OBSERVE mode
+                return {
+                    "action": GovernanceAction.ALLOW.value,
+                    "reason": "Engine error, failing open",
+                    "reason_codes": ["ENGINE_ERROR", "FAIL_OPEN"],
+                    "risk_score": 0,
+                }

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/guard.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/guard.py
@@ -1,0 +1,1585 @@
+"""TealTigerGuard — core register_reply interceptor for AG2.
+
+Deterministic governance interceptor for AG2 ConversableAgent.
+Attaches via AG2's register_reply mechanism to intercept tool calls
+and inter-agent messages before execution.
+
+Supports three operating modes:
+- OBSERVE: Zero-config tracking (cost, PII, tool usage) with no policy evaluation
+- MONITOR: Policy evaluation with logging only (fail-open)
+- ENFORCE: Policy evaluation with blocking (fail-closed)
+
+Requirements covered: 1.1, 1.2, 1.3, 1.4, 1.5, 4.1, 4.2, 4.4, 4.5, 4.6, 7.1, 7.2, 7.5, 7.6, 14.3, 15.1, 15.2, 15.8
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from ag2_tealtiger.budget_manager import BudgetStateManager
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.pii import detect_pii
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    BudgetState,
+    DenialMessage,
+    EscalationReceipt,
+    GovernanceAction,
+    GovernanceMode,
+    TEECContext,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TealTigerGuard:
+    """Deterministic governance interceptor for AG2 ConversableAgent.
+
+    Attaches via AG2's register_reply mechanism to intercept tool calls
+    and inter-agent messages before execution.
+
+    The guard evaluates governance policies in the configured mode:
+    - OBSERVE: Track cost, PII, and tool usage without blocking
+    - MONITOR: Evaluate policies, log decisions, but allow all through
+    - ENFORCE: Evaluate policies and block denied actions
+
+    Zero LLM in the governance path — all evaluation is deterministic,
+    targeting sub-5ms latency with in-process evaluation.
+
+    Usage:
+        # Zero-config observe mode
+        guard = TealTigerGuard()
+        guard.attach(my_agent)
+
+        # Policy enforcement
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        # Detach when done
+        guard.detach(agent_a)
+    """
+
+    def __init__(
+        self,
+        engine: Any | None = None,
+        mode: GovernanceMode = GovernanceMode.OBSERVE,
+        cost_per_1k_tokens: float = 0.002,
+        default_expiry_seconds: int = 3600,
+        fail_closed: bool = True,
+    ) -> None:
+        """Initialize the TealTigerGuard interceptor.
+
+        Args:
+            engine: Optional TealEngine instance for policy evaluation.
+                If None, the guard operates in observe mode regardless
+                of the mode parameter.
+            mode: Governance operating mode (ENFORCE, MONITOR, or OBSERVE).
+                Defaults to OBSERVE for zero-config usage.
+            cost_per_1k_tokens: Cost rate used for token-based cost estimation
+                in observe mode. Defaults to $0.002 per 1K tokens.
+            default_expiry_seconds: Default expiry duration in seconds for
+                decision receipts when not specified by policy. Defaults to 3600 (1 hour).
+            fail_closed: Whether to deny on engine errors in ENFORCE mode.
+                If True (default), engine exceptions result in DENY.
+                If False, engine exceptions result in ALLOW.
+        """
+        self.engine = engine
+        self.mode = mode
+        self.cost_per_1k_tokens = cost_per_1k_tokens
+        self.default_expiry_seconds = default_expiry_seconds
+        self.fail_closed = fail_closed
+
+        # ── Internal State ────────────────────────────────────────────────
+        # Per-agent frozen state (kill switch)
+        self._frozen_agents: set[str] = set()
+
+        # Ordered audit entries for all governance evaluations
+        self._audit_trail: list[AuditEntry] = []
+
+        # Per-agent budget tracking
+        self._budget_manager: BudgetStateManager = BudgetStateManager()
+
+        # Decision receipt lifecycle management
+        self._decision_manager: DecisionReceiptManager = DecisionReceiptManager(
+            default_expiry_seconds=default_expiry_seconds,
+        )
+
+        # TEEC context builder for correlation and telemetry
+        self._teec_builder: TEECContextBuilder = TEECContextBuilder()
+
+        # Monotonically increasing turn counter for _reply_hook invocations
+        self._turn_counter: int = 0
+
+        # Track which agents are currently attached (agent_name -> agent reference)
+        self._attached_agents: dict[str, Any] = {}
+
+        # Decision outcome cache for retry idempotency
+        # Maps decision_id -> outcome dict (action, reason_codes, risk_score, etc.)
+        # Enables same decision_id retries to return prior outcome without re-evaluation
+        self._decision_outcomes: dict[str, dict[str, Any]] = {}
+
+    # ── Attach / Detach ───────────────────────────────────────────────────────
+
+    def attach(self, agent: Any) -> None:
+        """Attach governance to an agent via register_reply.
+
+        Registers the interceptor reply function at the highest priority
+        position (position=0) in the agent's reply pipeline. This ensures
+        governance evaluation occurs before any other reply processing.
+
+        The same guard can be attached to multiple agents — each maintains
+        independent governance state per agent identity.
+
+        Args:
+            agent: An AG2 ConversableAgent instance to govern.
+                Must have a `name` attribute and `register_reply` method.
+
+        Raises:
+            ValueError: If the agent is already attached to this guard.
+        """
+        agent_name: str = agent.name
+
+        if agent_name in self._attached_agents:
+            raise ValueError(
+                f"Agent '{agent_name}' is already attached to this guard. "
+                f"Call detach() first to re-attach."
+            )
+
+        # Register the reply hook at highest priority (position=0)
+        agent.register_reply(
+            trigger=None,
+            reply_func=self._reply_hook,
+            position=0,
+        )
+
+        # Track the attached agent
+        self._attached_agents[agent_name] = agent
+
+    def detach(self, agent: Any) -> None:
+        """Remove governance from an agent.
+
+        Removes the registered reply function from the agent's reply pipeline
+        and clears the agent from the attached tracking dict.
+
+        Args:
+            agent: An AG2 ConversableAgent instance to detach.
+                Must have a `name` attribute and `_reply_funcs` list.
+
+        Raises:
+            ValueError: If the agent is not currently attached to this guard.
+        """
+        agent_name: str = agent.name
+
+        if agent_name not in self._attached_agents:
+            raise ValueError(
+                f"Agent '{agent_name}' is not attached to this guard."
+            )
+
+        # Remove the reply hook from the agent's reply function list
+        # AG2 stores reply funcs in _reply_funcs as a list of dicts
+        if hasattr(agent, "_reply_funcs"):
+            agent._reply_funcs = [
+                entry
+                for entry in agent._reply_funcs
+                if entry.get("reply_func") != self._reply_hook
+            ]
+
+        # Remove from tracking
+        del self._attached_agents[agent_name]
+
+    # ── Properties ────────────────────────────────────────────────────────────
+
+    @property
+    def audit_trail(self) -> list[AuditEntry]:
+        """Return the ordered list of audit entries for all governed agents."""
+        return self._audit_trail
+
+    @property
+    def attached_agents(self) -> dict[str, Any]:
+        """Return the dict of currently attached agents (name -> reference)."""
+        return dict(self._attached_agents)
+
+    def export_audit_trail(self, path: str, format: str = "jsonl") -> int:
+        """Export the audit trail to a file in the specified format.
+
+        Writes each AuditEntry as one JSON line to the file (JSONL format).
+        Handles nested dataclasses (TEECContext) via dataclasses.asdict.
+
+        Args:
+            path: File path to write the audit trail to.
+            format: Export format. Currently only "jsonl" is supported.
+
+        Returns:
+            The number of entries written.
+
+        Raises:
+            ValueError: If an unsupported format is specified.
+
+        Requirements: 12.1, 12.3, 12.4, 12.5, 13.5
+        """
+        if format != "jsonl":
+            raise ValueError(f"Unsupported export format: {format!r}. Only 'jsonl' is supported.")
+
+        entries_written = 0
+        with open(path, "w", encoding="utf-8") as f:
+            for entry in self._audit_trail:
+                entry_dict = dataclasses.asdict(entry)
+                line = json.dumps(entry_dict, ensure_ascii=False, default=str)
+                f.write(line + "\n")
+                entries_written += 1
+
+        return entries_written
+
+    # ── Per-Agent Kill Switch ─────────────────────────────────────────────────
+
+    def freeze(self, agent_id: str) -> None:
+        """Freeze an agent — block all subsequent tool calls and message sends.
+
+        A frozen agent receives DENY with reason_code "AGENT_FROZEN" and
+        risk_score 100 regardless of governance mode. Freeze is mode-independent:
+        it always blocks even in OBSERVE or MONITOR mode.
+
+        Records a freeze event in the audit trail with a timestamp.
+
+        Args:
+            agent_id: The identity of the agent to freeze.
+
+        Requirements: 4.1, 4.6
+        """
+        start_time = time.time()
+        self._frozen_agents.add(agent_id)
+        evaluation_time_ms = (time.time() - start_time) * 1000
+
+        # Record freeze event in audit trail
+        correlation_id = str(uuid.uuid4())
+        decision_id = str(uuid.uuid4())
+        timestamp_ms = time.time() * 1000
+
+        teec = TEECContext(
+            namespace="teec.ag2",
+            conversation_id=self._teec_builder.conversation_id,
+            turn_id=self._teec_builder.current_turn_id,
+            agent_role=agent_id,
+            decision_id=decision_id,
+            decision_source="default_mode",
+        )
+
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            timestamp_ms=timestamp_ms,
+            action=GovernanceAction.DENY.value,
+            action_kind=ActionKind.FREEZE.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=f"Agent '{agent_id}' frozen",
+            reason_codes=["AGENT_FROZEN"],
+            risk_score=100,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+        )
+        self._audit_trail.append(entry)
+
+    def unfreeze(self, agent_id: str) -> None:
+        """Unfreeze a previously frozen agent — restore normal governance evaluation.
+
+        After unfreezing, the agent's subsequent tool calls and messages will be
+        evaluated against policies normally (not auto-denied).
+
+        Records an unfreeze event in the audit trail with a timestamp.
+
+        Args:
+            agent_id: The identity of the agent to unfreeze.
+
+        Requirements: 4.4, 4.6
+        """
+        start_time = time.time()
+        self._frozen_agents.discard(agent_id)
+        evaluation_time_ms = (time.time() - start_time) * 1000
+
+        # Record unfreeze event in audit trail
+        correlation_id = str(uuid.uuid4())
+        decision_id = str(uuid.uuid4())
+        timestamp_ms = time.time() * 1000
+
+        teec = TEECContext(
+            namespace="teec.ag2",
+            conversation_id=self._teec_builder.conversation_id,
+            turn_id=self._teec_builder.current_turn_id,
+            agent_role=agent_id,
+            decision_id=decision_id,
+            decision_source="default_mode",
+        )
+
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            timestamp_ms=timestamp_ms,
+            action=GovernanceAction.ALLOW.value,
+            action_kind=ActionKind.FREEZE.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=f"Agent '{agent_id}' unfrozen",
+            reason_codes=["AGENT_UNFROZEN"],
+            risk_score=0,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+        )
+        self._audit_trail.append(entry)
+
+    def is_frozen(self, agent_id: str) -> bool:
+        """Check whether an agent is currently frozen.
+
+        Args:
+            agent_id: The identity of the agent to check.
+
+        Returns:
+            True if the agent is frozen, False otherwise.
+        """
+        return agent_id in self._frozen_agents
+
+    # ── Budget Management ─────────────────────────────────────────────────────
+
+    def set_budget(self, agent_id: str, limit: float) -> None:
+        """Set a budget limit for an agent.
+
+        Delegates to the internal BudgetStateManager. When the agent's
+        cumulative cost exceeds this limit, subsequent tool calls will be
+        denied with reason_code "BUDGET_EXCEEDED" in ENFORCE mode.
+
+        Args:
+            agent_id: The identity of the agent.
+            limit: The budget limit to set (must be > 0).
+
+        Raises:
+            ValueError: If limit is not positive.
+
+        Requirements: 18.3, 18.7
+        """
+        self._budget_manager.set_limit(agent_id, limit)
+
+    def get_budget_state(self, agent_id: str) -> BudgetState:
+        """Get the current budget state for an agent.
+
+        Returns per-agent budget state including current_spend, budget_limit,
+        and remaining_budget through the audit trail and summary properties.
+
+        Args:
+            agent_id: The identity of the agent.
+
+        Returns:
+            BudgetState with current spend, limit, and remaining budget.
+
+        Requirements: 18.4
+        """
+        return self._budget_manager.get_state(agent_id)
+
+    def reset_budget(self, agent_id: str) -> None:
+        """Reset an agent's budget spend to zero.
+
+        Preserves the configured budget_limit but resets current_spend
+        and warning state. Records the reset in the audit trail.
+
+        Args:
+            agent_id: The identity of the agent to reset.
+
+        Requirements: 18.7, 18.8
+        """
+        self._budget_manager.reset(agent_id)
+
+        # Record budget reset in audit trail
+        correlation_id = str(uuid.uuid4())
+        decision_id = str(uuid.uuid4())
+        timestamp_ms = time.time() * 1000
+
+        teec = TEECContext(
+            namespace="teec.ag2",
+            conversation_id=self._teec_builder.conversation_id,
+            turn_id=self._teec_builder.current_turn_id,
+            agent_role=agent_id,
+            decision_id=decision_id,
+            decision_source="default_mode",
+        )
+
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            timestamp_ms=timestamp_ms,
+            action=GovernanceAction.ALLOW.value,
+            action_kind=ActionKind.BUDGET_CHANGE.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=f"Budget reset for agent '{agent_id}'",
+            reason_codes=["BUDGET_RESET"],
+            risk_score=0,
+            evaluation_time_ms=0.0,
+            teec=teec,
+        )
+        self._audit_trail.append(entry)
+
+    # ── Decision Resolution ───────────────────────────────────────────────────
+
+    def resolve_refer(
+        self, decision_id: str, resolution: str, approval_id: str
+    ) -> dict[str, Any]:
+        """Resolve a REFER escalation — resume or deny the suspended action.
+
+        Looks up the decision receipt by decision_id, applies the resolution,
+        and records an audit entry. Handles retry idempotency: if the same
+        decision_id has already been resolved, returns the prior outcome
+        without duplicating side effects.
+
+        Args:
+            decision_id: The decision_id of the REFER escalation to resolve.
+            resolution: One of "ALLOW" or "DENY" indicating the reviewer's decision.
+            approval_id: Identifier linking the reviewer's decision to the original.
+
+        Returns:
+            A dict with the resolution outcome:
+            {
+                "decision_id": str,
+                "action": str,
+                "approval_id": str,
+                "reason_codes": list[str],
+                "already_resolved": bool,
+            }
+
+        Raises:
+            KeyError: If the decision_id is not found in the decision receipt store.
+            ValueError: If the resolution is not "ALLOW" or "DENY".
+
+        Requirements: 11.1, 11.5, 15.5, 15.6
+        """
+        # ── Retry idempotency: return prior outcome if already resolved ───
+        # A REFER decision with pending status is NOT yet resolved, so we
+        # allow the resolution to proceed. Only return early if the decision
+        # was already resolved (action is ALLOW or DENY after resolution).
+        if decision_id in self._decision_outcomes:
+            prior = self._decision_outcomes[decision_id]
+            if prior.get("action") != GovernanceAction.REFER.value:
+                # Already resolved — return the prior resolution outcome
+                return {**prior, "already_resolved": True}
+
+        # ── Validate resolution ───────────────────────────────────────────
+        resolution_upper = resolution.upper()
+        if resolution_upper not in ("ALLOW", "DENY"):
+            raise ValueError(
+                f"Invalid resolution '{resolution}'. Must be 'ALLOW' or 'DENY'."
+            )
+
+        # ── Look up the decision receipt ──────────────────────────────────
+        receipt = self._decision_manager.get_receipt(decision_id)
+        if receipt is None:
+            raise KeyError(f"Decision receipt not found: {decision_id}")
+
+        # ── Apply resolution ──────────────────────────────────────────────
+        start_time = time.perf_counter()
+        correlation_id = str(uuid.uuid4())
+        timestamp_ms = time.time() * 1000
+
+        teec = TEECContext(
+            namespace="teec.ag2",
+            conversation_id=self._teec_builder.conversation_id,
+            turn_id=self._teec_builder.current_turn_id,
+            decision_id=decision_id,
+            decision_source="human_reviewer",
+            approval_id=approval_id,
+        )
+
+        if resolution_upper == "ALLOW":
+            # Mark receipt with approval_id, record audit entry
+            receipt.approval_id = approval_id
+            receipt.execution_outcome = "approved"
+            receipt.is_expired = False
+
+            action = GovernanceAction.ALLOW.value
+            reason_codes = ["REFER_RESOLVED"]
+            reason = f"REFER resolved: ALLOW by reviewer (approval_id={approval_id})"
+
+        else:  # DENY
+            # Expire the receipt with REFER_DENIED reason
+            self._decision_manager.expire(decision_id, "REFER_DENIED")
+
+            action = GovernanceAction.DENY.value
+            reason_codes = ["REFER_DENIED"]
+            reason = f"REFER resolved: DENY by reviewer (approval_id={approval_id})"
+
+        evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+
+        # Record audit entry
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            timestamp_ms=timestamp_ms,
+            action=action,
+            action_kind=ActionKind.TOOL_CALL.value,
+            mode=self.mode.value,
+            agent_id="system",  # Resolution is a system-level action
+            reason=reason,
+            reason_codes=reason_codes,
+            risk_score=0 if resolution_upper == "ALLOW" else 100,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+        )
+        self._audit_trail.append(entry)
+
+        # ── Store outcome for retry idempotency ───────────────────────────
+        outcome: dict[str, Any] = {
+            "decision_id": decision_id,
+            "action": action,
+            "approval_id": approval_id,
+            "reason_codes": reason_codes,
+            "already_resolved": False,
+        }
+        self._decision_outcomes[decision_id] = outcome
+
+        return outcome
+
+    def get_prior_outcome(self, decision_id: str) -> dict[str, Any] | None:
+        """Look up a previously recorded decision outcome by decision_id.
+
+        Used for retry idempotency — callers can check if a decision has
+        already been evaluated and retrieve the prior result without
+        triggering duplicate evaluation or side effects.
+
+        Args:
+            decision_id: The decision identifier to look up.
+
+        Returns:
+            The prior outcome dict if found, None otherwise.
+
+        Requirements: 11.1, 11.5
+        """
+        return self._decision_outcomes.get(decision_id)
+
+    # ── Internal: Reply Hook ──────────────────────────────────────────────────
+
+    def _reply_hook(
+        self,
+        recipient: Any,
+        messages: list[dict[str, Any]] | None,
+        sender: Any,
+        config: Any,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """AG2 reply hook — governance interception point.
+
+        This method matches AG2's expected reply function signature:
+            (recipient, messages, sender, config) -> (bool, reply_or_none)
+
+        Flow:
+        1. Start performance timer
+        2. Increment turn_id
+        3. Determine agent_id from recipient
+        4. Check frozen state — if frozen, deny immediately (mode-independent)
+        5. Extract tool calls from latest message
+        6. Route to observe mode or policy mode based on engine presence
+        7. Record AuditEntry and return governance decision
+
+        Returns:
+            A tuple of (should_terminate, reply_message):
+            - (False, None): Let the agent continue to the next reply function
+            - (True, message): Terminate with this reply (used for denials)
+
+        Requirements covered: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6
+        """
+        start_time = time.perf_counter()
+
+        # Determine agent identity from recipient
+        agent_id: str = getattr(recipient, "name", "unknown")
+
+        # Increment turn_id for this invocation
+        self._turn_counter += 1
+        turn_id = self._turn_counter
+
+        # Handle None/empty messages gracefully
+        if not messages:
+            return (False, None)
+
+        # ── Frozen check (mode-independent kill switch) ───────────────────
+        # Frozen agents are blocked for both tool calls and messages.
+        # We also check if the sender is frozen (Req 4.5: originating agent identity).
+        sender_id: str = getattr(sender, "name", "unknown")
+
+        if self.is_frozen(agent_id):
+            evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+            correlation_id = str(uuid.uuid4())
+
+            # Determine action_kind based on message content
+            last_msg = messages[-1] if messages else {}
+            has_tool_calls = bool(last_msg.get("tool_calls"))
+            frozen_action_kind = (
+                ActionKind.TOOL_CALL.value if has_tool_calls else ActionKind.MESSAGE.value
+            )
+
+            teec = self._teec_builder.build(
+                agent_id=agent_id,
+                turn_id=turn_id,
+            )
+
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.DENY.value,
+                action_kind=frozen_action_kind,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=f"Agent '{agent_id}' is frozen",
+                reason_codes=["AGENT_FROZEN"],
+                risk_score=100,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+            )
+            self._audit_trail.append(entry)
+
+            # Frozen always blocks regardless of mode
+            return (True, f"[GOVERNANCE DENIAL] Agent '{agent_id}' is frozen. All actions blocked.")
+
+        # Check if sender is frozen (Req 4.5, 17.4: frozen agent sending through another)
+        if self.is_frozen(sender_id):
+            evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+            correlation_id = str(uuid.uuid4())
+
+            teec = self._teec_builder.build(
+                agent_id=sender_id,
+                turn_id=turn_id,
+            )
+
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.DENY.value,
+                action_kind=ActionKind.MESSAGE.value,
+                mode=self.mode.value,
+                agent_id=sender_id,
+                reason=f"Sender '{sender_id}' is frozen",
+                reason_codes=["AGENT_FROZEN"],
+                risk_score=100,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+            )
+            self._audit_trail.append(entry)
+
+            # Frozen sender always blocks regardless of mode
+            return (True, f"[GOVERNANCE DENIAL] Sender '{sender_id}' is frozen. Message blocked.")
+
+        # ── Budget check (after freeze, before engine evaluation) ─────────
+        budget_result = self._budget_manager.check_budget(agent_id)
+        if budget_result.exceeded:
+            if self.mode == GovernanceMode.ENFORCE:
+                # Deny with BUDGET_EXCEEDED in ENFORCE mode
+                evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+                correlation_id = str(uuid.uuid4())
+
+                teec = self._teec_builder.build(
+                    agent_id=agent_id,
+                    turn_id=turn_id,
+                )
+
+                budget_state = self._budget_manager.get_state(agent_id)
+                entry = AuditEntry(
+                    correlation_id=correlation_id,
+                    decision_id=teec.decision_id,
+                    timestamp_ms=time.time() * 1000,
+                    action=GovernanceAction.DENY.value,
+                    action_kind=ActionKind.TOOL_CALL.value,
+                    mode=self.mode.value,
+                    agent_id=agent_id,
+                    reason=f"Agent '{agent_id}' budget exceeded (spent: {budget_state.current_spend:.4f}, limit: {budget_state.budget_limit})",
+                    reason_codes=["BUDGET_EXCEEDED"],
+                    risk_score=80,
+                    evaluation_time_ms=evaluation_time_ms,
+                    teec=teec,
+                    cumulative_cost=budget_state.current_spend,
+                )
+                self._audit_trail.append(entry)
+
+                denial = DenialMessage(
+                    tool_name="unknown",
+                    action=GovernanceAction.DENY.value,
+                    reason=f"Budget exceeded for agent '{agent_id}'",
+                    risk_score=80,
+                    reason_codes=["BUDGET_EXCEEDED"],
+                    correlation_id=correlation_id,
+                    decision_id=teec.decision_id,
+                )
+                return (True, denial.to_reply_string())
+            else:
+                # MONITOR / OBSERVE: log warning but allow through
+                logger.warning(
+                    "BUDGET_EXCEEDED for agent '%s' (mode=%s) — allowing through",
+                    agent_id,
+                    self.mode.value,
+                )
+
+        # ── Extract tool calls from latest message ────────────────────────
+        last_message = messages[-1]
+        tool_calls = last_message.get("tool_calls", [])
+
+        # ── Observe mode (no engine) ─────────────────────────────────────
+        if self.engine is None:
+            return self._observe_mode(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                last_message=last_message,
+                tool_calls=tool_calls,
+                start_time=start_time,
+                sender=sender,
+                recipient=recipient,
+            )
+
+        # ── Policy mode (engine present) ────────────────────────────────
+        return self._policy_mode(
+            agent_id=agent_id,
+            turn_id=turn_id,
+            last_message=last_message,
+            tool_calls=tool_calls,
+            start_time=start_time,
+            sender=sender,
+            recipient=recipient,
+        )
+
+    # ── Observe Mode Logic ────────────────────────────────────────────────────
+
+    def _observe_mode(
+        self,
+        agent_id: str,
+        turn_id: int,
+        last_message: dict[str, Any],
+        tool_calls: list[dict[str, Any]],
+        start_time: float,
+        sender: Any = None,
+        recipient: Any = None,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle observe mode — track cost, PII, tools without blocking.
+
+        In observe mode (no TealEngine configured):
+        - Estimate cost from token usage / text length heuristics
+        - Detect PII in tool call arguments
+        - Record tool names, call counts, and argument summaries
+        - Produce AuditEntry with action=ALLOW and reason_codes=["OBSERVE_PASSTHROUGH"]
+        - Differentiate action_kind between "tool_call" and "message"
+        - Never block: always return (False, None)
+
+        Requirements covered: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 17.2, 17.7
+        """
+        # ── Cost estimation ───────────────────────────────────────────────
+        # Heuristic: chars / 4 = approx tokens, then * cost_per_1k / 1000
+        text_content = last_message.get("content") or ""
+        total_chars = len(text_content)
+
+        # Include tool call arguments in the cost estimation
+        for tc in tool_calls:
+            func_info = tc.get("function", {})
+            args = func_info.get("arguments", {})
+            if isinstance(args, str):
+                total_chars += len(args)
+            elif isinstance(args, dict):
+                total_chars += len(json.dumps(args))
+
+        estimated_tokens = total_chars / 4.0
+        cost = (estimated_tokens * self.cost_per_1k_tokens) / 1000.0
+
+        # Track cost for this agent
+        self._budget_manager.track_cost(agent_id, cost)
+        budget_state = self._budget_manager.get_state(agent_id)
+
+        # ── PII detection in tool call arguments ──────────────────────────
+        pii_findings: list[dict[str, Any]] = []
+        for tc in tool_calls:
+            func_info = tc.get("function", {})
+            args = func_info.get("arguments", {})
+            if isinstance(args, str):
+                # Try to parse JSON string arguments
+                try:
+                    parsed_args = json.loads(args)
+                    pii_findings.extend(detect_pii(parsed_args))
+                except (ValueError, TypeError):
+                    pii_findings.extend(detect_pii(args))
+            elif isinstance(args, dict):
+                pii_findings.extend(detect_pii(args))
+
+        # ── Record tool names and argument summaries ──────────────────────
+        tool_name: str | None = None
+        tool_args_summary: dict[str, Any] | None = None
+
+        if tool_calls:
+            # Record the first tool call (primary tool)
+            first_tc = tool_calls[0]
+            func_info = first_tc.get("function", {})
+            tool_name = func_info.get("name")
+            raw_args = func_info.get("arguments", {})
+
+            # Build argument summary (keys and types, not full values)
+            if isinstance(raw_args, str):
+                try:
+                    parsed = json.loads(raw_args)
+                    if isinstance(parsed, dict):
+                        tool_args_summary = {
+                            k: type(v).__name__ for k, v in parsed.items()
+                        }
+                    else:
+                        tool_args_summary = {"_raw": type(parsed).__name__}
+                except (ValueError, TypeError):
+                    tool_args_summary = {"_raw": "str"}
+            elif isinstance(raw_args, dict):
+                tool_args_summary = {
+                    k: type(v).__name__ for k, v in raw_args.items()
+                }
+
+        # ── Build TEEC context ────────────────────────────────────────────
+        # Resolve tool_args for params_hash computation
+        resolved_tool_args: dict[str, Any] | None = None
+        if tool_calls:
+            first_tc = tool_calls[0]
+            func_info = first_tc.get("function", {})
+            raw_args = func_info.get("arguments", {})
+            if isinstance(raw_args, str):
+                try:
+                    resolved_tool_args = json.loads(raw_args)
+                    if not isinstance(resolved_tool_args, dict):
+                        resolved_tool_args = None
+                except (ValueError, TypeError):
+                    resolved_tool_args = None
+            elif isinstance(raw_args, dict):
+                resolved_tool_args = raw_args
+
+        teec = self._teec_builder.build(
+            agent_id=agent_id,
+            turn_id=turn_id,
+            tool_name=tool_name,
+            tool_args=resolved_tool_args,
+        )
+
+        # ── Produce AuditEntry ────────────────────────────────────────────
+        evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+        correlation_id = str(uuid.uuid4())
+
+        # Determine action_kind: "tool_call" if tool_calls present, "message" otherwise
+        action_kind = (
+            ActionKind.TOOL_CALL.value if tool_calls else ActionKind.MESSAGE.value
+        )
+
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=teec.decision_id,
+            timestamp_ms=time.time() * 1000,
+            action=GovernanceAction.ALLOW.value,
+            action_kind=action_kind,
+            mode=GovernanceMode.OBSERVE.value,
+            agent_id=agent_id,
+            reason="Observe mode — passthrough",
+            reason_codes=["OBSERVE_PASSTHROUGH"],
+            risk_score=0,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+            tool_name=tool_name,
+            tool_args_summary=tool_args_summary,
+            pii_detected=pii_findings,
+            cost_tracked=cost,
+            cumulative_cost=budget_state.current_spend,
+        )
+        self._audit_trail.append(entry)
+
+        # ── Always allow in observe mode ──────────────────────────────────
+        return (False, None)
+
+    # ── Inter-Agent Message Governance ────────────────────────────────────────
+
+    def _message_governance(
+        self,
+        agent_id: str,
+        turn_id: int,
+        last_message: dict[str, Any],
+        sender: Any,
+        recipient: Any,
+        start_time: float,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Evaluate inter-agent message sends against TealEngine policies.
+
+        When the latest message contains no tool_calls (plain text), this method
+        evaluates the message content as a governed action_kind="message".
+
+        The engine receives:
+        - tool_name=None
+        - args={"content": message_content, "sender": sender_name, "recipient": recipient_name}
+        - context with action_kind="message"
+
+        Each message governance decision gets its own independent decision_id,
+        separate from any tool governance decisions in the same turn.
+
+        Requirements covered: 17.1, 17.2, 17.3, 17.4, 17.5, 17.6, 17.7
+        """
+        sender_name: str = getattr(sender, "name", "unknown") if sender else "unknown"
+        recipient_name: str = getattr(recipient, "name", "unknown") if recipient else "unknown"
+        message_content: str = last_message.get("content") or ""
+
+        # ── Build TEEC context with independent decision_id ───────────────
+        teec = self._teec_builder.build(
+            agent_id=agent_id,
+            turn_id=turn_id,
+        )
+
+        # ── Build framework context for TealEngine ────────────────────────
+        budget_state = self._budget_manager.get_state(agent_id)
+        framework_context: dict[str, Any] = {
+            "framework": "ag2",
+            "agent_id": agent_id,
+            "conversation_id": teec.conversation_id,
+            "cumulative_cost": budget_state.current_spend,
+            "action_kind": ActionKind.MESSAGE.value,
+        }
+
+        # ── Build message args for TealEngine evaluation ──────────────────
+        message_args: dict[str, Any] = {
+            "content": message_content,
+            "sender": sender_name,
+            "recipient": recipient_name,
+        }
+
+        # ── Call TealEngine.evaluate() with error handling ─────────────────
+        try:
+            decision = self.engine.evaluate(
+                tool_name=None,
+                args=message_args,
+                context=framework_context,
+            )
+        except Exception as exc:
+            # Engine threw an exception — apply fail-closed or fail-open
+            return self._handle_engine_error(
+                exc=exc,
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=None,
+                tool_args_summary={"content": "str", "sender": "str", "recipient": "str"},
+                teec=teec,
+                start_time=start_time,
+            )
+
+        action_str: str = decision.get("action", "DENY")
+        risk_score: int = decision.get("risk_score", 0)
+        reason_codes: list[str] = decision.get("reason_codes", [])
+        reason: str = decision.get("reason", "Message policy evaluation")
+
+        # ── Compute evaluation time ───────────────────────────────────────
+        evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+        correlation_id = str(uuid.uuid4())
+
+        # ── Handle decision based on action ───────────────────────────────
+        if action_str == GovernanceAction.ALLOW.value:
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.ALLOW.value,
+                action_kind=ActionKind.MESSAGE.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=reason,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+            )
+            self._audit_trail.append(entry)
+
+            self._decision_manager.create_receipt(
+                decision_id=teec.decision_id,
+                action=GovernanceAction.ALLOW,
+            )
+
+            return (False, None)
+
+        elif action_str == GovernanceAction.DENY.value:
+            # Record audit entry with action_kind="message"
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.DENY.value,
+                action_kind=ActionKind.MESSAGE.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=reason,
+                reason_codes=reason_codes if "MESSAGE_DENIED" in reason_codes else reason_codes + ["MESSAGE_DENIED"],
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+            )
+            self._audit_trail.append(entry)
+
+            self._decision_manager.create_receipt(
+                decision_id=teec.decision_id,
+                action=GovernanceAction.DENY,
+            )
+
+            if self.mode == GovernanceMode.ENFORCE:
+                # Block the message delivery
+                return (
+                    True,
+                    f"[GOVERNANCE DENIAL] Message from '{sender_name}' to '{recipient_name}' blocked. "
+                    f"Reason: {reason} | Codes: {','.join(entry.reason_codes)} | "
+                    f"Decision: {teec.decision_id}",
+                )
+            elif self.mode == GovernanceMode.MONITOR:
+                # Log but allow through
+                logger.info(
+                    "MONITOR mode MESSAGE_DENIED: agent=%s sender=%s recipient=%s reason=%s",
+                    agent_id,
+                    sender_name,
+                    recipient_name,
+                    reason,
+                )
+                return (False, None)
+
+            return (False, None)
+
+        else:
+            # REFER or unknown — log and allow for messages
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=action_str,
+                action_kind=ActionKind.MESSAGE.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=reason,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+            )
+            self._audit_trail.append(entry)
+            return (False, None)
+
+    # ── Policy Mode Logic ─────────────────────────────────────────────────────
+
+    def _policy_mode(
+        self,
+        agent_id: str,
+        turn_id: int,
+        last_message: dict[str, Any],
+        tool_calls: list[dict[str, Any]],
+        start_time: float,
+        sender: Any = None,
+        recipient: Any = None,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle policy mode — evaluate tool calls and messages against TealEngine policies.
+
+        When a TealEngine is configured, this method:
+        1. Determines if this is a tool call or a plain message
+        2. For tool calls: extracts tool_name and args, evaluates via TealEngine
+        3. For plain messages: routes to _message_governance for inter-agent evaluation
+        4. Routes to the appropriate handler based on the decision
+
+        Returns:
+            A tuple of (should_terminate, reply_message):
+            - (False, None): Let the agent continue
+            - (True, message): Terminate with denial or escalation reply
+
+        Requirements covered: 1.2, 1.3, 1.4, 1.5, 7.1, 7.2, 7.5, 7.6, 15.1, 15.2, 15.8, 17.1, 17.6, 17.7
+        """
+        # ── Route: If no tool_calls, handle as inter-agent message governance ──
+        if not tool_calls:
+            return self._message_governance(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                last_message=last_message,
+                sender=sender,
+                recipient=recipient,
+                start_time=start_time,
+            )
+        # ── Extract tool_name and args from latest message ────────────────
+        tool_name: str | None = None
+        tool_args: dict[str, Any] | None = None
+        tool_args_summary: dict[str, Any] | None = None
+
+        if tool_calls:
+            first_tc = tool_calls[0]
+            func_info = first_tc.get("function", {})
+            tool_name = func_info.get("name")
+            raw_args = func_info.get("arguments", {})
+
+            # Resolve args to dict
+            if isinstance(raw_args, str):
+                try:
+                    parsed = json.loads(raw_args)
+                    if isinstance(parsed, dict):
+                        tool_args = parsed
+                        tool_args_summary = {
+                            k: type(v).__name__ for k, v in parsed.items()
+                        }
+                    else:
+                        tool_args = {}
+                        tool_args_summary = {"_raw": type(parsed).__name__}
+                except (ValueError, TypeError):
+                    tool_args = {}
+                    tool_args_summary = {"_raw": "str"}
+            elif isinstance(raw_args, dict):
+                tool_args = raw_args
+                tool_args_summary = {
+                    k: type(v).__name__ for k, v in raw_args.items()
+                }
+            else:
+                tool_args = {}
+
+        if tool_args is None:
+            tool_args = {}
+
+        # ── Compute params_hash with non-serializable handling ────────────
+        # If tool_args contain non-serializable values, catch TypeError/ValueError
+        # and continue with params_hash=None (Requirements 7.3, 7.4)
+        params_hash: str | None = None
+        if tool_args:
+            try:
+                from ag2_tealtiger.idempotency import compute_params_hash
+                params_hash = compute_params_hash(tool_args)
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Non-serializable tool args for '%s' (agent=%s): %s. "
+                    "Continuing evaluation without params_hash.",
+                    tool_name,
+                    agent_id,
+                    exc,
+                )
+                params_hash = None
+
+        # ── Build TEEC context ────────────────────────────────────────────
+        teec = self._teec_builder.build(
+            agent_id=agent_id,
+            turn_id=turn_id,
+            tool_name=tool_name,
+            tool_args=tool_args if params_hash is not None else None,
+        )
+
+        # ── Build framework context for TealEngine ────────────────────────
+        budget_state = self._budget_manager.get_state(agent_id)
+        framework_context: dict[str, Any] = {
+            "framework": "ag2",
+            "agent_id": agent_id,
+            "conversation_id": teec.conversation_id,
+            "cumulative_cost": budget_state.current_spend,
+            "action_kind": ActionKind.TOOL_CALL.value,
+        }
+
+        # ── Call TealEngine.evaluate() with error handling ─────────────────
+        # Requirements 7.3, 7.4: Fail-closed in ENFORCE, fail-open in MONITOR/OBSERVE
+        try:
+            decision = self.engine.evaluate(
+                tool_name=tool_name,
+                args=tool_args,
+                context=framework_context,
+            )
+        except Exception as exc:
+            # Engine threw an exception — apply fail-closed or fail-open
+            return self._handle_engine_error(
+                exc=exc,
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+                teec=teec,
+                start_time=start_time,
+            )
+
+        action_str: str = decision.get("action", "DENY")
+        risk_score: int = decision.get("risk_score", 0)
+        reason_codes: list[str] = decision.get("reason_codes", [])
+        reason: str = decision.get("reason", "Policy evaluation")
+
+        # ── Compute evaluation time ───────────────────────────────────────
+        evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+        correlation_id = str(uuid.uuid4())
+
+        # ── Handle decision based on action ───────────────────────────────
+        if action_str == GovernanceAction.ALLOW.value:
+            return self._handle_allow(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+                teec=teec,
+                correlation_id=correlation_id,
+                reason=reason,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+            )
+
+        elif action_str == GovernanceAction.DENY.value:
+            return self._handle_deny(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+                teec=teec,
+                correlation_id=correlation_id,
+                reason=reason,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+            )
+
+        elif action_str == GovernanceAction.REFER.value:
+            return self._handle_refer(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                tool_args_summary=tool_args_summary,
+                teec=teec,
+                correlation_id=correlation_id,
+                reason=reason,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+                framework_context=framework_context,
+            )
+
+        else:
+            # Unknown action — treat as DENY in ENFORCE, ALLOW in MONITOR
+            logger.warning(
+                "Unknown governance action '%s' from TealEngine, treating as DENY",
+                action_str,
+            )
+            return self._handle_deny(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+                teec=teec,
+                correlation_id=correlation_id,
+                reason=f"Unknown action: {action_str}",
+                reason_codes=reason_codes + ["UNKNOWN_ACTION"],
+                risk_score=risk_score,
+                evaluation_time_ms=evaluation_time_ms,
+            )
+
+    # ── Decision Handlers ─────────────────────────────────────────────────────
+
+    def _handle_allow(
+        self,
+        agent_id: str,
+        turn_id: int,
+        tool_name: str | None,
+        tool_args_summary: dict[str, Any] | None,
+        teec: TEECContext,
+        correlation_id: str,
+        reason: str,
+        reason_codes: list[str],
+        risk_score: int,
+        evaluation_time_ms: float,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle ALLOW decision — pass through and record audit entry.
+
+        Requirements: 1.3, 7.5
+        """
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=teec.decision_id,
+            timestamp_ms=time.time() * 1000,
+            action=GovernanceAction.ALLOW.value,
+            action_kind=ActionKind.TOOL_CALL.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=reason,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+            tool_name=tool_name,
+            tool_args_summary=tool_args_summary,
+        )
+        self._audit_trail.append(entry)
+
+        # Track cost after tool execution is allowed (Requirements: 18.1, 18.8)
+        # Use a small estimated cost per tool call (based on text length heuristic)
+        estimated_cost = self.cost_per_1k_tokens / 1000.0 * 50  # ~50 tokens per call
+        track_result = self._budget_manager.track_cost(agent_id, estimated_cost)
+
+        # Emit BUDGET_WARNING audit entry if threshold crossed
+        if track_result.warning:
+            budget_state = self._budget_manager.get_state(agent_id)
+            warning_entry = AuditEntry(
+                correlation_id=str(uuid.uuid4()),
+                decision_id=str(uuid.uuid4()),
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.ALLOW.value,
+                action_kind=ActionKind.BUDGET_CHANGE.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=f"Agent '{agent_id}' approaching budget limit (80% threshold)",
+                reason_codes=["BUDGET_WARNING"],
+                risk_score=0,
+                evaluation_time_ms=0.0,
+                teec=teec,
+                cumulative_cost=budget_state.current_spend,
+            )
+            self._audit_trail.append(warning_entry)
+
+        # Store decision receipt
+        self._decision_manager.create_receipt(
+            decision_id=teec.decision_id,
+            action=GovernanceAction.ALLOW,
+        )
+
+        # Cache outcome for retry idempotency (Requirements: 11.1, 11.5)
+        self._decision_outcomes[teec.decision_id] = {
+            "decision_id": teec.decision_id,
+            "action": GovernanceAction.ALLOW.value,
+            "reason_codes": reason_codes,
+            "risk_score": risk_score,
+        }
+
+        return (False, None)
+
+    def _handle_deny(
+        self,
+        agent_id: str,
+        turn_id: int,
+        tool_name: str | None,
+        tool_args_summary: dict[str, Any] | None,
+        teec: TEECContext,
+        correlation_id: str,
+        reason: str,
+        reason_codes: list[str],
+        risk_score: int,
+        evaluation_time_ms: float,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle DENY decision — block in ENFORCE, log in MONITOR.
+
+        In ENFORCE mode: block the tool call and return a DenialMessage.
+        In MONITOR mode: log the denial and allow the tool call to proceed.
+
+        Requirements: 1.4, 1.5, 7.1, 7.2, 7.6
+        """
+        # Record audit entry regardless of mode
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=teec.decision_id,
+            timestamp_ms=time.time() * 1000,
+            action=GovernanceAction.DENY.value,
+            action_kind=ActionKind.TOOL_CALL.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=reason,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+            tool_name=tool_name,
+            tool_args_summary=tool_args_summary,
+        )
+        self._audit_trail.append(entry)
+
+        # Store decision receipt
+        self._decision_manager.create_receipt(
+            decision_id=teec.decision_id,
+            action=GovernanceAction.DENY,
+        )
+
+        # Cache outcome for retry idempotency (Requirements: 11.1, 11.5)
+        self._decision_outcomes[teec.decision_id] = {
+            "decision_id": teec.decision_id,
+            "action": GovernanceAction.DENY.value,
+            "reason_codes": reason_codes,
+            "risk_score": risk_score,
+        }
+
+        if self.mode == GovernanceMode.ENFORCE:
+            # Block — return DenialMessage as the reply
+            denial = DenialMessage(
+                tool_name=tool_name or "unknown",
+                action=GovernanceAction.DENY.value,
+                reason=reason,
+                risk_score=risk_score,
+                reason_codes=reason_codes,
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+            )
+            return (True, denial.to_reply_string())
+
+        elif self.mode == GovernanceMode.MONITOR:
+            # Log but allow through
+            logger.info(
+                "MONITOR mode DENY: agent=%s tool=%s reason=%s codes=%s",
+                agent_id,
+                tool_name,
+                reason,
+                reason_codes,
+            )
+            return (False, None)
+
+        # Fallback (shouldn't reach here in normal operation)
+        return (False, None)
+
+    def _handle_refer(
+        self,
+        agent_id: str,
+        turn_id: int,
+        tool_name: str | None,
+        tool_args: dict[str, Any],
+        tool_args_summary: dict[str, Any] | None,
+        teec: TEECContext,
+        correlation_id: str,
+        reason: str,
+        reason_codes: list[str],
+        risk_score: int,
+        evaluation_time_ms: float,
+        framework_context: dict[str, Any],
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle REFER decision — suspend action, emit escalation receipt.
+
+        Suspends the agent's pending action without terminating the GroupChat.
+        Emits a structured EscalationReceipt for human review.
+
+        Requirements: 15.1, 15.2, 15.8
+        """
+        decision_id = teec.decision_id
+
+        # Record audit entry
+        entry = AuditEntry(
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            timestamp_ms=time.time() * 1000,
+            action=GovernanceAction.REFER.value,
+            action_kind=ActionKind.TOOL_CALL.value,
+            mode=self.mode.value,
+            agent_id=agent_id,
+            reason=reason,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            evaluation_time_ms=evaluation_time_ms,
+            teec=teec,
+            tool_name=tool_name,
+            tool_args_summary=tool_args_summary,
+        )
+        self._audit_trail.append(entry)
+
+        # Create escalation receipt
+        escalation_receipt = EscalationReceipt(
+            decision_id=decision_id,
+            agent_id=agent_id,
+            tool_name=tool_name or "unknown",
+            tool_arguments=tool_args,
+            conversation_id=teec.conversation_id,
+            turn_id=turn_id,
+            group_chat_id=teec.group_chat_id,
+            risk_score=risk_score,
+            reason_codes=reason_codes,
+            human_readable_summary=(
+                f"Action '{tool_name}' by agent '{agent_id}' requires review. "
+                f"Risk: {risk_score}. Reason: {reason}"
+            ),
+            policy_context=framework_context,
+            issued_at=datetime.now(timezone.utc),
+            expires_at=None,
+        )
+
+        # Store decision receipt for lifecycle management
+        self._decision_manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.REFER,
+        )
+
+        # Store escalation receipt for resolution lookup
+        # (attached as metadata to the decision receipt for retrieval)
+        receipt = self._decision_manager.get_receipt(decision_id)
+        if receipt is not None:
+            receipt.execution_outcome = "pending_review"
+
+        # Cache outcome for retry idempotency (Requirements: 11.1, 11.5)
+        self._decision_outcomes[decision_id] = {
+            "decision_id": decision_id,
+            "action": GovernanceAction.REFER.value,
+            "reason_codes": reason_codes,
+            "risk_score": risk_score,
+        }
+
+        # Return suspension reply
+        return (True, f"Action pending review: {decision_id}")
+
+    # ── Error Handling ────────────────────────────────────────────────────────
+
+    def _handle_engine_error(
+        self,
+        exc: Exception,
+        agent_id: str,
+        turn_id: int,
+        tool_name: str | None,
+        tool_args_summary: dict[str, Any] | None,
+        teec: TEECContext,
+        start_time: float,
+    ) -> tuple[bool, str | dict[str, Any] | None]:
+        """Handle TealEngine exceptions with fail-closed or fail-open behavior.
+
+        In ENFORCE mode with fail_closed=True:
+            - DENY the action with reason_codes=["ENGINE_ERROR", "FAIL_CLOSED"]
+            - Return a governance denial message
+
+        In MONITOR or OBSERVE mode (or ENFORCE with fail_closed=False):
+            - ALLOW the action with reason_codes=["ENGINE_ERROR", "FAIL_OPEN"]
+            - Return (False, None) to let the agent continue
+
+        Requirements: 7.3, 7.4
+        """
+        evaluation_time_ms = (time.perf_counter() - start_time) * 1000
+        correlation_id = str(uuid.uuid4())
+
+        # Determine fail-closed vs fail-open
+        if self.mode == GovernanceMode.ENFORCE and self.fail_closed:
+            # Fail-closed: deny the action
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.DENY.value,
+                action_kind=ActionKind.TOOL_CALL.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=f"Engine error: {exc}",
+                reason_codes=["ENGINE_ERROR", "FAIL_CLOSED"],
+                risk_score=100,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+            )
+            self._audit_trail.append(entry)
+
+            return (
+                True,
+                "[GOVERNANCE DENIAL] Engine error. Fail-closed: action denied.",
+            )
+        else:
+            # Fail-open: allow the action through
+            entry = AuditEntry(
+                correlation_id=correlation_id,
+                decision_id=teec.decision_id,
+                timestamp_ms=time.time() * 1000,
+                action=GovernanceAction.ALLOW.value,
+                action_kind=ActionKind.TOOL_CALL.value,
+                mode=self.mode.value,
+                agent_id=agent_id,
+                reason=f"Engine error: {exc}",
+                reason_codes=["ENGINE_ERROR", "FAIL_OPEN"],
+                risk_score=0,
+                evaluation_time_ms=evaluation_time_ms,
+                teec=teec,
+                tool_name=tool_name,
+                tool_args_summary=tool_args_summary,
+            )
+            self._audit_trail.append(entry)
+
+            return (False, None)

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/idempotency.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/idempotency.py
@@ -1,0 +1,45 @@
+"""Idempotency key and params hash utilities for ag2-tealtiger.
+
+Provides deterministic hash computation for tool call arguments and
+idempotency key derivation for downstream tool deduplication.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def compute_params_hash(tool_args: dict) -> str:
+    """Compute SHA-256 of JCS-canonicalized (RFC 8785) tool arguments.
+
+    Uses sorted keys and compact separators for canonical JSON serialization,
+    ensuring the same logical arguments always produce the same hash regardless
+    of original key ordering or whitespace.
+
+    Args:
+        tool_args: Dictionary of tool call parameters to hash.
+
+    Returns:
+        Hex-encoded SHA-256 digest of the canonical JSON representation.
+    """
+    canonical = json.dumps(tool_args, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def derive_idempotency_key(decision_id: str, params_hash: str) -> str:
+    """Derive idempotency key from decision_id and params_hash.
+
+    The key is deterministic: same inputs always produce the same output.
+    Used for downstream tool deduplication to prevent duplicate side effects
+    on retries.
+
+    Args:
+        decision_id: Unique identifier for the governance decision instance.
+        params_hash: SHA-256 hash of the tool call parameters (from compute_params_hash).
+
+    Returns:
+        Hex-encoded SHA-256 digest of the combined decision_id:params_hash string.
+    """
+    combined = f"{decision_id}:{params_hash}"
+    return hashlib.sha256(combined.encode("utf-8")).hexdigest()

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/pii.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/pii.py
@@ -1,0 +1,129 @@
+"""Lightweight PII detection for ag2-tealtiger observe mode.
+
+Scans string values in dicts, lists, and plain strings using regex-based
+pattern matching to detect personally identifiable information. Used in
+observe mode to detect PII in tool call arguments and results without
+blocking execution.
+
+PII types detected:
+- email: Email addresses
+- phone_number: US phone numbers (various formats)
+- ssn: Social Security Numbers (XXX-XX-XXXX)
+- credit_card: Credit card numbers (16 digits, various separators)
+- ip_address: IPv4 addresses
+
+Returns structured detection results with type, location, and confidence.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# ── PII Regex Patterns ─────────────────────────────────────────────────────────
+
+_PII_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(
+        r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
+    ),
+    "phone_number": re.compile(
+        r"(\+\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"
+    ),
+    "ssn": re.compile(
+        r"\b\d{3}-\d{2}-\d{4}\b"
+    ),
+    "credit_card": re.compile(
+        r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b"
+    ),
+    "ip_address": re.compile(
+        r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b"
+    ),
+}
+
+# Confidence scores per PII type (higher = more certain the match is real PII)
+_CONFIDENCE_SCORES: dict[str, float] = {
+    "email": 0.95,
+    "phone_number": 0.80,
+    "ssn": 0.99,
+    "credit_card": 0.90,
+    "ip_address": 0.70,
+}
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def detect_pii(data: Any) -> list[dict[str, Any]]:
+    """Scan data for PII patterns and return detection results.
+
+    Recursively traverses dicts, lists, and plain strings to find
+    PII matches using regex patterns.
+
+    Args:
+        data: The data to scan. Can be a string, dict, list, or nested
+              combination thereof. Non-string leaf values are skipped.
+
+    Returns:
+        A list of detection dicts, each containing:
+            - type: PII type identifier (e.g., "email", "ssn")
+            - value: The matched text
+            - location: Dot-notation path to the value (e.g., "args.user.email")
+            - confidence: Float 0.0-1.0 indicating detection confidence
+            - start: Start index of match within the scanned string
+            - end: End index of match within the scanned string
+    """
+    results: list[dict[str, Any]] = []
+    _scan_recursive(data, "", results)
+    return results
+
+
+def detect_pii_in_text(text: str, location: str = "") -> list[dict[str, Any]]:
+    """Scan a single string for PII patterns.
+
+    Args:
+        text: The string to scan.
+        location: Optional path label for the location field in results.
+
+    Returns:
+        A list of detection dicts (same format as detect_pii).
+    """
+    results: list[dict[str, Any]] = []
+    _scan_string(text, location, results)
+    return results
+
+
+# ── Internal Helpers ───────────────────────────────────────────────────────────
+
+
+def _scan_recursive(
+    data: Any, path: str, results: list[dict[str, Any]]
+) -> None:
+    """Recursively scan data structures for PII in string values."""
+    if isinstance(data, str):
+        _scan_string(data, path, results)
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            _scan_recursive(value, child_path, results)
+    elif isinstance(data, (list, tuple)):
+        for idx, item in enumerate(data):
+            child_path = f"{path}[{idx}]" if path else f"[{idx}]"
+            _scan_recursive(item, child_path, results)
+    # Non-string, non-container types are skipped (int, float, bool, None, etc.)
+
+
+def _scan_string(
+    text: str, location: str, results: list[dict[str, Any]]
+) -> None:
+    """Scan a single string against all PII patterns."""
+    for pii_type, pattern in _PII_PATTERNS.items():
+        for match in pattern.finditer(text):
+            results.append({
+                "type": pii_type,
+                "value": match.group(0),
+                "location": location,
+                "confidence": _CONFIDENCE_SCORES[pii_type],
+                "start": match.start(),
+                "end": match.end(),
+            })

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/teec_builder.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/teec_builder.py
@@ -1,0 +1,133 @@
+"""TEECContextBuilder — builds teec.ag2 namespace objects for audit entries.
+
+Provides structured telemetry context for every governance decision,
+supporting conversation correlation, nested chat tracking, and
+monotonically increasing turn IDs per conversation scope.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ag2_tealtiger.idempotency import compute_params_hash, derive_idempotency_key
+from ag2_tealtiger.types import TEECContext
+
+
+class TEECContextBuilder:
+    """Builds teec.ag2 namespace objects for audit entries.
+
+    Each builder instance is scoped to a single conversation (top-level or nested).
+    It maintains a stable conversation_id (UUID v4) and a monotonically increasing
+    turn_id counter. Nested chats get their own builder via `enter_nested_chat()`,
+    which preserves the parent conversation_id for correlation.
+
+    Usage:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1, tool_name="run_code", tool_args={"code": "x=1"})
+
+        # Nested chat
+        nested = builder.enter_nested_chat()
+        nested_ctx = nested.build(agent_id="reviewer", turn_id=1)
+    """
+
+    def __init__(self, conversation_id: str | None = None) -> None:
+        """Initialize a new TEECContextBuilder.
+
+        Args:
+            conversation_id: Optional conversation ID to use. If not provided,
+                a new UUID v4 is generated automatically.
+        """
+        self._conversation_id: str = conversation_id or str(uuid.uuid4())
+        self._turn_counter: int = 0
+        self._parent_conversation_id: str | None = None
+
+    @property
+    def conversation_id(self) -> str:
+        """The stable conversation ID for this builder's scope."""
+        return self._conversation_id
+
+    @property
+    def current_turn_id(self) -> int:
+        """The current (most recently used) turn ID value."""
+        return self._turn_counter
+
+    def build(
+        self,
+        agent_id: str,
+        turn_id: int,
+        tool_name: str | None = None,
+        tool_args: dict | None = None,
+        group_chat_id: str | None = None,
+        parent_conversation_id: str | None = None,
+    ) -> TEECContext:
+        """Build a TEECContext for a governance evaluation.
+
+        Generates a fresh decision_id (UUID v4) each time, computes params_hash
+        from tool_args if provided, and derives the idempotency_key from the
+        decision_id and params_hash combination.
+
+        The turn_id counter is updated to the provided value, enforcing
+        monotonically increasing turns within this conversation scope.
+
+        Args:
+            agent_id: The identity of the agent being evaluated.
+            turn_id: The turn number for this evaluation. Must be >= current counter.
+            tool_name: Optional name of the tool being called.
+            tool_args: Optional dictionary of tool call parameters for hash computation.
+            group_chat_id: Optional GroupChat session identifier.
+            parent_conversation_id: Optional override for parent conversation ID.
+                If not provided, uses the builder's stored parent (set by enter_nested_chat).
+
+        Returns:
+            A fully populated TEECContext with all correlation fields set.
+        """
+        # Update the turn counter (monotonically increasing)
+        if turn_id > self._turn_counter:
+            self._turn_counter = turn_id
+
+        # Generate unique decision_id for this evaluation
+        decision_id = str(uuid.uuid4())
+
+        # Compute params_hash from tool_args if provided
+        params_hash: str | None = None
+        if tool_args is not None:
+            params_hash = compute_params_hash(tool_args)
+
+        # Derive idempotency_key from decision_id + params_hash
+        idempotency_key: str | None = None
+        if params_hash is not None:
+            idempotency_key = derive_idempotency_key(decision_id, params_hash)
+
+        # Resolve parent_conversation_id: explicit arg > stored value
+        resolved_parent = parent_conversation_id or self._parent_conversation_id
+
+        return TEECContext(
+            namespace="teec.ag2",
+            conversation_id=self._conversation_id,
+            turn_id=turn_id,
+            agent_role=agent_id,
+            group_chat_id=group_chat_id,
+            params_hash=params_hash,
+            parent_conversation_id=resolved_parent,
+            decision_id=decision_id,
+            idempotency_key=idempotency_key,
+            policy_digest=None,
+            decision_source="default_mode",
+            execution_outcome=None,
+            approval_id=None,
+        )
+
+    def enter_nested_chat(self) -> TEECContextBuilder:
+        """Create a new builder for a nested chat scope.
+
+        The nested builder has:
+        - A fresh conversation_id (new UUID v4)
+        - The current builder's conversation_id stored as parent_conversation_id
+        - An independent turn_id counter starting at 0
+
+        Returns:
+            A new TEECContextBuilder for the nested chat scope.
+        """
+        nested = TEECContextBuilder()
+        nested._parent_conversation_id = self._conversation_id
+        return nested

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/types.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/types.py
@@ -1,0 +1,222 @@
+"""Data models and enums for ag2-tealtiger governance adapter.
+
+This module defines all core types used throughout the ag2-tealtiger package:
+- Enums for governance actions, modes, action kinds, and decision sources
+- Dataclasses for TEEC context, audit entries, decision receipts, and more
+
+All types use Python 3.10+ annotations with `from __future__ import annotations`
+for forward reference support.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+class GovernanceAction(str, Enum):
+    """Governance decision action returned by TealEngine evaluation."""
+
+    ALLOW = "ALLOW"
+    DENY = "DENY"
+    MODIFY = "MODIFY"
+    REFER = "REFER"
+
+
+class GovernanceMode(str, Enum):
+    """Operating mode for the governance interceptor."""
+
+    ENFORCE = "ENFORCE"
+    MONITOR = "MONITOR"
+    OBSERVE = "OBSERVE"
+
+
+class ActionKind(str, Enum):
+    """Category of governed action being evaluated."""
+
+    MESSAGE = "message"
+    TOOL_CALL = "tool_call"
+    BUDGET_CHANGE = "budget_change"
+    STOP = "stop"
+    FREEZE = "freeze"
+
+
+class DecisionSource(str, Enum):
+    """Entity that made the governance decision."""
+
+    POLICY_ENGINE = "policy_engine"
+    HUMAN_REVIEWER = "human_reviewer"
+    DELEGATED_AUTHORITY = "delegated_authority"
+    DEFAULT_MODE = "default_mode"
+    SYSTEM_TIMEOUT = "system_timeout"
+
+
+@dataclass
+class TEECContext:
+    """teec.ag2 namespace — structured telemetry context.
+
+    Attached to every AuditEntry to enable correlation and audit
+    reconstruction across conversations, nested chats, and group interactions.
+    """
+
+    namespace: str = "teec.ag2"
+    conversation_id: str = ""
+    turn_id: int = 0
+    agent_role: str | None = None
+    group_chat_id: str | None = None
+    params_hash: str | None = None
+    parent_conversation_id: str | None = None
+    decision_id: str = ""
+    idempotency_key: str | None = None
+    policy_digest: str | None = None
+    decision_source: str = "default_mode"
+    execution_outcome: str | None = None
+    approval_id: str | None = None
+
+
+@dataclass
+class AuditEntry:
+    """Structured audit entry for every governance evaluation.
+
+    Produced for every intercepted tool call, message send, or speaker
+    selection event regardless of the governance decision outcome.
+    """
+
+    correlation_id: str
+    decision_id: str
+    timestamp_ms: float
+    action: str  # GovernanceAction value
+    action_kind: str  # ActionKind value
+    mode: str  # GovernanceMode value
+    agent_id: str
+    reason: str
+    reason_codes: list[str]
+    risk_score: int
+    evaluation_time_ms: float
+    teec: TEECContext
+
+    # Optional fields
+    tool_name: str | None = None
+    tool_args_summary: dict[str, Any] | None = None
+    pii_detected: list[dict[str, Any]] = field(default_factory=list)
+    cost_tracked: float = 0.0
+    cumulative_cost: float = 0.0
+    trace_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RevalidationCondition:
+    """Condition that triggers decision re-evaluation.
+
+    Attached to decision receipts to define when a previously granted
+    ALLOW decision becomes stale and requires fresh evaluation.
+    """
+
+    condition_type: str  # e.g., "cost_exceeded", "time_elapsed", "context_changed"
+    threshold: Any
+    description: str
+
+
+@dataclass
+class DecisionReceipt:
+    """Record of a governance decision with expiry and revalidation.
+
+    Tracks the lifecycle of a governance decision including when it
+    expires and under what conditions it should be re-evaluated.
+    """
+
+    decision_id: str
+    action: GovernanceAction
+    issued_at: datetime
+    expires_at: datetime | None
+    revalidate_if: list[RevalidationCondition] = field(default_factory=list)
+    execution_outcome: str | None = None
+    approval_id: str | None = None
+    is_expired: bool = False
+
+
+@dataclass
+class EscalationReceipt:
+    """Structured escalation receipt for REFER decisions.
+
+    Contains full decision context enabling a downstream reviewer to
+    make an informed decision without re-running the agent.
+    """
+
+    decision_id: str
+    agent_id: str
+    tool_name: str
+    tool_arguments: dict[str, Any]
+    conversation_id: str
+    turn_id: int
+    group_chat_id: str | None
+    risk_score: int
+    reason_codes: list[str]
+    human_readable_summary: str
+    policy_context: dict[str, Any]
+    issued_at: datetime
+    expires_at: datetime | None
+
+
+@dataclass
+class BudgetState:
+    """Per-agent budget tracking state.
+
+    Maintains current spend, configured limit, and remaining budget
+    for cost enforcement per agent identity.
+    """
+
+    agent_id: str
+    budget_limit: float | None
+    current_spend: float = 0.0
+    remaining_budget: float | None = None
+    warning_emitted: bool = False
+
+
+@dataclass
+class SpeakerSelectionAuditEntry:
+    """Audit entry for GovernedGroupChat speaker selection rounds.
+
+    Records which candidates were evaluated, the decision for each,
+    and the final selected speaker for each selection round.
+    """
+
+    round_id: str
+    timestamp_ms: float
+    candidates_evaluated: list[dict[str, Any]]  # [{agent_id, decision, reason}]
+    selected_speaker: str | None
+    reason_codes: list[str]
+    group_chat_id: str
+
+
+@dataclass
+class DenialMessage:
+    """Structured denial result visible in the AG2 conversation.
+
+    Produced when a tool call is denied in ENFORCE mode, formatted
+    as a parseable string for downstream agents.
+    """
+
+    tool_name: str
+    action: str
+    reason: str
+    risk_score: int
+    reason_codes: list[str]
+    correlation_id: str
+    decision_id: str
+
+    def to_reply_string(self) -> str:
+        """Format as a parseable string for downstream agents.
+
+        Returns a structured denial message containing all relevant
+        fields separated by pipe delimiters for easy parsing.
+        """
+        return (
+            f"[GOVERNANCE DENIAL] Tool: {self.tool_name} | "
+            f"Action: {self.action} | Risk: {self.risk_score} | "
+            f"Reason: {self.reason} | Codes: {','.join(self.reason_codes)} | "
+            f"Decision: {self.decision_id}"
+        )

--- a/packages/ag2-tealtiger/tests/conftest.py
+++ b/packages/ag2-tealtiger/tests/conftest.py
@@ -1,0 +1,431 @@
+"""Shared fixtures for ag2-tealtiger tests.
+
+Provides mock TealEngine factories, AG2 agent factories, and
+common test utilities used across the test suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    GovernanceMode,
+)
+
+
+# ── Mock TealEngine Factories ─────────────────────────────────────────────────
+
+
+class MockTealEngine:
+    """Mock TealEngine that returns configurable decisions.
+
+    Provides a drop-in replacement for tealtiger.TealEngine in tests,
+    allowing deterministic governance decisions without requiring the
+    full tealtiger-core dependency.
+
+    Supports:
+    - Default decision for all evaluations
+    - Per-tool decision overrides
+    - Per-agent decision overrides
+    - Call recording for assertions
+    - Error injection via should_raise flag
+    """
+
+    def __init__(
+        self,
+        default_action: GovernanceAction = GovernanceAction.ALLOW,
+        default_risk_score: int = 0,
+        default_reason_codes: list[str] | None = None,
+        default_reason: str = "Mock decision",
+    ) -> None:
+        self.default_action = default_action
+        self.default_risk_score = default_risk_score
+        self.default_reason_codes = default_reason_codes or []
+        self.default_reason = default_reason
+        self.evaluate_calls: list[dict[str, Any]] = []
+        self._override_decisions: dict[str, dict[str, Any]] = {}
+        self._agent_decisions: dict[str, dict[str, Any]] = {}
+        self._should_raise: Exception | None = None
+        self._call_count = 0
+
+    def set_decision_for_tool(
+        self,
+        tool_name: str,
+        action: GovernanceAction,
+        risk_score: int = 0,
+        reason_codes: list[str] | None = None,
+        reason: str = "Tool-specific decision",
+    ) -> None:
+        """Configure a specific decision outcome for a tool name."""
+        self._override_decisions[tool_name] = {
+            "action": action.value,
+            "risk_score": risk_score,
+            "reason_codes": reason_codes or [],
+            "reason": reason,
+        }
+
+    def set_decision_for_agent(
+        self,
+        agent_id: str,
+        action: GovernanceAction,
+        risk_score: int = 0,
+        reason_codes: list[str] | None = None,
+        reason: str = "Agent-specific decision",
+    ) -> None:
+        """Configure a specific decision outcome for an agent identity."""
+        self._agent_decisions[agent_id] = {
+            "action": action.value,
+            "risk_score": risk_score,
+            "reason_codes": reason_codes or [],
+            "reason": reason,
+        }
+
+    def set_error(self, error: Exception) -> None:
+        """Configure the engine to raise an error on next evaluate call."""
+        self._should_raise = error
+
+    def clear_error(self) -> None:
+        """Clear any configured error injection."""
+        self._should_raise = None
+
+    @property
+    def call_count(self) -> int:
+        """Number of times evaluate() has been called."""
+        return self._call_count
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Evaluate a governance request and return a decision.
+
+        Checks overrides in order: error injection -> agent-specific ->
+        tool-specific -> default decision.
+        """
+        self._call_count += 1
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+
+        # Error injection takes priority
+        if self._should_raise is not None:
+            error = self._should_raise
+            raise error
+
+        # Agent-specific override (from context)
+        if context and "agent_id" in context:
+            agent_id = context["agent_id"]
+            if agent_id in self._agent_decisions:
+                return self._agent_decisions[agent_id]
+
+        # Tool-specific override
+        if tool_name and tool_name in self._override_decisions:
+            return self._override_decisions[tool_name]
+
+        # Default decision
+        return {
+            "action": self.default_action.value,
+            "risk_score": self.default_risk_score,
+            "reason_codes": self.default_reason_codes,
+            "reason": self.default_reason,
+        }
+
+    def reset(self) -> None:
+        """Reset all state: calls, overrides, and error injection."""
+        self.evaluate_calls.clear()
+        self._override_decisions.clear()
+        self._agent_decisions.clear()
+        self._should_raise = None
+        self._call_count = 0
+
+
+class ErrorTealEngine:
+    """Mock TealEngine that raises exceptions on evaluate.
+
+    Used to test fail-closed and fail-open error handling paths.
+    """
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error or RuntimeError("Engine evaluation failed")
+        self.evaluate_calls: list[dict[str, Any]] = []
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Always raises the configured exception."""
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+        raise self.error
+
+
+# ── Mock TealEngine Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_engine() -> MockTealEngine:
+    """Create a mock TealEngine that returns ALLOW by default."""
+    return MockTealEngine()
+
+
+@pytest.fixture
+def deny_engine() -> MockTealEngine:
+    """Create a mock TealEngine that returns DENY by default."""
+    return MockTealEngine(
+        default_action=GovernanceAction.DENY,
+        default_risk_score=80,
+        default_reason_codes=["POLICY_VIOLATION"],
+        default_reason="Policy denied the action",
+    )
+
+
+@pytest.fixture
+def refer_engine() -> MockTealEngine:
+    """Create a mock TealEngine that returns REFER by default."""
+    return MockTealEngine(
+        default_action=GovernanceAction.REFER,
+        default_risk_score=50,
+        default_reason_codes=["REQUIRES_REVIEW"],
+        default_reason="Action requires human review",
+    )
+
+
+@pytest.fixture
+def error_engine() -> ErrorTealEngine:
+    """Create a mock TealEngine that raises errors on evaluation."""
+    return ErrorTealEngine()
+
+
+def make_mock_engine(
+    action: GovernanceAction = GovernanceAction.ALLOW,
+    risk_score: int = 0,
+    reason_codes: list[str] | None = None,
+    reason: str = "Mock decision",
+) -> MockTealEngine:
+    """Factory function for creating MockTealEngine instances.
+
+    Use this in property-based tests where fixtures aren't available.
+    """
+    return MockTealEngine(
+        default_action=action,
+        default_risk_score=risk_score,
+        default_reason_codes=reason_codes,
+        default_reason=reason,
+    )
+
+
+# ── TealTigerGuard Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def guard() -> TealTigerGuard:
+    """Create a basic TealTigerGuard in observe mode (no engine)."""
+    return TealTigerGuard()
+
+
+@pytest.fixture
+def enforce_guard(mock_engine: MockTealEngine) -> TealTigerGuard:
+    """Create a TealTigerGuard in ENFORCE mode with mock engine."""
+    return TealTigerGuard(
+        engine=mock_engine,
+        mode=GovernanceMode.ENFORCE,
+    )
+
+
+@pytest.fixture
+def monitor_guard(mock_engine: MockTealEngine) -> TealTigerGuard:
+    """Create a TealTigerGuard in MONITOR mode with mock engine."""
+    return TealTigerGuard(
+        engine=mock_engine,
+        mode=GovernanceMode.MONITOR,
+    )
+
+
+# ── AG2 Agent Factory Fixtures ────────────────────────────────────────────────
+
+
+class MockConversableAgent:
+    """Lightweight mock of AG2's ConversableAgent for unit testing.
+
+    Provides the minimal interface needed by TealTigerGuard:
+    - name attribute (agent identity)
+    - register_reply method
+    - Configurable reply hooks list
+
+    This avoids importing ag2 in unit tests while preserving
+    the register_reply interface contract.
+    """
+
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+        self._kwargs = kwargs
+
+    def register_reply(
+        self,
+        trigger: Any,
+        reply_func: Any,
+        position: int = 0,
+        config: Any = None,
+        reset_config: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        """Register a reply function — mirrors AG2's ConversableAgent API."""
+        self._reply_funcs.insert(
+            position,
+            {
+                "trigger": trigger,
+                "reply_func": reply_func,
+                "config": config,
+                "reset_config": reset_config,
+            },
+        )
+
+    @property
+    def registered_reply_funcs(self) -> list[dict[str, Any]]:
+        """Access registered reply functions for test assertions."""
+        return self._reply_funcs
+
+
+class MockGroupChat:
+    """Lightweight mock of AG2's GroupChat for unit testing.
+
+    Provides the minimal interface for GovernedGroupChat tests:
+    - agents list
+    - messages list
+    - max_round configuration
+    - speaker_selection_method
+    """
+
+    def __init__(
+        self,
+        agents: list[MockConversableAgent] | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        max_round: int = 10,
+        speaker_selection_method: str = "auto",
+    ) -> None:
+        self.agents = agents or []
+        self.messages = messages or []
+        self.max_round = max_round
+        self.speaker_selection_method = speaker_selection_method
+
+
+@pytest.fixture
+def make_agent():
+    """Factory fixture for creating MockConversableAgent instances.
+
+    Usage:
+        agent = make_agent("coder")
+        agent = make_agent("reviewer", system_message="Review code")
+    """
+
+    def _factory(name: str, **kwargs: Any) -> MockConversableAgent:
+        return MockConversableAgent(name=name, **kwargs)
+
+    return _factory
+
+
+@pytest.fixture
+def agent_coder() -> MockConversableAgent:
+    """Pre-built coder agent for common test scenarios."""
+    return MockConversableAgent(name="coder")
+
+
+@pytest.fixture
+def agent_reviewer() -> MockConversableAgent:
+    """Pre-built reviewer agent for common test scenarios."""
+    return MockConversableAgent(name="reviewer")
+
+
+@pytest.fixture
+def agent_executor() -> MockConversableAgent:
+    """Pre-built executor agent for common test scenarios."""
+    return MockConversableAgent(name="executor")
+
+
+@pytest.fixture
+def agent_planner() -> MockConversableAgent:
+    """Pre-built planner agent for common test scenarios."""
+    return MockConversableAgent(name="planner")
+
+
+@pytest.fixture
+def multi_agent_group(
+    agent_coder: MockConversableAgent,
+    agent_reviewer: MockConversableAgent,
+    agent_executor: MockConversableAgent,
+) -> list[MockConversableAgent]:
+    """A group of 3 agents for GroupChat test scenarios."""
+    return [agent_coder, agent_reviewer, agent_executor]
+
+
+@pytest.fixture
+def large_agent_group(make_agent) -> list[MockConversableAgent]:
+    """A group of 5+ agents for REFER decision test scenarios."""
+    return [
+        make_agent("coder"),
+        make_agent("reviewer"),
+        make_agent("executor"),
+        make_agent("planner"),
+        make_agent("critic"),
+    ]
+
+
+def make_mock_agent(name: str, **kwargs: Any) -> MockConversableAgent:
+    """Factory function for creating MockConversableAgent in property tests.
+
+    Use this in property-based tests where fixtures aren't available.
+    """
+    return MockConversableAgent(name=name, **kwargs)
+
+
+# ── Test Utility Helpers ──────────────────────────────────────────────────────
+
+
+def make_tool_call_message(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    sender_name: str = "user",
+) -> dict[str, Any]:
+    """Create a mock tool call message in AG2 format.
+
+    AG2 represents tool calls as messages with a specific structure.
+    This helper creates that structure for test assertions.
+    """
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}_001",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments or {},
+                },
+            }
+        ],
+        "name": sender_name,
+    }
+
+
+def make_text_message(
+    content: str,
+    sender_name: str = "user",
+    role: str = "assistant",
+) -> dict[str, Any]:
+    """Create a mock text message in AG2 format."""
+    return {
+        "role": role,
+        "content": content,
+        "name": sender_name,
+    }

--- a/packages/ag2-tealtiger/tests/strategies.py
+++ b/packages/ag2-tealtiger/tests/strategies.py
@@ -1,0 +1,294 @@
+"""Custom Hypothesis strategies for ag2-tealtiger property-based tests.
+
+Provides generators for core domain types: agent identifiers, tool names,
+tool arguments, governance modes, governance decisions, TEEC contexts,
+and audit entries. These strategies constrain inputs to realistic values
+matching the AG2 + TealTiger domain.
+"""
+
+from __future__ import annotations
+
+import string
+from typing import Any
+
+from hypothesis import strategies as st
+
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    BudgetState,
+    DecisionSource,
+    DenialMessage,
+    GovernanceAction,
+    GovernanceMode,
+    TEECContext,
+)
+
+# ── Primitive Strategies ──────────────────────────────────────────────────────
+
+# Agent IDs: realistic identifiers matching AG2 agent naming conventions
+agent_ids: st.SearchStrategy[str] = st.from_regex(
+    r"[a-z][a-z0-9_]{2,29}", fullmatch=True
+)
+
+# Tool names: realistic function-style names (snake_case, dot-separated namespaces)
+tool_names: st.SearchStrategy[str] = st.one_of(
+    st.from_regex(r"[a-z][a-z0-9_]{1,24}", fullmatch=True),
+    st.sampled_from([
+        "web_search",
+        "file_read",
+        "file_write",
+        "code_execute",
+        "send_email",
+        "db_query",
+        "api_call",
+        "shell_exec",
+        "create_file",
+        "delete_file",
+        "http_request",
+        "calculate",
+        "summarize",
+        "translate",
+        "analyze_data",
+    ]),
+)
+
+# Tool arguments: dictionaries with string keys and JSON-serializable values
+_json_primitives: st.SearchStrategy[Any] = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-1_000_000, max_value=1_000_000),
+    st.floats(
+        min_value=-1e6,
+        max_value=1e6,
+        allow_nan=False,
+        allow_infinity=False,
+    ),
+    st.text(
+        alphabet=string.ascii_letters + string.digits + " _-./",
+        min_size=0,
+        max_size=100,
+    ),
+)
+
+# Recursive JSON-serializable values (nested dicts and lists)
+_json_values: st.SearchStrategy[Any] = st.recursive(
+    _json_primitives,
+    lambda children: st.one_of(
+        st.lists(children, max_size=5),
+        st.dictionaries(
+            keys=st.text(
+                alphabet=string.ascii_lowercase + "_",
+                min_size=1,
+                max_size=20,
+            ),
+            values=children,
+            max_size=5,
+        ),
+    ),
+    max_leaves=20,
+)
+
+tool_args: st.SearchStrategy[dict[str, Any]] = st.dictionaries(
+    keys=st.text(
+        alphabet=string.ascii_lowercase + "_",
+        min_size=1,
+        max_size=20,
+    ),
+    values=_json_values,
+    min_size=0,
+    max_size=8,
+)
+
+# ── Enum Strategies ───────────────────────────────────────────────────────────
+
+governance_modes: st.SearchStrategy[GovernanceMode] = st.sampled_from(
+    list(GovernanceMode)
+)
+
+governance_actions: st.SearchStrategy[GovernanceAction] = st.sampled_from(
+    list(GovernanceAction)
+)
+
+governance_decisions: st.SearchStrategy[dict[str, Any]] = st.fixed_dictionaries(
+    {
+        "action": st.sampled_from([a.value for a in GovernanceAction]),
+        "risk_score": st.integers(min_value=0, max_value=100),
+        "reason_codes": st.lists(
+            st.sampled_from([
+                "POLICY_VIOLATION",
+                "BUDGET_EXCEEDED",
+                "AGENT_FROZEN",
+                "REQUIRES_REVIEW",
+                "OBSERVE_PASSTHROUGH",
+                "ENGINE_ERROR",
+                "FAIL_CLOSED",
+                "FAIL_OPEN",
+                "ALL_SPEAKERS_DENIED",
+                "MESSAGE_DENIED",
+                "BUDGET_WARNING",
+                "DECISION_EXPIRED",
+                "REVALIDATION_TRIGGERED",
+                "REFER_DENIED",
+                "RECEIPT_EXPIRED",
+            ]),
+            min_size=1,
+            max_size=4,
+        ),
+        "reason": st.text(
+            alphabet=string.ascii_letters + string.digits + " _-.",
+            min_size=1,
+            max_size=100,
+        ),
+    }
+)
+
+action_kinds: st.SearchStrategy[ActionKind] = st.sampled_from(list(ActionKind))
+
+decision_sources: st.SearchStrategy[DecisionSource] = st.sampled_from(
+    list(DecisionSource)
+)
+
+# ── Composite Strategies ──────────────────────────────────────────────────────
+
+# UUID v4 strings (simplified: 32 hex chars formatted as UUID)
+uuids: st.SearchStrategy[str] = st.from_regex(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    fullmatch=True,
+)
+
+# SHA-256 hex digests (64 hex characters)
+sha256_hashes: st.SearchStrategy[str] = st.from_regex(
+    r"[0-9a-f]{64}", fullmatch=True
+)
+
+# Risk scores: 0-100 integer
+risk_scores: st.SearchStrategy[int] = st.integers(min_value=0, max_value=100)
+
+# Evaluation time in milliseconds (sub-5ms target, but allow range for testing)
+evaluation_times_ms: st.SearchStrategy[float] = st.floats(
+    min_value=0.01, max_value=100.0, allow_nan=False, allow_infinity=False
+)
+
+# Cost values: non-negative floats representing dollar amounts
+cost_values: st.SearchStrategy[float] = st.floats(
+    min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False
+)
+
+# Budget limits: positive floats
+budget_limits: st.SearchStrategy[float] = st.floats(
+    min_value=0.01, max_value=10000.0, allow_nan=False, allow_infinity=False
+)
+
+# Turn IDs: monotonically increasing positive integers
+turn_ids: st.SearchStrategy[int] = st.integers(min_value=1, max_value=10000)
+
+# Reason codes lists
+reason_codes: st.SearchStrategy[list[str]] = st.lists(
+    st.sampled_from([
+        "POLICY_VIOLATION",
+        "BUDGET_EXCEEDED",
+        "AGENT_FROZEN",
+        "REQUIRES_REVIEW",
+        "OBSERVE_PASSTHROUGH",
+        "ENGINE_ERROR",
+        "FAIL_CLOSED",
+        "FAIL_OPEN",
+        "ALL_SPEAKERS_DENIED",
+        "MESSAGE_DENIED",
+        "BUDGET_WARNING",
+        "DECISION_EXPIRED",
+        "REVALIDATION_TRIGGERED",
+        "REFER_DENIED",
+        "RECEIPT_EXPIRED",
+    ]),
+    min_size=1,
+    max_size=4,
+)
+
+# ── Domain Object Strategies ──────────────────────────────────────────────────
+
+
+@st.composite
+def teec_contexts(draw: st.DrawFn) -> TEECContext:
+    """Generate valid TEECContext instances."""
+    return TEECContext(
+        namespace="teec.ag2",
+        conversation_id=draw(uuids),
+        turn_id=draw(turn_ids),
+        agent_role=draw(st.one_of(st.none(), st.sampled_from([
+            "coder", "reviewer", "executor", "planner", "critic",
+        ]))),
+        group_chat_id=draw(st.one_of(st.none(), uuids)),
+        params_hash=draw(st.one_of(st.none(), sha256_hashes)),
+        parent_conversation_id=draw(st.one_of(st.none(), uuids)),
+        decision_id=draw(uuids),
+        idempotency_key=draw(st.one_of(st.none(), sha256_hashes)),
+        policy_digest=draw(st.one_of(st.none(), sha256_hashes)),
+        decision_source=draw(st.sampled_from([ds.value for ds in DecisionSource])),
+        execution_outcome=draw(st.one_of(st.none(), st.sampled_from([
+            "success", "failure", "timeout", "pending",
+        ]))),
+        approval_id=draw(st.one_of(st.none(), uuids)),
+    )
+
+
+@st.composite
+def audit_entries(draw: st.DrawFn) -> AuditEntry:
+    """Generate valid AuditEntry instances with complete fields."""
+    return AuditEntry(
+        correlation_id=draw(uuids),
+        decision_id=draw(uuids),
+        timestamp_ms=draw(st.floats(min_value=1e12, max_value=2e12)),
+        action=draw(st.sampled_from([a.value for a in GovernanceAction])),
+        action_kind=draw(st.sampled_from([ak.value for ak in ActionKind])),
+        mode=draw(st.sampled_from([m.value for m in GovernanceMode])),
+        agent_id=draw(agent_ids),
+        reason=draw(st.text(
+            alphabet=string.ascii_letters + " _-.",
+            min_size=1,
+            max_size=80,
+        )),
+        reason_codes=draw(reason_codes),
+        risk_score=draw(risk_scores),
+        evaluation_time_ms=draw(evaluation_times_ms),
+        teec=draw(teec_contexts()),
+        tool_name=draw(st.one_of(st.none(), tool_names)),
+        tool_args_summary=draw(st.one_of(st.none(), tool_args)),
+        pii_detected=draw(st.just([])),
+        cost_tracked=draw(cost_values),
+        cumulative_cost=draw(cost_values),
+    )
+
+
+@st.composite
+def budget_states(draw: st.DrawFn) -> BudgetState:
+    """Generate valid BudgetState instances."""
+    limit = draw(st.one_of(st.none(), budget_limits))
+    spend = draw(st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False))
+    remaining = (limit - spend) if limit is not None else None
+    return BudgetState(
+        agent_id=draw(agent_ids),
+        budget_limit=limit,
+        current_spend=spend,
+        remaining_budget=remaining,
+        warning_emitted=draw(st.booleans()),
+    )
+
+
+@st.composite
+def denial_messages(draw: st.DrawFn) -> DenialMessage:
+    """Generate valid DenialMessage instances."""
+    return DenialMessage(
+        tool_name=draw(tool_names),
+        action=GovernanceAction.DENY.value,
+        reason=draw(st.text(
+            alphabet=string.ascii_letters + " _-.",
+            min_size=1,
+            max_size=80,
+        )),
+        risk_score=draw(risk_scores),
+        reason_codes=draw(reason_codes),
+        correlation_id=draw(uuids),
+        decision_id=draw(uuids),
+    )

--- a/packages/ag2-tealtiger/tests/test_audit_agent.py
+++ b/packages/ag2-tealtiger/tests/test_audit_agent.py
@@ -1,0 +1,411 @@
+"""Unit tests for TealTigerAuditAgent.
+
+Tests the ConversableAgent subclass with built-in governance:
+- Extends ConversableAgent (or fallback base) and auto-registers TealTigerGuard
+- Accepts all ConversableAgent kwargs without modification
+- Zero-config observe mode when no TealEngine provided
+- Exposes guard, audit_trail, and summary properties
+- Optional budget_limit parameter
+
+Requirements validated: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+"""
+
+from __future__ import annotations
+
+from ag2_tealtiger.audit_agent import TealTigerAuditAgent
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+)
+from .conftest import (
+    make_mock_engine,
+    make_tool_call_message,
+    make_text_message,
+)
+
+
+# ── Initialization Tests ──────────────────────────────────────────────────────
+
+
+class TestAuditAgentInit:
+    """Tests for TealTigerAuditAgent initialization."""
+
+    def test_creates_with_name(self) -> None:
+        """Agent initializes with a name attribute."""
+        agent = TealTigerAuditAgent(name="coder")
+        assert agent.name == "coder"
+
+    def test_default_observe_mode_no_engine(self) -> None:
+        """Without engine, agent operates in observe mode (zero-config)."""
+        agent = TealTigerAuditAgent(name="coder")
+        assert agent.guard.engine is None
+        assert agent.guard.mode == GovernanceMode.OBSERVE
+
+    def test_with_engine_enforce_mode(self) -> None:
+        """With engine and mode, agent operates in specified mode."""
+        engine = make_mock_engine()
+        agent = TealTigerAuditAgent(
+            name="executor",
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        assert agent.guard.engine is engine
+        assert agent.guard.mode == GovernanceMode.ENFORCE
+
+    def test_with_engine_monitor_mode(self) -> None:
+        """Agent can be initialized in MONITOR mode."""
+        engine = make_mock_engine()
+        agent = TealTigerAuditAgent(
+            name="reviewer",
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+        )
+        assert agent.guard.mode == GovernanceMode.MONITOR
+
+    def test_registers_guard_on_init(self) -> None:
+        """Guard is automatically attached during initialization."""
+        agent = TealTigerAuditAgent(name="coder")
+        # Guard should track this agent as attached
+        assert "coder" in agent.guard.attached_agents
+
+    def test_accepts_kwargs_without_modification(self) -> None:
+        """All ConversableAgent kwargs are passed through to parent."""
+        agent = TealTigerAuditAgent(
+            name="coder",
+            system_message="You are a coder",
+            max_consecutive_auto_reply=5,
+            human_input_mode="NEVER",
+        )
+        assert agent.name == "coder"
+        # The agent should still have its guard working
+        assert agent.guard is not None
+
+    def test_budget_limit_sets_budget_on_guard(self) -> None:
+        """When budget_limit is provided, guard.set_budget is called."""
+        agent = TealTigerAuditAgent(name="executor", budget_limit=2.5)
+        budget_state = agent.guard.get_budget_state("executor")
+        assert budget_state.budget_limit == 2.5
+
+    def test_no_budget_limit_by_default(self) -> None:
+        """When budget_limit is None, no budget is configured."""
+        agent = TealTigerAuditAgent(name="coder")
+        budget_state = agent.guard.get_budget_state("coder")
+        assert budget_state.budget_limit is None
+
+
+# ── Guard Property Tests ──────────────────────────────────────────────────────
+
+
+class TestGuardProperty:
+    """Tests for the guard property."""
+
+    def test_returns_tealtiger_guard(self) -> None:
+        """guard property returns a TealTigerGuard instance."""
+        agent = TealTigerAuditAgent(name="coder")
+        assert isinstance(agent.guard, TealTigerGuard)
+
+    def test_guard_is_same_instance(self) -> None:
+        """guard property returns the same instance on multiple accesses."""
+        agent = TealTigerAuditAgent(name="coder")
+        first_guard = agent.guard
+        assert agent.guard is first_guard
+
+    def test_guard_has_correct_mode(self) -> None:
+        """Guard mode matches what was specified during init."""
+        engine = make_mock_engine()
+        agent = TealTigerAuditAgent(
+            name="coder",
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        assert agent.guard.mode == GovernanceMode.ENFORCE
+
+
+# ── Audit Trail Property Tests ────────────────────────────────────────────────
+
+
+class TestAuditTrailProperty:
+    """Tests for the audit_trail property."""
+
+    def test_empty_audit_trail_initially(self) -> None:
+        """audit_trail is empty when no evaluations have occurred."""
+        agent = TealTigerAuditAgent(name="coder")
+        assert agent.audit_trail == []
+
+    def test_audit_trail_records_evaluations(self) -> None:
+        """audit_trail accumulates entries after governance evaluations."""
+        agent = TealTigerAuditAgent(name="coder")
+
+        # Simulate a tool call message through the guard's reply hook
+        messages = [make_tool_call_message("run_code", {"code": "print('hi')"})]
+        sender = type("MockSender", (), {"name": "user"})()
+
+        agent.guard._reply_hook(agent, messages, sender, None)
+
+        assert len(agent.audit_trail) > 0
+
+    def test_audit_trail_returns_ordered_list(self) -> None:
+        """audit_trail returns AuditEntry objects in chronological order."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        # Multiple tool calls
+        for tool in ["run_code", "web_search", "read_file"]:
+            messages = [make_tool_call_message(tool, {"input": "test"})]
+            agent.guard._reply_hook(agent, messages, sender, None)
+
+        assert len(agent.audit_trail) >= 3
+        # Verify ordering by timestamp
+        timestamps = [e.timestamp_ms for e in agent.audit_trail]
+        assert timestamps == sorted(timestamps)
+
+    def test_audit_trail_entries_are_audit_entry_type(self) -> None:
+        """All entries in audit_trail are AuditEntry instances."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+        messages = [make_tool_call_message("run_code", {"code": "x=1"})]
+
+        agent.guard._reply_hook(agent, messages, sender, None)
+
+        for entry in agent.audit_trail:
+            assert isinstance(entry, AuditEntry)
+
+    def test_audit_trail_delegates_to_guard(self) -> None:
+        """audit_trail property returns the same list as guard.audit_trail."""
+        agent = TealTigerAuditAgent(name="coder")
+        assert agent.audit_trail is agent.guard.audit_trail
+
+
+# ── Summary Property Tests ────────────────────────────────────────────────────
+
+
+class TestSummaryProperty:
+    """Tests for the summary property."""
+
+    def test_empty_summary_initially(self) -> None:
+        """summary returns zero totals when no evaluations occurred."""
+        agent = TealTigerAuditAgent(name="coder")
+        summary = agent.summary
+        assert summary == {
+            "tools": {},
+            "total_cost": 0.0,
+            "total_calls": 0,
+        }
+
+    def test_summary_groups_by_tool_name(self) -> None:
+        """summary groups call counts and costs by tool name."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        # Simulate multiple tool calls
+        for _ in range(3):
+            messages = [make_tool_call_message("run_code", {"code": "x=1"})]
+            agent.guard._reply_hook(agent, messages, sender, None)
+
+        for _ in range(2):
+            messages = [make_tool_call_message("web_search", {"query": "test"})]
+            agent.guard._reply_hook(agent, messages, sender, None)
+
+        summary = agent.summary
+        assert "run_code" in summary["tools"]
+        assert "web_search" in summary["tools"]
+        assert summary["tools"]["run_code"]["calls"] == 3
+        assert summary["tools"]["web_search"]["calls"] == 2
+        assert summary["total_calls"] == 5
+
+    def test_summary_total_calls_matches_tool_sum(self) -> None:
+        """total_calls equals the sum of per-tool call counts."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        tools = ["run_code", "web_search", "run_code", "read_file"]
+        for tool in tools:
+            messages = [make_tool_call_message(tool, {"input": "x"})]
+            agent.guard._reply_hook(agent, messages, sender, None)
+
+        summary = agent.summary
+        per_tool_sum = sum(t["calls"] for t in summary["tools"].values())
+        assert summary["total_calls"] == per_tool_sum
+
+    def test_summary_does_not_count_message_actions(self) -> None:
+        """summary only counts tool_call action kinds, not messages."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        # Send a plain text message (no tool calls)
+        messages = [make_text_message("Hello, world!")]
+        agent.guard._reply_hook(agent, messages, sender, None)
+
+        summary = agent.summary
+        assert summary["total_calls"] == 0
+
+    def test_summary_structure(self) -> None:
+        """summary returns the expected dict structure."""
+        agent = TealTigerAuditAgent(name="coder")
+        summary = agent.summary
+        assert "tools" in summary
+        assert "total_cost" in summary
+        assert "total_calls" in summary
+        assert isinstance(summary["tools"], dict)
+        assert isinstance(summary["total_cost"], float)
+        assert isinstance(summary["total_calls"], int)
+
+
+# ── Zero-Config Observe Mode Tests ───────────────────────────────────────────
+
+
+class TestZeroConfigObserveMode:
+    """Tests for zero-config observe mode behavior."""
+
+    def test_observe_mode_allows_all_tool_calls(self) -> None:
+        """In observe mode, all tool calls pass through without blocking."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        messages = [make_tool_call_message("dangerous_tool", {"target": "system"})]
+        result = agent.guard._reply_hook(agent, messages, sender, None)
+
+        # (False, None) means pass through — not blocked
+        assert result == (False, None)
+
+    def test_observe_mode_records_audit_entries(self) -> None:
+        """In observe mode, audit entries are still recorded."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        messages = [make_tool_call_message("run_code", {"code": "x=1"})]
+        agent.guard._reply_hook(agent, messages, sender, None)
+
+        assert len(agent.audit_trail) > 0
+        entry = agent.audit_trail[-1]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert "OBSERVE_PASSTHROUGH" in entry.reason_codes
+
+    def test_observe_mode_tracks_tool_names(self) -> None:
+        """In observe mode, tool names are tracked in audit entries."""
+        agent = TealTigerAuditAgent(name="coder")
+        sender = type("MockSender", (), {"name": "user"})()
+
+        messages = [make_tool_call_message("run_code", {"code": "x=1"})]
+        agent.guard._reply_hook(agent, messages, sender, None)
+
+        # Check that tool_name is recorded
+        tool_call_entries = [
+            e for e in agent.audit_trail if e.action_kind == "tool_call"
+        ]
+        assert len(tool_call_entries) > 0
+        assert tool_call_entries[0].tool_name == "run_code"
+
+
+# ── Budget Limit Integration Tests ───────────────────────────────────────────
+
+
+class TestBudgetLimitIntegration:
+    """Tests for budget_limit parameter integration."""
+
+    def test_budget_limit_configures_guard(self) -> None:
+        """budget_limit parameter configures the guard's budget manager."""
+        agent = TealTigerAuditAgent(name="executor", budget_limit=5.0)
+        state = agent.guard.get_budget_state("executor")
+        assert state.budget_limit == 5.0
+        assert state.current_spend == 0.0
+
+    def test_budget_limit_zero_spend_initially(self) -> None:
+        """Budget starts at zero spend when configured."""
+        agent = TealTigerAuditAgent(name="executor", budget_limit=10.0)
+        state = agent.guard.get_budget_state("executor")
+        assert state.remaining_budget == 10.0
+
+    def test_no_budget_without_parameter(self) -> None:
+        """Without budget_limit, no budget constraint is applied."""
+        agent = TealTigerAuditAgent(name="coder")
+        state = agent.guard.get_budget_state("coder")
+        assert state.budget_limit is None
+        assert state.remaining_budget is None
+
+
+# ── ConversableAgent Kwargs Passthrough Tests ─────────────────────────────────
+
+
+class TestKwargsPassthrough:
+    """Tests that ConversableAgent kwargs are passed through unchanged."""
+
+    def test_multiple_kwargs_accepted(self) -> None:
+        """Multiple kwargs can be passed without error."""
+        # These kwargs are typical ConversableAgent params
+        agent = TealTigerAuditAgent(
+            name="coder",
+            system_message="You are a helpful coder",
+            max_consecutive_auto_reply=10,
+            human_input_mode="NEVER",
+            llm_config={"model": "gpt-4"},
+            code_execution_config={"work_dir": "/tmp"},
+        )
+        assert agent.name == "coder"
+        # Guard should still be functional
+        assert isinstance(agent.guard, TealTigerGuard)
+
+    def test_kwargs_do_not_interfere_with_guard(self) -> None:
+        """ConversableAgent kwargs don't break guard registration."""
+        agent = TealTigerAuditAgent(
+            name="agent",
+            system_message="test",
+            is_termination_msg=lambda msg: False,
+        )
+        assert "agent" in agent.guard.attached_agents
+
+    def test_engine_kwarg_goes_to_guard_not_parent(self) -> None:
+        """engine param is consumed by TealTigerAuditAgent, not passed to parent."""
+        engine = make_mock_engine()
+        agent = TealTigerAuditAgent(name="agent", engine=engine)
+        assert agent.guard.engine is engine
+
+
+# ── Policy Mode Integration Tests ─────────────────────────────────────────────
+
+
+class TestPolicyModeIntegration:
+    """Tests for TealTigerAuditAgent with policy engine."""
+
+    def test_enforce_mode_blocks_denied_calls(self) -> None:
+        """In ENFORCE mode with DENY engine, tool calls are blocked."""
+        engine = make_mock_engine(
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        agent = TealTigerAuditAgent(
+            name="executor",
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        sender = type("MockSender", (), {"name": "user"})()
+
+        messages = [make_tool_call_message("run_code", {"code": "rm -rf /"})]
+        result = agent.guard._reply_hook(agent, messages, sender, None)
+
+        # (True, message) means blocked
+        assert result[0] is True
+        assert "GOVERNANCE DENIAL" in str(result[1])
+
+    def test_monitor_mode_allows_denied_calls(self) -> None:
+        """In MONITOR mode with DENY engine, tool calls pass through."""
+        engine = make_mock_engine(
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        agent = TealTigerAuditAgent(
+            name="executor",
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+        )
+        sender = type("MockSender", (), {"name": "user"})()
+
+        messages = [make_tool_call_message("run_code", {"code": "rm -rf /"})]
+        result = agent.guard._reply_hook(agent, messages, sender, None)
+
+        # (False, None) means pass through
+        assert result == (False, None)

--- a/packages/ag2-tealtiger/tests/test_audit_export.py
+++ b/packages/ag2-tealtiger/tests/test_audit_export.py
@@ -1,0 +1,405 @@
+"""Tests for TealTigerGuard.export_audit_trail — JSONL export and round-trip parsing.
+
+Validates:
+- Task 6.9: audit_trail property, export_audit_trail(path, format="jsonl"), evaluation_time_ms
+- Requirements: 12.1, 12.3, 12.4, 12.5, 13.5
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+    ActionKind,
+    TEECContext,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_audit_entry(
+    agent_id: str = "agent-1",
+    tool_name: str | None = "web_search",
+    action: str = GovernanceAction.ALLOW.value,
+    evaluation_time_ms: float = 1.5,
+    **overrides: Any,
+) -> AuditEntry:
+    """Create a minimal valid AuditEntry for testing."""
+    import uuid
+
+    decision_id = str(uuid.uuid4())
+    defaults = dict(
+        correlation_id=str(uuid.uuid4()),
+        decision_id=decision_id,
+        timestamp_ms=time.time() * 1000,
+        action=action,
+        action_kind=ActionKind.TOOL_CALL.value,
+        mode=GovernanceMode.OBSERVE.value,
+        agent_id=agent_id,
+        reason="Test entry",
+        reason_codes=["OBSERVE_PASSTHROUGH"],
+        risk_score=0,
+        evaluation_time_ms=evaluation_time_ms,
+        teec=TEECContext(
+            namespace="teec.ag2",
+            conversation_id=str(uuid.uuid4()),
+            turn_id=1,
+            agent_role=agent_id,
+            decision_id=decision_id,
+            decision_source="default_mode",
+        ),
+        tool_name=tool_name,
+    )
+    defaults.update(overrides)
+    return AuditEntry(**defaults)
+
+
+class _MockConversableAgent:
+    """Lightweight mock of AG2's ConversableAgent."""
+
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self,
+        trigger: Any,
+        reply_func: Any,
+        position: int = 0,
+        config: Any = None,
+        reset_config: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._reply_funcs.insert(
+            position,
+            {
+                "trigger": trigger,
+                "reply_func": reply_func,
+                "config": config,
+                "reset_config": reset_config,
+            },
+        )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestExportAuditTrailBasic:
+    """Test export_audit_trail core behavior."""
+
+    def test_export_empty_trail(self, tmp_path: Path) -> None:
+        """Exporting an empty audit trail writes an empty file and returns 0."""
+        guard = TealTigerGuard()
+        out_file = tmp_path / "audit.jsonl"
+
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == 0
+        assert out_file.read_text() == ""
+
+    def test_export_single_entry(self, tmp_path: Path) -> None:
+        """Exporting a single entry writes one JSON line."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(agent_id="coder")
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == 1
+        lines = out_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+
+        parsed = json.loads(lines[0])
+        assert parsed["agent_id"] == "coder"
+        assert parsed["tool_name"] == "web_search"
+
+    def test_export_multiple_entries(self, tmp_path: Path) -> None:
+        """Exporting multiple entries writes one JSON line per entry."""
+        guard = TealTigerGuard()
+        for i in range(5):
+            guard._audit_trail.append(_make_audit_entry(agent_id=f"agent-{i}"))
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == 5
+        lines = out_file.read_text().strip().split("\n")
+        assert len(lines) == 5
+
+        for i, line in enumerate(lines):
+            parsed = json.loads(line)
+            assert parsed["agent_id"] == f"agent-{i}"
+
+    def test_export_preserves_order(self, tmp_path: Path) -> None:
+        """Entries are written in the same order they appear in the audit trail."""
+        guard = TealTigerGuard()
+        agents = ["alpha", "beta", "gamma", "delta"]
+        for name in agents:
+            guard._audit_trail.append(_make_audit_entry(agent_id=name))
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        lines = out_file.read_text().strip().split("\n")
+        for i, line in enumerate(lines):
+            parsed = json.loads(line)
+            assert parsed["agent_id"] == agents[i]
+
+
+class TestExportAuditTrailRoundTrip:
+    """Test JSONL export round-trip — export then parse back."""
+
+    def test_roundtrip_all_fields(self, tmp_path: Path) -> None:
+        """All AuditEntry fields survive round-trip through JSONL export."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(
+            agent_id="reviewer",
+            tool_name="code_execute",
+            action=GovernanceAction.DENY.value,
+            evaluation_time_ms=3.75,
+            risk_score=85,
+            reason="Policy violation",
+            reason_codes=["UNAUTHORIZED_TOOL", "HIGH_RISK"],
+            pii_detected=[{"type": "email", "value": "***@***.com"}],
+            cost_tracked=0.005,
+            cumulative_cost=0.123,
+        )
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        parsed = json.loads(out_file.read_text().strip())
+
+        # Verify core fields
+        assert parsed["agent_id"] == "reviewer"
+        assert parsed["tool_name"] == "code_execute"
+        assert parsed["action"] == "DENY"
+        assert parsed["evaluation_time_ms"] == 3.75
+        assert parsed["risk_score"] == 85
+        assert parsed["reason"] == "Policy violation"
+        assert parsed["reason_codes"] == ["UNAUTHORIZED_TOOL", "HIGH_RISK"]
+        assert parsed["pii_detected"] == [{"type": "email", "value": "***@***.com"}]
+        assert parsed["cost_tracked"] == 0.005
+        assert parsed["cumulative_cost"] == 0.123
+
+    def test_roundtrip_teec_context(self, tmp_path: Path) -> None:
+        """Nested TEECContext dataclass is correctly serialized."""
+        import uuid
+
+        conv_id = str(uuid.uuid4())
+        decision_id = str(uuid.uuid4())
+        parent_conv_id = str(uuid.uuid4())
+
+        teec = TEECContext(
+            namespace="teec.ag2",
+            conversation_id=conv_id,
+            turn_id=7,
+            agent_role="executor",
+            group_chat_id="gc-001",
+            params_hash="abc123def",
+            parent_conversation_id=parent_conv_id,
+            decision_id=decision_id,
+            idempotency_key="idem-key-456",
+            policy_digest="pol-digest-789",
+            decision_source="policy_engine",
+            execution_outcome="success",
+            approval_id="approval-001",
+        )
+
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(teec=teec)
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        parsed = json.loads(out_file.read_text().strip())
+        teec_parsed = parsed["teec"]
+
+        assert teec_parsed["namespace"] == "teec.ag2"
+        assert teec_parsed["conversation_id"] == conv_id
+        assert teec_parsed["turn_id"] == 7
+        assert teec_parsed["agent_role"] == "executor"
+        assert teec_parsed["group_chat_id"] == "gc-001"
+        assert teec_parsed["params_hash"] == "abc123def"
+        assert teec_parsed["parent_conversation_id"] == parent_conv_id
+        assert teec_parsed["decision_id"] == decision_id
+        assert teec_parsed["idempotency_key"] == "idem-key-456"
+        assert teec_parsed["policy_digest"] == "pol-digest-789"
+        assert teec_parsed["decision_source"] == "policy_engine"
+        assert teec_parsed["execution_outcome"] == "success"
+        assert teec_parsed["approval_id"] == "approval-001"
+
+    def test_roundtrip_optional_none_fields(self, tmp_path: Path) -> None:
+        """Optional None fields serialize as null in JSON."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(
+            tool_name=None,
+            tool_args_summary=None,
+            trace_id=None,
+        )
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        parsed = json.loads(out_file.read_text().strip())
+        assert parsed["tool_name"] is None
+        assert parsed["tool_args_summary"] is None
+        assert parsed["trace_id"] is None
+
+    def test_roundtrip_metadata_dict(self, tmp_path: Path) -> None:
+        """Metadata dict with arbitrary content is preserved."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(
+            metadata={"custom_key": "value", "nested": {"a": 1, "b": [2, 3]}}
+        )
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        parsed = json.loads(out_file.read_text().strip())
+        assert parsed["metadata"] == {"custom_key": "value", "nested": {"a": 1, "b": [2, 3]}}
+
+
+class TestExportAuditTrailEvaluationTime:
+    """Test that evaluation_time_ms is recorded in every AuditEntry."""
+
+    def test_evaluation_time_positive(self, tmp_path: Path) -> None:
+        """evaluation_time_ms is present and positive in exported entries."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(evaluation_time_ms=2.34)
+        guard._audit_trail.append(entry)
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        parsed = json.loads(out_file.read_text().strip())
+        assert parsed["evaluation_time_ms"] == 2.34
+        assert parsed["evaluation_time_ms"] > 0
+
+    def test_evaluation_time_in_freeze_entries(self, tmp_path: Path) -> None:
+        """Freeze/unfreeze audit entries include evaluation_time_ms > 0."""
+        guard = TealTigerGuard()
+        guard.freeze("test-agent")
+        guard.unfreeze("test-agent")
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == 2
+        lines = out_file.read_text().strip().split("\n")
+        for line in lines:
+            parsed = json.loads(line)
+            assert "evaluation_time_ms" in parsed
+            assert parsed["evaluation_time_ms"] >= 0
+
+
+class TestExportAuditTrailFormat:
+    """Test format parameter validation."""
+
+    def test_unsupported_format_raises(self, tmp_path: Path) -> None:
+        """Unsupported format raises ValueError."""
+        guard = TealTigerGuard()
+        out_file = tmp_path / "audit.csv"
+
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            guard.export_audit_trail(str(out_file), format="csv")
+
+    def test_jsonl_format_explicit(self, tmp_path: Path) -> None:
+        """Explicit format='jsonl' works the same as the default."""
+        guard = TealTigerGuard()
+        guard._audit_trail.append(_make_audit_entry())
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file), format="jsonl")
+
+        assert count == 1
+        parsed = json.loads(out_file.read_text().strip())
+        assert "agent_id" in parsed
+
+    def test_each_line_is_valid_json(self, tmp_path: Path) -> None:
+        """Each line in the JSONL file is independently parseable as JSON."""
+        guard = TealTigerGuard()
+        for i in range(10):
+            guard._audit_trail.append(_make_audit_entry(agent_id=f"agent-{i}"))
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        lines = out_file.read_text().strip().split("\n")
+        assert len(lines) == 10
+        for line in lines:
+            # Should not raise
+            parsed = json.loads(line)
+            assert isinstance(parsed, dict)
+
+    def test_no_multiline_json(self, tmp_path: Path) -> None:
+        """Each entry is serialized as a single line (no pretty-printing)."""
+        guard = TealTigerGuard()
+        guard._audit_trail.append(
+            _make_audit_entry(metadata={"key": "value\nwith newline"})
+        )
+
+        out_file = tmp_path / "audit.jsonl"
+        guard.export_audit_trail(str(out_file))
+
+        content = out_file.read_text()
+        # Only one entry, so content should have exactly one newline at the end
+        # (the line terminator) — the embedded \n in metadata should be escaped
+        lines = content.split("\n")
+        # Last element is empty after the trailing newline
+        assert len(lines) == 2
+        assert lines[1] == ""
+
+
+class TestExportAuditTrailIntegration:
+    """Integration tests verifying export works with guard lifecycle."""
+
+    def test_export_after_freeze_and_unfreeze(self, tmp_path: Path) -> None:
+        """Export includes freeze and unfreeze entries from guard operations."""
+        guard = TealTigerGuard()
+        guard.freeze("agent-x")
+        guard.unfreeze("agent-x")
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == 2
+        lines = out_file.read_text().strip().split("\n")
+
+        freeze_entry = json.loads(lines[0])
+        assert freeze_entry["action_kind"] == "freeze"
+        assert freeze_entry["action"] == "DENY"
+        assert "AGENT_FROZEN" in freeze_entry["reason_codes"]
+
+        unfreeze_entry = json.loads(lines[1])
+        assert unfreeze_entry["action_kind"] == "freeze"
+        assert unfreeze_entry["action"] == "ALLOW"
+        assert "AGENT_UNFROZEN" in unfreeze_entry["reason_codes"]
+
+    def test_export_returns_count_matching_trail_length(self, tmp_path: Path) -> None:
+        """Return value equals the length of the audit trail."""
+        guard = TealTigerGuard()
+        n = 7
+        for i in range(n):
+            guard._audit_trail.append(_make_audit_entry(agent_id=f"a-{i}"))
+
+        out_file = tmp_path / "audit.jsonl"
+        count = guard.export_audit_trail(str(out_file))
+
+        assert count == n
+        assert count == len(guard.audit_trail)

--- a/packages/ag2-tealtiger/tests/test_budget_manager.py
+++ b/packages/ag2-tealtiger/tests/test_budget_manager.py
@@ -1,0 +1,349 @@
+"""Unit tests for BudgetStateManager.
+
+Tests cover:
+- Per-agent cost accumulation
+- Budget limit enforcement
+- 80% threshold warning emission
+- remaining_budget invariant
+- Reset behavior
+- Edge cases (no limit, zero cost, multiple agents)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ag2_tealtiger.budget_manager import BudgetCheckResult, BudgetStateManager
+from ag2_tealtiger.types import BudgetState
+
+
+class TestTrackCost:
+    """Tests for track_cost method."""
+
+    def test_accumulates_cost(self) -> None:
+        """Cost is accumulated across multiple track_cost calls."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 2.0)
+        mgr.track_cost("agent-1", 3.0)
+        state = mgr.get_state("agent-1")
+        assert state.current_spend == 5.0
+
+    def test_returns_budget_check_result(self) -> None:
+        """track_cost returns a BudgetCheckResult."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        result = mgr.track_cost("agent-1", 2.0)
+        assert isinstance(result, BudgetCheckResult)
+        assert result.exceeded is False
+        assert result.remaining == 8.0
+        assert result.warning is False
+
+    def test_negative_cost_raises(self) -> None:
+        """Negative cost values are rejected."""
+        mgr = BudgetStateManager()
+        with pytest.raises(ValueError, match="non-negative"):
+            mgr.track_cost("agent-1", -1.0)
+
+    def test_zero_cost_is_valid(self) -> None:
+        """Zero cost is a valid no-op."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        result = mgr.track_cost("agent-1", 0.0)
+        assert result.exceeded is False
+        assert result.remaining == 10.0
+
+    def test_no_limit_configured(self) -> None:
+        """Track cost works even without a budget limit configured."""
+        mgr = BudgetStateManager()
+        result = mgr.track_cost("agent-1", 5.0)
+        assert result.exceeded is False
+        assert result.remaining is None
+        assert result.warning is False
+
+    def test_exceeded_detection(self) -> None:
+        """Budget exceeded is detected when spend > limit."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        result = mgr.track_cost("agent-1", 11.0)
+        assert result.exceeded is True
+        assert result.remaining == -1.0
+
+
+class TestBudgetWarning:
+    """Tests for the 80% warning threshold."""
+
+    def test_warning_emitted_at_80_percent(self) -> None:
+        """Warning is emitted when cost crosses 80% of limit."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        # 7.9 is under 80% (8.0)
+        result = mgr.track_cost("agent-1", 7.9)
+        assert result.warning is False
+        # 0.2 pushes total to 8.1, crossing 80%
+        result = mgr.track_cost("agent-1", 0.2)
+        assert result.warning is True
+
+    def test_warning_emitted_only_once(self) -> None:
+        """Warning is only emitted once per agent (not on subsequent calls)."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 8.5)  # Triggers warning
+        result = mgr.track_cost("agent-1", 0.5)
+        assert result.warning is False  # Already emitted
+
+    def test_warning_callback_invoked(self) -> None:
+        """Callback is invoked when warning threshold is crossed."""
+        warnings: list[tuple[str, float, float]] = []
+
+        def on_warning(agent_id: str, spend: float, limit: float) -> None:
+            warnings.append((agent_id, spend, limit))
+
+        mgr = BudgetStateManager(on_budget_warning=on_warning)
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 9.0)
+        assert len(warnings) == 1
+        assert warnings[0] == ("agent-1", 9.0, 10.0)
+
+    def test_warning_not_triggered_without_limit(self) -> None:
+        """No warning is emitted when no limit is configured."""
+        warnings: list[tuple[str, float, float]] = []
+
+        def on_warning(agent_id: str, spend: float, limit: float) -> None:
+            warnings.append((agent_id, spend, limit))
+
+        mgr = BudgetStateManager(on_budget_warning=on_warning)
+        mgr.track_cost("agent-1", 100.0)
+        assert len(warnings) == 0
+
+    def test_exact_80_percent_triggers_warning(self) -> None:
+        """Exactly 80% of the limit triggers the warning."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        result = mgr.track_cost("agent-1", 8.0)
+        assert result.warning is True
+
+
+class TestGetState:
+    """Tests for get_state method."""
+
+    def test_new_agent_default_state(self) -> None:
+        """New agent returns default BudgetState."""
+        mgr = BudgetStateManager()
+        state = mgr.get_state("new-agent")
+        assert state.agent_id == "new-agent"
+        assert state.budget_limit is None
+        assert state.current_spend == 0.0
+        assert state.remaining_budget is None
+        assert state.warning_emitted is False
+
+    def test_remaining_budget_invariant(self) -> None:
+        """remaining_budget = budget_limit - current_spend."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 20.0)
+        mgr.track_cost("agent-1", 7.5)
+        state = mgr.get_state("agent-1")
+        assert state.remaining_budget == 12.5
+        assert state.remaining_budget == state.budget_limit - state.current_spend
+
+    def test_returns_budget_state_type(self) -> None:
+        """get_state returns a BudgetState dataclass."""
+        mgr = BudgetStateManager()
+        state = mgr.get_state("agent-1")
+        assert isinstance(state, BudgetState)
+
+
+class TestCheckBudget:
+    """Tests for check_budget method."""
+
+    def test_within_budget(self) -> None:
+        """Agent within budget returns exceeded=False."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 5.0)
+        result = mgr.check_budget("agent-1")
+        assert result.exceeded is False
+        assert result.remaining == 5.0
+
+    def test_exceeded_budget(self) -> None:
+        """Agent over budget returns exceeded=True."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 15.0)
+        result = mgr.check_budget("agent-1")
+        assert result.exceeded is True
+        assert result.remaining == -5.0
+
+    def test_no_limit_never_exceeded(self) -> None:
+        """Without a limit, budget is never exceeded."""
+        mgr = BudgetStateManager()
+        mgr.track_cost("agent-1", 1000.0)
+        result = mgr.check_budget("agent-1")
+        assert result.exceeded is False
+        assert result.remaining is None
+
+    def test_does_not_modify_state(self) -> None:
+        """check_budget is a read-only operation."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 5.0)
+        state_before = mgr.get_state("agent-1")
+        mgr.check_budget("agent-1")
+        state_after = mgr.get_state("agent-1")
+        assert state_before.current_spend == state_after.current_spend
+
+    def test_reports_warning_status(self) -> None:
+        """check_budget reports whether warning was previously emitted."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        result = mgr.check_budget("agent-1")
+        assert result.warning is False
+        mgr.track_cost("agent-1", 9.0)  # Triggers warning
+        result = mgr.check_budget("agent-1")
+        assert result.warning is True
+
+
+class TestSetLimit:
+    """Tests for set_limit method."""
+
+    def test_sets_budget_limit(self) -> None:
+        """set_limit configures the budget limit for an agent."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 50.0)
+        state = mgr.get_state("agent-1")
+        assert state.budget_limit == 50.0
+        assert state.remaining_budget == 50.0
+
+    def test_updates_remaining_budget(self) -> None:
+        """Changing limit updates remaining_budget correctly."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 20.0)
+        mgr.track_cost("agent-1", 5.0)
+        mgr.set_limit("agent-1", 30.0)
+        state = mgr.get_state("agent-1")
+        assert state.budget_limit == 30.0
+        assert state.remaining_budget == 25.0
+
+    def test_invalid_limit_raises(self) -> None:
+        """Non-positive limits are rejected."""
+        mgr = BudgetStateManager()
+        with pytest.raises(ValueError, match="positive"):
+            mgr.set_limit("agent-1", 0.0)
+        with pytest.raises(ValueError, match="positive"):
+            mgr.set_limit("agent-1", -5.0)
+
+    def test_lowering_limit_triggers_warning(self) -> None:
+        """Lowering limit below 80% of current spend triggers warning."""
+        warnings: list[tuple[str, float, float]] = []
+
+        def on_warning(agent_id: str, spend: float, limit: float) -> None:
+            warnings.append((agent_id, spend, limit))
+
+        mgr = BudgetStateManager(on_budget_warning=on_warning)
+        mgr.set_limit("agent-1", 100.0)
+        mgr.track_cost("agent-1", 9.0)  # 9% of 100, no warning
+        assert len(warnings) == 0
+        mgr.set_limit("agent-1", 10.0)  # Now 9.0 is 90% of 10.0
+        assert len(warnings) == 1
+
+
+class TestReset:
+    """Tests for reset method."""
+
+    def test_resets_spend_to_zero(self) -> None:
+        """reset clears current_spend to zero."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 5.0)
+        mgr.reset("agent-1")
+        state = mgr.get_state("agent-1")
+        assert state.current_spend == 0.0
+
+    def test_preserves_budget_limit(self) -> None:
+        """reset preserves the configured budget limit."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 5.0)
+        mgr.reset("agent-1")
+        state = mgr.get_state("agent-1")
+        assert state.budget_limit == 10.0
+        assert state.remaining_budget == 10.0
+
+    def test_resets_warning_flag(self) -> None:
+        """reset clears the warning_emitted flag."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 9.0)  # Triggers warning
+        state = mgr.get_state("agent-1")
+        assert state.warning_emitted is True
+        mgr.reset("agent-1")
+        state = mgr.get_state("agent-1")
+        assert state.warning_emitted is False
+
+    def test_warning_can_re_trigger_after_reset(self) -> None:
+        """After reset, the warning can be emitted again."""
+        warnings: list[tuple[str, float, float]] = []
+
+        def on_warning(agent_id: str, spend: float, limit: float) -> None:
+            warnings.append((agent_id, spend, limit))
+
+        mgr = BudgetStateManager(on_budget_warning=on_warning)
+        mgr.set_limit("agent-1", 10.0)
+        mgr.track_cost("agent-1", 9.0)
+        assert len(warnings) == 1
+        mgr.reset("agent-1")
+        mgr.track_cost("agent-1", 8.5)
+        assert len(warnings) == 2
+
+    def test_reset_nonexistent_agent(self) -> None:
+        """Resetting an agent that hasn't been tracked creates default state."""
+        mgr = BudgetStateManager()
+        mgr.reset("new-agent")
+        state = mgr.get_state("new-agent")
+        assert state.current_spend == 0.0
+        assert state.budget_limit is None
+
+
+class TestMultiAgentIsolation:
+    """Tests for per-agent isolation."""
+
+    def test_independent_cost_tracking(self) -> None:
+        """Each agent tracks cost independently."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-a", 10.0)
+        mgr.set_limit("agent-b", 20.0)
+        mgr.track_cost("agent-a", 5.0)
+        mgr.track_cost("agent-b", 15.0)
+        assert mgr.get_state("agent-a").current_spend == 5.0
+        assert mgr.get_state("agent-b").current_spend == 15.0
+
+    def test_independent_budget_limits(self) -> None:
+        """Each agent has its own budget limit."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-a", 10.0)
+        mgr.set_limit("agent-b", 100.0)
+        mgr.track_cost("agent-a", 11.0)
+        mgr.track_cost("agent-b", 11.0)
+        assert mgr.check_budget("agent-a").exceeded is True
+        assert mgr.check_budget("agent-b").exceeded is False
+
+    def test_independent_warning_emission(self) -> None:
+        """Warnings are tracked independently per agent."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-a", 10.0)
+        mgr.set_limit("agent-b", 10.0)
+        result_a = mgr.track_cost("agent-a", 9.0)
+        result_b = mgr.track_cost("agent-b", 3.0)
+        assert result_a.warning is True
+        assert result_b.warning is False
+
+    def test_reset_one_does_not_affect_other(self) -> None:
+        """Resetting one agent doesn't affect another."""
+        mgr = BudgetStateManager()
+        mgr.set_limit("agent-a", 10.0)
+        mgr.set_limit("agent-b", 10.0)
+        mgr.track_cost("agent-a", 5.0)
+        mgr.track_cost("agent-b", 7.0)
+        mgr.reset("agent-a")
+        assert mgr.get_state("agent-a").current_spend == 0.0
+        assert mgr.get_state("agent-b").current_spend == 7.0

--- a/packages/ag2-tealtiger/tests/test_decision_manager.py
+++ b/packages/ag2-tealtiger/tests/test_decision_manager.py
@@ -1,0 +1,385 @@
+"""Unit tests for DecisionReceiptManager.
+
+Tests cover:
+- Receipt creation with explicit and default expiry
+- Validity checking (valid, expired, manually expired, unknown)
+- Revalidation condition evaluation (cost_exceeded, time_elapsed, context_changed)
+- Manual expiry with reason recording
+- Configurable default expiry duration
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.types import GovernanceAction, RevalidationCondition
+
+
+class TestCreateReceipt:
+    """Tests for DecisionReceiptManager.create_receipt."""
+
+    def test_creates_receipt_with_explicit_expiry(self) -> None:
+        manager = DecisionReceiptManager()
+        expires = datetime.now(timezone.utc) + timedelta(hours=2)
+
+        receipt = manager.create_receipt(
+            decision_id="dec-001",
+            action=GovernanceAction.ALLOW,
+            expires_at=expires,
+            revalidate_if=None,
+        )
+
+        assert receipt.decision_id == "dec-001"
+        assert receipt.action == GovernanceAction.ALLOW
+        assert receipt.expires_at == expires
+        assert receipt.is_expired is False
+        assert receipt.revalidate_if == []
+
+    def test_creates_receipt_with_default_expiry(self) -> None:
+        manager = DecisionReceiptManager(default_expiry_seconds=1800)
+        before = datetime.now(timezone.utc)
+
+        receipt = manager.create_receipt(
+            decision_id="dec-002",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=None,
+        )
+
+        after = datetime.now(timezone.utc)
+        assert receipt.expires_at is not None
+        # Default expiry should be ~1800 seconds from now
+        expected_min = before + timedelta(seconds=1800)
+        expected_max = after + timedelta(seconds=1800)
+        assert expected_min <= receipt.expires_at <= expected_max
+
+    def test_creates_receipt_with_revalidation_conditions(self) -> None:
+        manager = DecisionReceiptManager()
+        conditions = [
+            RevalidationCondition(
+                condition_type="cost_exceeded",
+                threshold=10.0,
+                description="Re-evaluate when cost exceeds $10",
+            ),
+            RevalidationCondition(
+                condition_type="time_elapsed",
+                threshold=300,
+                description="Re-evaluate after 5 minutes",
+            ),
+        ]
+
+        receipt = manager.create_receipt(
+            decision_id="dec-003",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            revalidate_if=conditions,
+        )
+
+        assert len(receipt.revalidate_if) == 2
+        assert receipt.revalidate_if[0].condition_type == "cost_exceeded"
+        assert receipt.revalidate_if[1].condition_type == "time_elapsed"
+
+    def test_creates_receipt_for_refer_action(self) -> None:
+        manager = DecisionReceiptManager()
+
+        receipt = manager.create_receipt(
+            decision_id="dec-004",
+            action=GovernanceAction.REFER,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+        )
+
+        assert receipt.action == GovernanceAction.REFER
+        assert receipt.is_expired is False
+
+    def test_receipt_stores_issued_at_timestamp(self) -> None:
+        manager = DecisionReceiptManager()
+        before = datetime.now(timezone.utc)
+
+        receipt = manager.create_receipt(
+            decision_id="dec-005",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+        )
+
+        after = datetime.now(timezone.utc)
+        assert before <= receipt.issued_at <= after
+
+    def test_receipt_is_stored_and_retrievable(self) -> None:
+        manager = DecisionReceiptManager()
+        receipt = manager.create_receipt(
+            decision_id="dec-006",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+        )
+
+        retrieved = manager.get_receipt("dec-006")
+        assert retrieved is receipt
+
+
+class TestIsValid:
+    """Tests for DecisionReceiptManager.is_valid."""
+
+    def test_valid_receipt_not_expired(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-valid",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+        assert manager.is_valid("dec-valid") is True
+
+    def test_expired_receipt_returns_false(self) -> None:
+        manager = DecisionReceiptManager()
+        # Create with an already-passed expiry
+        manager.create_receipt(
+            decision_id="dec-expired",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+
+        assert manager.is_valid("dec-expired") is False
+
+    def test_manually_expired_receipt_returns_false(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-manual",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        manager.expire("dec-manual", "RECEIPT_EXPIRED")
+
+        assert manager.is_valid("dec-manual") is False
+
+    def test_unknown_decision_id_returns_false(self) -> None:
+        manager = DecisionReceiptManager()
+
+        assert manager.is_valid("nonexistent-id") is False
+
+    def test_expired_receipt_gets_marked_is_expired(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-mark",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+
+        # First call discovers expiry and marks it
+        manager.is_valid("dec-mark")
+
+        receipt = manager.get_receipt("dec-mark")
+        assert receipt is not None
+        assert receipt.is_expired is True
+
+
+class TestCheckRevalidation:
+    """Tests for DecisionReceiptManager.check_revalidation."""
+
+    def test_no_conditions_returns_false(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-no-conds",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[],
+        )
+
+        result = manager.check_revalidation("dec-no-conds", {"cost": 100.0})
+        assert result is False
+
+    def test_cost_exceeded_triggers_revalidation(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-cost",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[
+                RevalidationCondition(
+                    condition_type="cost_exceeded",
+                    threshold=10.0,
+                    description="Cost limit",
+                )
+            ],
+        )
+
+        # Cost below threshold — no revalidation
+        assert manager.check_revalidation("dec-cost", {"cost": 5.0}) is False
+        # Cost at threshold — triggers revalidation
+        assert manager.check_revalidation("dec-cost", {"cost": 10.0}) is True
+        # Cost above threshold — triggers revalidation
+        assert manager.check_revalidation("dec-cost", {"cost": 15.0}) is True
+
+    def test_time_elapsed_triggers_revalidation(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-time",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[
+                RevalidationCondition(
+                    condition_type="time_elapsed",
+                    threshold=300,
+                    description="5 minutes",
+                )
+            ],
+        )
+
+        assert manager.check_revalidation("dec-time", {"elapsed_seconds": 100}) is False
+        assert manager.check_revalidation("dec-time", {"elapsed_seconds": 300}) is True
+        assert manager.check_revalidation("dec-time", {"elapsed_seconds": 600}) is True
+
+    def test_context_changed_triggers_revalidation(self) -> None:
+        manager = DecisionReceiptManager()
+        original_hash = "abc123"
+        manager.create_receipt(
+            decision_id="dec-ctx",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[
+                RevalidationCondition(
+                    condition_type="context_changed",
+                    threshold=original_hash,
+                    description="Context hash changed",
+                )
+            ],
+        )
+
+        # Same hash — no revalidation
+        assert manager.check_revalidation("dec-ctx", {"context_hash": "abc123"}) is False
+        # Different hash — triggers revalidation
+        assert manager.check_revalidation("dec-ctx", {"context_hash": "xyz789"}) is True
+
+    def test_unknown_decision_returns_false(self) -> None:
+        manager = DecisionReceiptManager()
+
+        result = manager.check_revalidation("nonexistent", {"cost": 100.0})
+        assert result is False
+
+    def test_multiple_conditions_any_triggers(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-multi",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[
+                RevalidationCondition(
+                    condition_type="cost_exceeded",
+                    threshold=50.0,
+                    description="Cost limit",
+                ),
+                RevalidationCondition(
+                    condition_type="time_elapsed",
+                    threshold=600,
+                    description="10 minutes",
+                ),
+            ],
+        )
+
+        # Neither met
+        assert manager.check_revalidation(
+            "dec-multi", {"cost": 10.0, "elapsed_seconds": 100}
+        ) is False
+        # Only cost met
+        assert manager.check_revalidation(
+            "dec-multi", {"cost": 60.0, "elapsed_seconds": 100}
+        ) is True
+        # Only time met
+        assert manager.check_revalidation(
+            "dec-multi", {"cost": 10.0, "elapsed_seconds": 700}
+        ) is True
+
+    def test_missing_context_key_does_not_trigger(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-missing",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+            revalidate_if=[
+                RevalidationCondition(
+                    condition_type="cost_exceeded",
+                    threshold=10.0,
+                    description="Cost limit",
+                )
+            ],
+        )
+
+        # Context doesn't have "cost" key — should not trigger
+        assert manager.check_revalidation("dec-missing", {"unrelated": "value"}) is False
+
+
+class TestExpire:
+    """Tests for DecisionReceiptManager.expire."""
+
+    def test_expire_marks_receipt_as_expired(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-exp",
+            action=GovernanceAction.ALLOW,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+        manager.expire("dec-exp", "RECEIPT_EXPIRED")
+
+        receipt = manager.get_receipt("dec-exp")
+        assert receipt is not None
+        assert receipt.is_expired is True
+        assert receipt.execution_outcome == "RECEIPT_EXPIRED"
+
+    def test_expire_with_revalidation_triggered_reason(self) -> None:
+        manager = DecisionReceiptManager()
+        manager.create_receipt(
+            decision_id="dec-reval",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+        )
+
+        manager.expire("dec-reval", "REVALIDATION_TRIGGERED")
+
+        receipt = manager.get_receipt("dec-reval")
+        assert receipt is not None
+        assert receipt.execution_outcome == "REVALIDATION_TRIGGERED"
+
+    def test_expire_unknown_decision_raises_key_error(self) -> None:
+        manager = DecisionReceiptManager()
+
+        with pytest.raises(KeyError, match="Decision receipt not found"):
+            manager.expire("nonexistent", "SOME_REASON")
+
+
+class TestConfigurableDefaultExpiry:
+    """Tests for configurable default expiry behavior."""
+
+    def test_default_expiry_is_3600_seconds(self) -> None:
+        manager = DecisionReceiptManager()
+        assert manager.default_expiry_seconds == 3600
+
+    def test_custom_default_expiry(self) -> None:
+        manager = DecisionReceiptManager(default_expiry_seconds=7200)
+        before = datetime.now(timezone.utc)
+
+        receipt = manager.create_receipt(
+            decision_id="dec-custom",
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+        )
+
+        after = datetime.now(timezone.utc)
+        assert receipt.expires_at is not None
+        expected_min = before + timedelta(seconds=7200)
+        expected_max = after + timedelta(seconds=7200)
+        assert expected_min <= receipt.expires_at <= expected_max
+
+    def test_explicit_expiry_overrides_default(self) -> None:
+        manager = DecisionReceiptManager(default_expiry_seconds=3600)
+        explicit_expiry = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+        receipt = manager.create_receipt(
+            decision_id="dec-override",
+            action=GovernanceAction.ALLOW,
+            expires_at=explicit_expiry,
+        )
+
+        assert receipt.expires_at == explicit_expiry

--- a/packages/ag2-tealtiger/tests/test_error_handling.py
+++ b/packages/ag2-tealtiger/tests/test_error_handling.py
@@ -1,0 +1,618 @@
+"""Tests for TealTigerGuard error handling — fail-closed, fail-open, and non-serializable args.
+
+Validates:
+- Task 6.5: Fail-closed and fail-open error handling
+- Requirements: 7.3, 7.4
+
+Scenarios:
+- TealEngine exception in ENFORCE mode with fail_closed=True -> DENY with ENGINE_ERROR + FAIL_CLOSED
+- TealEngine exception in MONITOR mode -> ALLOW with ENGINE_ERROR + FAIL_OPEN
+- TealEngine exception in OBSERVE mode (with engine) -> ALLOW with ENGINE_ERROR + FAIL_OPEN
+- TealEngine exception in ENFORCE mode with fail_closed=False -> ALLOW with ENGINE_ERROR + FAIL_OPEN
+- Non-serializable tool args -> log warning, evaluate without params_hash
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+
+# ── Inline helpers (mirror conftest patterns) ─────────────────────────────────
+
+
+class _MockAgent:
+    """Lightweight mock of AG2's ConversableAgent for unit testing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self,
+        trigger: Any,
+        reply_func: Any,
+        position: int = 0,
+        config: Any = None,
+        reset_config: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._reply_funcs.insert(
+            position,
+            {
+                "trigger": trigger,
+                "reply_func": reply_func,
+                "config": config,
+                "reset_config": reset_config,
+            },
+        )
+
+
+class _ErrorEngine:
+    """Engine that always raises on evaluate()."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error or RuntimeError("Engine evaluation failed")
+        self.evaluate_calls: list[dict[str, Any]] = []
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+        raise self.error
+
+
+class _AllowEngine:
+    """Engine that always returns ALLOW."""
+
+    def __init__(self) -> None:
+        self.evaluate_calls: list[dict[str, Any]] = []
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+        return {
+            "action": "ALLOW",
+            "risk_score": 0,
+            "reason_codes": [],
+            "reason": "Allowed",
+        }
+
+
+def _make_tool_call_message(
+    tool_name: str,
+    arguments: dict[str, Any] | str | None = None,
+) -> dict[str, Any]:
+    """Create a tool call message in AG2 format."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}_001",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments if arguments is not None else {},
+                },
+            }
+        ],
+    }
+
+
+# ── Fail-Closed Tests (ENFORCE mode + fail_closed=True) ──────────────────────
+
+
+class TestFailClosed:
+    """Test fail-closed behavior: ENFORCE mode with engine exceptions."""
+
+    def test_engine_error_in_enforce_mode_denies(self) -> None:
+        """ENFORCE + fail_closed=True: engine exception -> DENY with ENGINE_ERROR + FAIL_CLOSED."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("run_code", {"code": "x=1"})]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should block the tool call
+        assert should_terminate is True
+        assert reply is not None
+        assert "GOVERNANCE DENIAL" in reply
+        assert "Engine error" in reply
+        assert "Fail-closed" in reply
+
+    def test_engine_error_in_enforce_records_audit_entry(self) -> None:
+        """Fail-closed produces an AuditEntry with ENGINE_ERROR and FAIL_CLOSED reason codes."""
+        engine = _ErrorEngine(RuntimeError("Connection timeout"))
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="executor")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("delete_file", {"path": "/tmp/x"})]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Check audit trail
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.DENY.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_CLOSED" in entry.reason_codes
+        assert entry.risk_score == 100
+        assert entry.agent_id == "executor"
+        assert entry.tool_name == "delete_file"
+        assert entry.mode == GovernanceMode.ENFORCE.value
+        assert entry.evaluation_time_ms > 0
+
+    def test_engine_error_includes_exception_in_reason(self) -> None:
+        """Audit entry reason includes the exception message."""
+        engine = _ErrorEngine(ValueError("Invalid policy config"))
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("search", {"q": "test"})]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert "Invalid policy config" in entry.reason
+
+    def test_engine_error_in_enforce_with_fail_closed_false_allows(self) -> None:
+        """ENFORCE + fail_closed=False: engine exception -> ALLOW (fail-open)."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=False,  # Override fail-closed behavior
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("run_code", {"code": "x=1"})]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should allow through (fail-open)
+        assert should_terminate is False
+        assert reply is None
+
+        # Audit entry should show ALLOW with FAIL_OPEN
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_OPEN" in entry.reason_codes
+
+
+# ── Fail-Open Tests (MONITOR/OBSERVE modes) ──────────────────────────────────
+
+
+class TestFailOpen:
+    """Test fail-open behavior: MONITOR/OBSERVE modes with engine exceptions."""
+
+    def test_engine_error_in_monitor_mode_allows(self) -> None:
+        """MONITOR mode: engine exception -> ALLOW with ENGINE_ERROR + FAIL_OPEN."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+            fail_closed=True,  # fail_closed only matters in ENFORCE
+        )
+        agent = _MockAgent(name="reviewer")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("review_code", {"pr": 42})]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should allow through
+        assert should_terminate is False
+        assert reply is None
+
+    def test_engine_error_in_monitor_records_audit_entry(self) -> None:
+        """MONITOR mode: audit entry has ENGINE_ERROR + FAIL_OPEN reason codes."""
+        engine = _ErrorEngine(OSError("Disk full"))
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+        )
+        agent = _MockAgent(name="planner")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("plan_task", {"task": "deploy"})]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_OPEN" in entry.reason_codes
+        assert entry.risk_score == 0
+        assert entry.agent_id == "planner"
+        assert entry.mode == GovernanceMode.MONITOR.value
+        assert "Disk full" in entry.reason
+
+    def test_engine_error_in_observe_with_engine_allows(self) -> None:
+        """OBSERVE mode with engine: engine exception -> ALLOW with FAIL_OPEN.
+
+        Even though OBSERVE mode normally doesn't use a policy engine, if one
+        is explicitly provided (e.g., for testing), exceptions should fail-open.
+        """
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.OBSERVE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("run", {"cmd": "ls"})]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        assert should_terminate is False
+        assert reply is None
+
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_OPEN" in entry.reason_codes
+
+    def test_multiple_engine_errors_all_logged(self) -> None:
+        """Multiple consecutive engine errors each produce their own audit entry."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        for i in range(3):
+            messages = [_make_tool_call_message(f"tool_{i}", {"i": i})]
+            guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+
+        assert len(guard.audit_trail) == 3
+        for entry in guard.audit_trail:
+            assert "ENGINE_ERROR" in entry.reason_codes
+            assert "FAIL_OPEN" in entry.reason_codes
+            assert entry.action == GovernanceAction.ALLOW.value
+
+
+# ── Non-Serializable Tool Args Tests ─────────────────────────────────────────
+
+
+class TestNonSerializableArgs:
+    """Test handling of non-serializable tool arguments.
+
+    When tool args contain values that can't be JSON-serialized for params_hash
+    computation (e.g., circular references, custom objects), the guard should:
+    - Log a warning
+    - Set params_hash=None in the TEEC context
+    - Continue with evaluation (don't block)
+    """
+
+    def test_non_serializable_args_allow_evaluation(self) -> None:
+        """Non-serializable args don't block evaluation — tool call proceeds."""
+        engine = _AllowEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        # Create args that will raise TypeError during JSON serialization
+        # Using a set which is not JSON-serializable
+        non_serializable_args = {"data": {"nested": object()}}
+
+        messages = [_make_tool_call_message("process", non_serializable_args)]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should allow through (engine returned ALLOW)
+        assert should_terminate is False
+        assert reply is None
+
+    def test_non_serializable_args_params_hash_is_none(self) -> None:
+        """Non-serializable args result in params_hash=None in TEEC context."""
+        engine = _AllowEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        # Use an object() which cannot be JSON-serialized
+        non_serializable_args = {"callback": object()}
+
+        messages = [_make_tool_call_message("process", non_serializable_args)]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Check audit entry — params_hash in teec should be None
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.teec.params_hash is None
+
+    def test_non_serializable_args_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Non-serializable args emit a warning log."""
+        engine = _AllowEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        non_serializable_args = {"func": object()}
+
+        messages = [_make_tool_call_message("invoke", non_serializable_args)]
+
+        with caplog.at_level(logging.WARNING, logger="ag2_tealtiger.guard"):
+            guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+
+        # Should have logged a warning about non-serializable args
+        assert len(caplog.records) >= 1
+        warning_msg = caplog.records[0].message
+        assert "Non-serializable" in warning_msg or "non-serializable" in warning_msg.lower()
+
+    def test_non_serializable_args_engine_still_called(self) -> None:
+        """Engine is still called even when params_hash computation fails."""
+        engine = _AllowEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        non_serializable_args = {"obj": object()}
+
+        messages = [_make_tool_call_message("run", non_serializable_args)]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Engine should have been called
+        assert len(engine.evaluate_calls) == 1
+        call = engine.evaluate_calls[0]
+        assert call["tool_name"] == "run"
+
+    def test_serializable_args_params_hash_populated(self) -> None:
+        """Normal serializable args produce a valid params_hash (control test)."""
+        engine = _AllowEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        # Normal dict args that can be serialized
+        normal_args = {"query": "hello", "limit": 10}
+
+        messages = [_make_tool_call_message("search", normal_args)]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # params_hash should be populated
+        entry = guard.audit_trail[0]
+        assert entry.teec.params_hash is not None
+        assert len(entry.teec.params_hash) == 64  # SHA-256 hex
+
+    def test_non_serializable_with_engine_error_fail_closed(self) -> None:
+        """Non-serializable args + engine error in ENFORCE mode -> fail-closed DENY."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        non_serializable_args = {"obj": object()}
+
+        messages = [_make_tool_call_message("dangerous", non_serializable_args)]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should deny (fail-closed)
+        assert should_terminate is True
+        assert "GOVERNANCE DENIAL" in reply
+
+        # Audit entry
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.DENY.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_CLOSED" in entry.reason_codes
+        # params_hash should be None since args weren't serializable
+        assert entry.teec.params_hash is None
+
+
+# ── Edge Cases ────────────────────────────────────────────────────────────────
+
+
+class TestErrorHandlingEdgeCases:
+    """Edge cases for error handling behavior."""
+
+    def test_different_exception_types_handled(self) -> None:
+        """Various exception types are all caught and handled."""
+        for exc_type in [RuntimeError, ValueError, TypeError, OSError, KeyError]:
+            engine = _ErrorEngine(exc_type("test error"))
+            guard = TealTigerGuard(
+                engine=engine,
+                mode=GovernanceMode.ENFORCE,
+                fail_closed=True,
+            )
+            agent = _MockAgent(name="coder")
+            sender = _MockAgent(name="user")
+
+            messages = [_make_tool_call_message("tool", {"x": 1})]
+
+            should_terminate, reply = guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+
+            assert should_terminate is True, f"Failed for {exc_type.__name__}"
+            assert "GOVERNANCE DENIAL" in reply
+
+    def test_tool_call_without_args_handled(self) -> None:
+        """Tool calls with empty/no args still handle engine errors properly."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("no_args_tool", {})]
+
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        assert should_terminate is True
+        entry = guard.audit_trail[0]
+        assert entry.tool_name == "no_args_tool"
+        assert "ENGINE_ERROR" in entry.reason_codes
+
+    def test_teec_context_populated_on_engine_error(self) -> None:
+        """TEEC context fields are populated even when engine errors occur."""
+        engine = _ErrorEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+        agent = _MockAgent(name="coder")
+        sender = _MockAgent(name="user")
+
+        messages = [_make_tool_call_message("search", {"q": "test"})]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        # TEEC should still have valid fields
+        assert entry.teec.conversation_id is not None
+        assert len(entry.teec.conversation_id) > 0
+        assert entry.teec.decision_id is not None
+        assert len(entry.teec.decision_id) > 0
+        assert entry.teec.turn_id > 0
+        assert entry.teec.agent_role == "coder"

--- a/packages/ag2-tealtiger/tests/test_exceptions.py
+++ b/packages/ag2-tealtiger/tests/test_exceptions.py
@@ -1,0 +1,236 @@
+"""Unit tests for ag2_tealtiger.exceptions module.
+
+Validates the exception hierarchy for the ag2-tealtiger governance adapter:
+- AG2TealTigerError base exception
+- GovernanceDenyError with decision dict
+- DecisionExpiredError with decision_id and expired_at
+- BudgetExceededError extending GovernanceDenyError
+- AgentFrozenError extending GovernanceDenyError
+- EscalationPendingError with escalation_receipt
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# Ensure package is importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from ag2_tealtiger.exceptions import (
+    AG2TealTigerError,
+    AgentFrozenError,
+    BudgetExceededError,
+    DecisionExpiredError,
+    EscalationPendingError,
+    GovernanceDenyError,
+)
+from ag2_tealtiger.types import EscalationReceipt
+
+
+class TestAG2TealTigerError:
+    """Tests for the base exception class."""
+
+    def test_can_be_raised(self) -> None:
+        with pytest.raises(AG2TealTigerError, match="something went wrong"):
+            raise AG2TealTigerError("something went wrong")
+
+    def test_inherits_from_exception(self) -> None:
+        assert issubclass(AG2TealTigerError, Exception)
+
+    def test_empty_message(self) -> None:
+        e = AG2TealTigerError()
+        assert str(e) == ""
+
+
+class TestGovernanceDenyError:
+    """Tests for GovernanceDenyError with decision dict."""
+
+    def test_stores_decision_dict(self) -> None:
+        decision = {"reason": "Policy violation", "risk_score": 85, "reason_codes": ["BLOCKED"]}
+        e = GovernanceDenyError(decision)
+        assert e.decision == decision
+
+    def test_message_includes_reason(self) -> None:
+        decision = {"reason": "Tool not allowed", "risk_score": 90}
+        e = GovernanceDenyError(decision)
+        assert "Tool not allowed" in str(e)
+
+    def test_message_default_when_no_reason(self) -> None:
+        decision = {"risk_score": 50}
+        e = GovernanceDenyError(decision)
+        assert "Policy violation" in str(e)
+
+    def test_inherits_from_base(self) -> None:
+        assert issubclass(GovernanceDenyError, AG2TealTigerError)
+
+    def test_catchable_as_base(self) -> None:
+        decision = {"reason": "test"}
+        with pytest.raises(AG2TealTigerError):
+            raise GovernanceDenyError(decision)
+
+
+class TestDecisionExpiredError:
+    """Tests for DecisionExpiredError with decision_id and expired_at."""
+
+    def test_stores_decision_id(self) -> None:
+        e = DecisionExpiredError("dec-abc-123", "2026-03-15T10:30:00Z")
+        assert e.decision_id == "dec-abc-123"
+
+    def test_stores_expired_at(self) -> None:
+        e = DecisionExpiredError("dec-abc-123", "2026-03-15T10:30:00Z")
+        assert e.expired_at == "2026-03-15T10:30:00Z"
+
+    def test_message_includes_both_fields(self) -> None:
+        e = DecisionExpiredError("dec-xyz", "2026-01-01T00:00:00Z")
+        msg = str(e)
+        assert "dec-xyz" in msg
+        assert "expired at" in msg
+        assert "2026-01-01T00:00:00Z" in msg
+
+    def test_inherits_from_base(self) -> None:
+        assert issubclass(DecisionExpiredError, AG2TealTigerError)
+
+    def test_not_a_governance_deny_error(self) -> None:
+        assert not issubclass(DecisionExpiredError, GovernanceDenyError)
+
+
+class TestBudgetExceededError:
+    """Tests for BudgetExceededError extending GovernanceDenyError."""
+
+    def test_inherits_from_governance_deny(self) -> None:
+        assert issubclass(BudgetExceededError, GovernanceDenyError)
+
+    def test_inherits_from_base(self) -> None:
+        assert issubclass(BudgetExceededError, AG2TealTigerError)
+
+    def test_stores_decision(self) -> None:
+        decision = {"reason": "Budget limit exceeded", "risk_score": 95, "reason_codes": ["BUDGET_EXCEEDED"]}
+        e = BudgetExceededError(decision)
+        assert e.decision == decision
+
+    def test_catchable_as_governance_deny(self) -> None:
+        decision = {"reason": "Over budget"}
+        with pytest.raises(GovernanceDenyError):
+            raise BudgetExceededError(decision)
+
+
+class TestAgentFrozenError:
+    """Tests for AgentFrozenError extending GovernanceDenyError."""
+
+    def test_inherits_from_governance_deny(self) -> None:
+        assert issubclass(AgentFrozenError, GovernanceDenyError)
+
+    def test_inherits_from_base(self) -> None:
+        assert issubclass(AgentFrozenError, AG2TealTigerError)
+
+    def test_stores_decision(self) -> None:
+        decision = {"reason": "Agent is frozen", "risk_score": 100, "reason_codes": ["AGENT_FROZEN"]}
+        e = AgentFrozenError(decision)
+        assert e.decision == decision
+
+    def test_catchable_as_governance_deny(self) -> None:
+        decision = {"reason": "Frozen"}
+        with pytest.raises(GovernanceDenyError):
+            raise AgentFrozenError(decision)
+
+
+class TestEscalationPendingError:
+    """Tests for EscalationPendingError with escalation_receipt field."""
+
+    @pytest.fixture
+    def sample_receipt(self) -> EscalationReceipt:
+        return EscalationReceipt(
+            decision_id="esc-456",
+            agent_id="agent-1",
+            tool_name="file_write",
+            tool_arguments={"path": "/tmp/test", "content": "hello"},
+            conversation_id="conv-789",
+            turn_id=3,
+            group_chat_id="gc-001",
+            risk_score=75,
+            reason_codes=["HIGH_RISK_TOOL", "FILESYSTEM_ACCESS"],
+            human_readable_summary="Agent wants to write to filesystem",
+            policy_context={"policy": "fs_access", "version": "1.0"},
+            issued_at=datetime(2026, 3, 15, 10, 0, 0),
+            expires_at=None,
+        )
+
+    def test_stores_escalation_receipt(self, sample_receipt: EscalationReceipt) -> None:
+        e = EscalationPendingError(sample_receipt)
+        assert e.escalation_receipt is sample_receipt
+
+    def test_message_includes_decision_id(self, sample_receipt: EscalationReceipt) -> None:
+        e = EscalationPendingError(sample_receipt)
+        assert "esc-456" in str(e)
+
+    def test_message_includes_refer(self, sample_receipt: EscalationReceipt) -> None:
+        e = EscalationPendingError(sample_receipt)
+        assert "REFER" in str(e)
+
+    def test_message_includes_suspended(self, sample_receipt: EscalationReceipt) -> None:
+        e = EscalationPendingError(sample_receipt)
+        assert "suspended" in str(e).lower() or "Action suspended" in str(e)
+
+    def test_inherits_from_base(self) -> None:
+        assert issubclass(EscalationPendingError, AG2TealTigerError)
+
+    def test_not_a_governance_deny_error(self) -> None:
+        assert not issubclass(EscalationPendingError, GovernanceDenyError)
+
+
+class TestExceptionHierarchy:
+    """Tests verifying the overall inheritance hierarchy."""
+
+    def test_all_exceptions_derive_from_base(self) -> None:
+        for exc_class in [
+            GovernanceDenyError,
+            DecisionExpiredError,
+            BudgetExceededError,
+            AgentFrozenError,
+            EscalationPendingError,
+        ]:
+            assert issubclass(exc_class, AG2TealTigerError), f"{exc_class.__name__} must inherit AG2TealTigerError"
+
+    def test_budget_and_frozen_are_deny_subtypes(self) -> None:
+        assert issubclass(BudgetExceededError, GovernanceDenyError)
+        assert issubclass(AgentFrozenError, GovernanceDenyError)
+
+    def test_expired_and_escalation_are_not_deny_subtypes(self) -> None:
+        assert not issubclass(DecisionExpiredError, GovernanceDenyError)
+        assert not issubclass(EscalationPendingError, GovernanceDenyError)
+
+    def test_catch_all_with_base_exception(self) -> None:
+        """Verify that catching AG2TealTigerError catches all subtypes."""
+        decision = {"reason": "test"}
+        receipt = EscalationReceipt(
+            decision_id="x",
+            agent_id="a",
+            tool_name="t",
+            tool_arguments={},
+            conversation_id="c",
+            turn_id=1,
+            group_chat_id=None,
+            risk_score=50,
+            reason_codes=["TEST"],
+            human_readable_summary="test",
+            policy_context={},
+            issued_at=datetime.now(),
+            expires_at=None,
+        )
+
+        exceptions_to_test = [
+            AG2TealTigerError("base"),
+            GovernanceDenyError(decision),
+            DecisionExpiredError("id", "time"),
+            BudgetExceededError(decision),
+            AgentFrozenError(decision),
+            EscalationPendingError(receipt),
+        ]
+
+        for exc in exceptions_to_test:
+            with pytest.raises(AG2TealTigerError):
+                raise exc

--- a/packages/ag2-tealtiger/tests/test_governed_groupchat.py
+++ b/packages/ag2-tealtiger/tests/test_governed_groupchat.py
@@ -1,0 +1,553 @@
+"""Unit tests for GovernedGroupChat speaker selection.
+
+Tests speaker selection with frozen, over-budget, and policy-denied agents.
+Verifies requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 15.1, 15.3, 18.6
+
+Uses MockConversableAgent and MockTealEngine from conftest.py.
+"""
+
+from __future__ import annotations
+
+from ag2_tealtiger.governed_groupchat import GovernedGroupChat
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import (
+    MockConversableAgent,
+    make_mock_agent,
+    make_mock_engine,
+)
+
+
+# ── Helper Factories ──────────────────────────────────────────────────────────
+
+
+def _make_groupchat(
+    agents: list[MockConversableAgent],
+    guard: TealTigerGuard,
+    **kwargs,
+) -> GovernedGroupChat:
+    """Create a GovernedGroupChat with the given agents and guard."""
+    return GovernedGroupChat(
+        agents=agents,
+        guard=guard,
+        **kwargs,
+    )
+
+
+# ── Test: Basic Speaker Selection ─────────────────────────────────────────────
+
+
+class TestBasicSpeakerSelection:
+    """Test basic speaker selection without governance denials."""
+
+    def test_selects_first_eligible_speaker(self):
+        """When all agents are allowed, select the first candidate."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is not None
+        assert speaker.name == "bob"  # First candidate after last_speaker (alice)
+
+    def test_excludes_last_speaker_from_candidates(self):
+        """The last_speaker should not be a candidate for next speaker."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is not None
+        assert speaker.name == "bob"
+
+    def test_no_guard_allows_all(self):
+        """When guard is None, first available candidate is selected."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        gc = GovernedGroupChat(agents=agents, guard=None)
+
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+        assert speaker is not None
+        assert speaker.name == "bob"
+
+    def test_observe_mode_allows_all(self):
+        """In observe mode (no engine), all candidates are allowed."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        guard = TealTigerGuard(engine=None, mode=GovernanceMode.OBSERVE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is not None
+        assert speaker.name == "bob"
+
+
+# ── Test: Frozen Agent Skipping ───────────────────────────────────────────────
+
+
+class TestFrozenAgentSkipping:
+    """Test that frozen agents are skipped without TealEngine invocation."""
+
+    def test_frozen_agent_skipped(self):
+        """A frozen agent should be skipped during speaker selection."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Freeze bob
+        guard.freeze("bob")
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # bob is frozen, so carol should be selected
+        assert speaker is not None
+        assert speaker.name == "carol"
+
+    def test_frozen_agent_no_engine_call(self):
+        """Frozen agents should NOT trigger TealEngine evaluation."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Freeze bob
+        guard.freeze("bob")
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # Engine should only be called for carol (bob was skipped before engine)
+        # alice is excluded as last_speaker, bob is frozen, carol is evaluated
+        assert engine.call_count == 1
+        assert engine.evaluate_calls[0]["context"]["agent_id"] == "carol"
+
+    def test_frozen_agent_audit_entry(self):
+        """Frozen agents should be recorded in the audit with AGENT_FROZEN reason."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        guard.freeze("bob")
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        audit = gc.speaker_selection_audit
+        assert len(audit) == 1
+
+        # Check bob's entry
+        bob_eval = next(
+            c for c in audit[0].candidates_evaluated if c["agent_id"] == "bob"
+        )
+        assert bob_eval["decision"] == "DENY"
+        assert bob_eval["reason"] == "AGENT_FROZEN"
+
+    def test_all_frozen_returns_none(self):
+        """When all candidates are frozen, no speaker is selected."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        guard.freeze("bob")
+        guard.freeze("carol")
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is None
+
+        # Verify ALL_SPEAKERS_DENIED reason
+        audit = gc.speaker_selection_audit
+        assert "ALL_SPEAKERS_DENIED" in audit[0].reason_codes
+
+
+# ── Test: Over-Budget Agent Skipping ──────────────────────────────────────────
+
+
+class TestOverBudgetAgentSkipping:
+    """Test that over-budget agents are skipped without TealEngine invocation."""
+
+    def test_over_budget_agent_skipped(self):
+        """An over-budget agent should be skipped during speaker selection."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Set bob's budget and exceed it
+        guard.set_budget("bob", 10.0)
+        guard._budget_manager.track_cost("bob", 15.0)  # Over budget
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # bob is over budget, carol should be selected
+        assert speaker is not None
+        assert speaker.name == "carol"
+
+    def test_over_budget_agent_no_engine_call(self):
+        """Over-budget agents should NOT trigger TealEngine evaluation."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Set bob's budget and exceed it
+        guard.set_budget("bob", 5.0)
+        guard._budget_manager.track_cost("bob", 6.0)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # Engine should only be called for carol (bob was skipped before engine)
+        assert engine.call_count == 1
+        assert engine.evaluate_calls[0]["context"]["agent_id"] == "carol"
+
+    def test_over_budget_audit_entry(self):
+        """Over-budget agents should be recorded in audit with BUDGET_EXCEEDED reason."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        guard.set_budget("bob", 5.0)
+        guard._budget_manager.track_cost("bob", 6.0)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        audit = gc.speaker_selection_audit
+        bob_eval = next(
+            c for c in audit[0].candidates_evaluated if c["agent_id"] == "bob"
+        )
+        assert bob_eval["decision"] == "DENY"
+        assert bob_eval["reason"] == "BUDGET_EXCEEDED"
+
+    def test_within_budget_not_skipped(self):
+        """An agent within budget should NOT be skipped."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Set bob's budget but stay within
+        guard.set_budget("bob", 10.0)
+        guard._budget_manager.track_cost("bob", 5.0)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is not None
+        assert speaker.name == "bob"
+
+
+# ── Test: Policy-Denied Agent Skipping ────────────────────────────────────────
+
+
+class TestPolicyDeniedAgentSkipping:
+    """Test that policy-denied agents are skipped to next candidate."""
+
+    def test_denied_agent_skipped_to_next(self):
+        """When first candidate is denied by policy, next is selected."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        # Deny bob specifically
+        engine.set_decision_for_agent(
+            "bob",
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+            reason="Policy denied bob",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # bob is denied, carol should be selected
+        assert speaker is not None
+        assert speaker.name == "carol"
+
+    def test_multiple_denied_agents(self):
+        """When multiple candidates are denied, select the first allowed."""
+        agents = [
+            make_mock_agent("alice"),
+            make_mock_agent("bob"),
+            make_mock_agent("carol"),
+            make_mock_agent("dave"),
+        ]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        engine.set_decision_for_agent("bob", action=GovernanceAction.DENY)
+        engine.set_decision_for_agent("carol", action=GovernanceAction.DENY)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[3])
+
+        assert speaker is not None
+        assert speaker.name == "dave"
+
+
+# ── Test: REFER Decision Handling ─────────────────────────────────────────────
+
+
+class TestReferDecisionHandling:
+    """Test REFER decision suspends candidate and continues with others."""
+
+    def test_refer_agent_suspended_continue_others(self):
+        """REFER should suspend candidate and select next available."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        # Refer bob
+        engine.set_decision_for_agent(
+            "bob",
+            action=GovernanceAction.REFER,
+            risk_score=50,
+            reason_codes=["REQUIRES_REVIEW"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # bob is referred/suspended, carol should be selected
+        assert speaker is not None
+        assert speaker.name == "carol"
+
+    def test_refer_audit_entry_records_suspended(self):
+        """REFER decision should be recorded in audit as REFER."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        engine.set_decision_for_agent(
+            "bob",
+            action=GovernanceAction.REFER,
+            reason="",  # Empty reason triggers fallback to "REQUIRES_REVIEW"
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        audit = gc.speaker_selection_audit
+        bob_eval = next(
+            c for c in audit[0].candidates_evaluated if c["agent_id"] == "bob"
+        )
+        assert bob_eval["decision"] == "REFER"
+        assert bob_eval["reason"] == "REQUIRES_REVIEW"
+
+    def test_refer_does_not_terminate_groupchat(self):
+        """REFER should not terminate the group conversation."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        engine.set_decision_for_agent("bob", action=GovernanceAction.REFER)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # GroupChat continues — carol is selected
+        assert speaker is not None
+        assert "ALL_SPEAKERS_DENIED" not in gc.speaker_selection_audit[0].reason_codes
+
+
+# ── Test: ALL_SPEAKERS_DENIED Termination ─────────────────────────────────────
+
+
+class TestAllSpeakersDenied:
+    """Test termination when all candidates are denied."""
+
+    def test_all_denied_returns_none(self):
+        """When all candidates denied by policy, return None."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is None
+
+    def test_all_denied_audit_reason_code(self):
+        """ALL_SPEAKERS_DENIED reason code should be in audit."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.DENY)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        audit = gc.speaker_selection_audit
+        assert len(audit) == 1
+        assert "ALL_SPEAKERS_DENIED" in audit[0].reason_codes
+        assert audit[0].selected_speaker is None
+
+    def test_mixed_frozen_budget_denied_all_blocked(self):
+        """Combination of frozen, over-budget, and denied results in ALL_SPEAKERS_DENIED."""
+        agents = [
+            make_mock_agent("alice"),
+            make_mock_agent("bob"),
+            make_mock_agent("carol"),
+            make_mock_agent("dave"),
+        ]
+        engine = make_mock_engine(action=GovernanceAction.DENY)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Freeze bob
+        guard.freeze("bob")
+        # Over-budget carol
+        guard.set_budget("carol", 5.0)
+        guard._budget_manager.track_cost("carol", 10.0)
+        # dave denied by policy (engine default is DENY)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        assert speaker is None
+        audit = gc.speaker_selection_audit[0]
+        assert "ALL_SPEAKERS_DENIED" in audit.reason_codes
+
+        # Verify each agent has a deny entry
+        agent_reasons = {c["agent_id"]: c["reason"] for c in audit.candidates_evaluated}
+        assert agent_reasons["bob"] == "AGENT_FROZEN"
+        assert agent_reasons["carol"] == "BUDGET_EXCEEDED"
+        assert "dave" in agent_reasons
+
+
+# ── Test: Speaker Selection Audit ─────────────────────────────────────────────
+
+
+class TestSpeakerSelectionAudit:
+    """Test that speaker selection produces correct audit entries."""
+
+    def test_audit_records_all_candidates(self):
+        """Audit entry should contain all evaluated candidates."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        audit = gc.speaker_selection_audit
+        assert len(audit) == 1
+        # bob is the first candidate evaluated (after alice is excluded)
+        # Once bob is ALLOW'd, carol is not evaluated
+        assert len(audit[0].candidates_evaluated) >= 1
+        assert audit[0].candidates_evaluated[0]["agent_id"] == "bob"
+
+    def test_audit_records_selected_speaker(self):
+        """Audit entry should contain the selected speaker name."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        audit = gc.speaker_selection_audit
+        assert audit[0].selected_speaker == "bob"
+        # When a speaker is successfully selected without any denials,
+        # reason_codes may be empty (no denial reasons to record)
+        assert "ALL_SPEAKERS_DENIED" not in audit[0].reason_codes
+
+    def test_audit_has_group_chat_id(self):
+        """Audit entry should include the group_chat_id."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard, group_chat_id="test-gc-123")
+        gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        audit = gc.speaker_selection_audit
+        assert audit[0].group_chat_id == "test-gc-123"
+
+    def test_audit_has_round_id_and_timestamp(self):
+        """Audit entry should have a round_id (UUID) and timestamp_ms."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[1])
+
+        audit = gc.speaker_selection_audit
+        assert audit[0].round_id  # Non-empty UUID
+        assert audit[0].timestamp_ms > 0
+
+    def test_multiple_rounds_accumulate_audit(self):
+        """Multiple selection rounds should accumulate audit entries."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard)
+        gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+        gc.select_speaker(last_speaker=agents[1], selector=agents[0])
+
+        audit = gc.speaker_selection_audit
+        assert len(audit) == 2
+
+
+# ── Test: Engine Error Handling ───────────────────────────────────────────────
+
+
+class TestEngineErrorHandling:
+    """Test behavior when TealEngine raises exceptions during evaluation."""
+
+    def test_engine_error_skips_candidate(self):
+        """Engine error during evaluation should skip that candidate."""
+        agents = [make_mock_agent("alice"), make_mock_agent("bob"), make_mock_agent("carol")]
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        # Make engine raise for bob
+        engine.set_decision_for_agent("bob", action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Replace evaluate to raise for bob specifically
+        original_evaluate = engine.evaluate
+
+        def raise_for_bob(**kwargs):
+            context = kwargs.get("context") or {}
+            if context.get("agent_id") == "bob":
+                raise RuntimeError("Engine failed for bob")
+            return original_evaluate(**kwargs)
+
+        engine.evaluate = lambda tool_name=None, args=None, context=None: (
+            (_ for _ in ()).throw(RuntimeError("Engine failed for bob"))
+            if context and context.get("agent_id") == "bob"
+            else original_evaluate(tool_name=tool_name, args=args, context=context)
+        )
+
+        # Simpler approach: use set_error then clear
+        # Actually let's use a custom engine
+        class ErrorForBobEngine:
+            def __init__(self):
+                self.call_count = 0
+                self.evaluate_calls = []
+
+            def evaluate(self, tool_name=None, args=None, context=None):
+                self.call_count += 1
+                self.evaluate_calls.append({"tool_name": tool_name, "args": args, "context": context})
+                if context and context.get("agent_id") == "bob":
+                    raise RuntimeError("Engine failed for bob")
+                return {"action": "ALLOW", "risk_score": 0, "reason_codes": [], "reason": "OK"}
+
+        error_engine = ErrorForBobEngine()
+        guard2 = TealTigerGuard(engine=error_engine, mode=GovernanceMode.ENFORCE)
+
+        gc = _make_groupchat(agents=agents, guard=guard2)
+        speaker = gc.select_speaker(last_speaker=agents[0], selector=agents[2])
+
+        # bob should be skipped due to engine error, carol selected
+        assert speaker is not None
+        assert speaker.name == "carol"
+
+        # Verify audit captures engine error for bob
+        audit = gc.speaker_selection_audit[0]
+        bob_eval = next(c for c in audit.candidates_evaluated if c["agent_id"] == "bob")
+        assert bob_eval["decision"] == "DENY"
+        assert bob_eval["reason"] == "ENGINE_ERROR"

--- a/packages/ag2-tealtiger/tests/test_guard.py
+++ b/packages/ag2-tealtiger/tests/test_guard.py
@@ -1,0 +1,362 @@
+"""Tests for TealTigerGuard core — attach, detach, and initialization.
+
+Validates:
+- Task 6.1: __init__ with all parameters, attach/detach mechanics
+- Requirements: 1.1, 1.2, 1.3, 14.3
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.budget_manager import BudgetStateManager
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+from ag2_tealtiger.types import GovernanceMode
+
+
+# ── Inline helpers for test isolation (mirror conftest factories) ──────────────
+
+
+class _MockConversableAgent:
+    """Lightweight mock of AG2's ConversableAgent for unit testing."""
+
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self,
+        trigger: Any,
+        reply_func: Any,
+        position: int = 0,
+        config: Any = None,
+        reset_config: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._reply_funcs.insert(
+            position,
+            {
+                "trigger": trigger,
+                "reply_func": reply_func,
+                "config": config,
+                "reset_config": reset_config,
+            },
+        )
+
+    @property
+    def registered_reply_funcs(self) -> list[dict[str, Any]]:
+        return self._reply_funcs
+
+
+class _MockTealEngine:
+    """Minimal mock TealEngine for init tests."""
+
+    def evaluate(self, **kwargs: Any) -> dict[str, Any]:
+        return {"action": "ALLOW", "risk_score": 0, "reason_codes": [], "reason": "ok"}
+
+
+class TestTealTigerGuardInit:
+    """Test TealTigerGuard initialization and default values."""
+
+    def test_default_initialization(self) -> None:
+        """Guard initializes in observe mode with sensible defaults."""
+        guard = TealTigerGuard()
+
+        assert guard.engine is None
+        assert guard.mode == GovernanceMode.OBSERVE
+        assert guard.cost_per_1k_tokens == 0.002
+        assert guard.default_expiry_seconds == 3600
+        assert guard.fail_closed is True
+
+    def test_initialization_with_engine(self) -> None:
+        """Guard accepts a TealEngine instance and custom mode."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+        )
+
+        assert guard.engine is engine
+        assert guard.mode == GovernanceMode.ENFORCE
+
+    def test_initialization_with_custom_params(self) -> None:
+        """Guard accepts all custom initialization parameters."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.MONITOR,
+            cost_per_1k_tokens=0.01,
+            default_expiry_seconds=7200,
+            fail_closed=False,
+        )
+
+        assert guard.engine is engine
+        assert guard.mode == GovernanceMode.MONITOR
+        assert guard.cost_per_1k_tokens == 0.01
+        assert guard.default_expiry_seconds == 7200
+        assert guard.fail_closed is False
+
+    def test_internal_state_initialized(self) -> None:
+        """Guard initializes all required internal state components."""
+        guard = TealTigerGuard()
+
+        # Frozen agents set
+        assert isinstance(guard._frozen_agents, set)
+        assert len(guard._frozen_agents) == 0
+
+        # Audit trail
+        assert isinstance(guard._audit_trail, list)
+        assert len(guard._audit_trail) == 0
+
+        # Budget manager
+        assert isinstance(guard._budget_manager, BudgetStateManager)
+
+        # Decision manager
+        assert isinstance(guard._decision_manager, DecisionReceiptManager)
+
+        # TEEC builder
+        assert isinstance(guard._teec_builder, TEECContextBuilder)
+
+        # Attached agents
+        assert isinstance(guard._attached_agents, dict)
+        assert len(guard._attached_agents) == 0
+
+    def test_decision_manager_uses_configured_expiry(self) -> None:
+        """DecisionReceiptManager is initialized with guard's expiry setting."""
+        guard = TealTigerGuard(default_expiry_seconds=1800)
+        assert guard._decision_manager.default_expiry_seconds == 1800
+
+    def test_audit_trail_property_returns_list(self) -> None:
+        """audit_trail property returns the internal list."""
+        guard = TealTigerGuard()
+        assert guard.audit_trail is guard._audit_trail
+
+    def test_attached_agents_property_returns_copy(self) -> None:
+        """attached_agents property returns a copy of the internal dict."""
+        guard = TealTigerGuard()
+        result = guard.attached_agents
+        assert result == {}
+        # Should be a copy, not the same object
+        assert result is not guard._attached_agents
+
+
+class TestTealTigerGuardAttach:
+    """Test TealTigerGuard.attach() — register_reply hook registration."""
+
+    def test_attach_registers_reply_at_position_zero(self) -> None:
+        """attach() registers the reply hook at highest priority (position=0)."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        guard.attach(agent)
+
+        # Verify reply was registered
+        assert len(agent.registered_reply_funcs) == 1
+        registered = agent.registered_reply_funcs[0]
+        # Bound methods create new objects on access, so compare __func__
+        assert registered["reply_func"].__func__ is TealTigerGuard._reply_hook
+        assert registered["trigger"] is None
+
+    def test_attach_tracks_agent(self) -> None:
+        """attach() adds the agent to the attached_agents tracking."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="reviewer")
+
+        guard.attach(agent)
+
+        assert "reviewer" in guard._attached_agents
+        assert guard._attached_agents["reviewer"] is agent
+
+    def test_attach_multiple_agents(self) -> None:
+        """attach() supports attaching multiple agents to the same guard."""
+        guard = TealTigerGuard()
+        agent_a = _MockConversableAgent(name="coder")
+        agent_b = _MockConversableAgent(name="reviewer")
+        agent_c = _MockConversableAgent(name="executor")
+
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+        guard.attach(agent_c)
+
+        assert len(guard._attached_agents) == 3
+        assert "coder" in guard._attached_agents
+        assert "reviewer" in guard._attached_agents
+        assert "executor" in guard._attached_agents
+
+        # Each agent gets its own reply hook registered
+        assert len(agent_a.registered_reply_funcs) == 1
+        assert len(agent_b.registered_reply_funcs) == 1
+        assert len(agent_c.registered_reply_funcs) == 1
+
+    def test_attach_duplicate_raises_value_error(self) -> None:
+        """attach() raises ValueError when agent is already attached."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        guard.attach(agent)
+
+        with pytest.raises(ValueError, match="already attached"):
+            guard.attach(agent)
+
+    def test_attach_registers_at_position_zero_with_existing_hooks(self) -> None:
+        """attach() inserts at position 0 even if other hooks exist."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        # Pre-register a dummy reply function
+        agent.register_reply(trigger=None, reply_func=lambda *a: (False, None), position=0)
+        assert len(agent.registered_reply_funcs) == 1
+
+        guard.attach(agent)
+
+        # Guard's hook should be at position 0 (first)
+        assert len(agent.registered_reply_funcs) == 2
+        assert agent.registered_reply_funcs[0]["reply_func"].__func__ is TealTigerGuard._reply_hook
+
+    def test_attached_agents_property_after_attach(self) -> None:
+        """attached_agents property reflects attached state."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="planner")
+
+        guard.attach(agent)
+
+        result = guard.attached_agents
+        assert "planner" in result
+        assert result["planner"] is agent
+
+
+class TestTealTigerGuardDetach:
+    """Test TealTigerGuard.detach() — reply hook removal."""
+
+    def test_detach_removes_reply_hook(self) -> None:
+        """detach() removes the registered reply function from the agent."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        guard.attach(agent)
+        assert len(agent.registered_reply_funcs) == 1
+
+        guard.detach(agent)
+        assert len(agent.registered_reply_funcs) == 0
+
+    def test_detach_removes_from_tracking(self) -> None:
+        """detach() removes the agent from the attached_agents dict."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        guard.attach(agent)
+        assert "coder" in guard._attached_agents
+
+        guard.detach(agent)
+        assert "coder" not in guard._attached_agents
+
+    def test_detach_unattached_raises_value_error(self) -> None:
+        """detach() raises ValueError when agent is not attached."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        with pytest.raises(ValueError, match="not attached"):
+            guard.detach(agent)
+
+    def test_detach_preserves_other_hooks(self) -> None:
+        """detach() only removes the guard's hook, leaving others intact."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        # Register a separate hook first
+        other_hook = lambda *a: (False, None)
+        agent.register_reply(trigger=None, reply_func=other_hook, position=0)
+
+        # Attach guard (inserts at position 0)
+        guard.attach(agent)
+        assert len(agent.registered_reply_funcs) == 2
+
+        # Detach should only remove the guard's hook
+        guard.detach(agent)
+        assert len(agent.registered_reply_funcs) == 1
+        assert agent.registered_reply_funcs[0]["reply_func"] is other_hook
+
+    def test_detach_allows_reattach(self) -> None:
+        """After detach(), the same agent can be re-attached."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+
+        guard.attach(agent)
+        guard.detach(agent)
+
+        # Should not raise
+        guard.attach(agent)
+        assert "coder" in guard._attached_agents
+        assert len(agent.registered_reply_funcs) == 1
+
+    def test_detach_one_agent_preserves_others(self) -> None:
+        """detach() only removes the specified agent, others remain attached."""
+        guard = TealTigerGuard()
+        agent_a = _MockConversableAgent(name="coder")
+        agent_b = _MockConversableAgent(name="reviewer")
+
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        guard.detach(agent_a)
+
+        assert "coder" not in guard._attached_agents
+        assert "reviewer" in guard._attached_agents
+        assert len(agent_b.registered_reply_funcs) == 1
+
+
+class TestTealTigerGuardReplyHookStub:
+    """Test the _reply_hook stub behavior."""
+
+    def test_reply_hook_returns_passthrough(self) -> None:
+        """_reply_hook stub returns (False, None) to pass through."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+        sender = _MockConversableAgent(name="user")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=[{"role": "user", "content": "hello"}],
+            sender=sender,
+            config=None,
+        )
+
+        assert result == (False, None)
+
+    def test_reply_hook_signature_matches_ag2(self) -> None:
+        """_reply_hook accepts the AG2-expected parameters."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+        sender = _MockConversableAgent(name="user")
+
+        # Should not raise — all AG2 expected params provided
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=[
+                {"role": "assistant", "content": None, "tool_calls": []},
+            ],
+            sender=sender,
+            config={"custom": "config"},
+        )
+
+        assert isinstance(should_terminate, bool)
+        assert reply is None
+
+    def test_reply_hook_with_none_messages(self) -> None:
+        """_reply_hook handles None messages gracefully."""
+        guard = TealTigerGuard()
+        agent = _MockConversableAgent(name="coder")
+        sender = _MockConversableAgent(name="user")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=None,
+            sender=sender,
+            config=None,
+        )
+
+        assert result == (False, None)

--- a/packages/ag2-tealtiger/tests/test_guard_budget.py
+++ b/packages/ag2-tealtiger/tests/test_guard_budget.py
@@ -1,0 +1,490 @@
+"""Tests for TealTigerGuard budget integration (task 6.7).
+
+Validates:
+- Budget check before tool call evaluation via BudgetStateManager
+- Deny with "BUDGET_EXCEEDED" when limit exceeded in ENFORCE mode
+- Log warning and allow in MONITOR mode when budget exceeded
+- Track cost after tool execution
+- Expose budget management methods: set_budget, get_budget_state, reset_budget
+
+Requirements: 18.1, 18.2, 18.3, 18.6, 18.7, 18.8
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    GovernanceMode,
+    ActionKind,
+    BudgetState,
+)
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for budget integration tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+class _MockTealEngine:
+    """Mock TealEngine that returns ALLOW by default."""
+
+    def __init__(self, action: str = "ALLOW") -> None:
+        self._action = action
+        self.call_count = 0
+
+    def evaluate(self, **kwargs: Any) -> dict[str, Any]:
+        self.call_count += 1
+        return {
+            "action": self._action,
+            "risk_score": 0,
+            "reason_codes": [],
+            "reason": "Mock decision",
+        }
+
+
+def _make_tool_call_message(
+    tool_name: str = "run_code",
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a mock tool call message in AG2 format."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}_001",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments if arguments is not None else {},
+                },
+            }
+        ],
+    }
+
+
+def _invoke(
+    guard: TealTigerGuard,
+    agent: _MockAgent,
+    messages: list[dict[str, Any]] | None = None,
+) -> tuple[bool, str | dict[str, Any] | None]:
+    """Invoke the guard's reply hook with standard params."""
+    if messages is None:
+        messages = [_make_tool_call_message()]
+    sender = _MockAgent("user")
+    return guard._reply_hook(
+        recipient=agent, messages=messages, sender=sender, config=None
+    )
+
+
+# ── Tests: Budget Management Methods ─────────────────────────────────────────
+
+
+class TestBudgetManagementMethods:
+    """Test public budget management methods on TealTigerGuard."""
+
+    def test_set_budget_configures_limit(self) -> None:
+        """set_budget() delegates to BudgetStateManager.set_limit()."""
+        guard = TealTigerGuard()
+        guard.set_budget("agent-1", 10.0)
+
+        state = guard.get_budget_state("agent-1")
+        assert state.budget_limit == 10.0
+        assert state.current_spend == 0.0
+        assert state.remaining_budget == 10.0
+
+    def test_set_budget_negative_raises_value_error(self) -> None:
+        """set_budget() raises ValueError for non-positive limits."""
+        guard = TealTigerGuard()
+        with pytest.raises(ValueError):
+            guard.set_budget("agent-1", -5.0)
+
+    def test_set_budget_zero_raises_value_error(self) -> None:
+        """set_budget() raises ValueError for zero limit."""
+        guard = TealTigerGuard()
+        with pytest.raises(ValueError):
+            guard.set_budget("agent-1", 0.0)
+
+    def test_get_budget_state_returns_budget_state(self) -> None:
+        """get_budget_state() returns a BudgetState dataclass."""
+        guard = TealTigerGuard()
+        guard.set_budget("agent-1", 5.0)
+
+        state = guard.get_budget_state("agent-1")
+        assert isinstance(state, BudgetState)
+        assert state.agent_id == "agent-1"
+        assert state.budget_limit == 5.0
+
+    def test_get_budget_state_no_limit_returns_none_budget(self) -> None:
+        """get_budget_state() returns None for budget_limit when no limit set."""
+        guard = TealTigerGuard()
+
+        state = guard.get_budget_state("agent-1")
+        assert state.budget_limit is None
+        assert state.remaining_budget is None
+        assert state.current_spend == 0.0
+
+    def test_reset_budget_clears_spend(self) -> None:
+        """reset_budget() resets current_spend to zero."""
+        guard = TealTigerGuard()
+        guard.set_budget("agent-1", 10.0)
+
+        # Manually track some cost
+        guard._budget_manager.track_cost("agent-1", 5.0)
+        state = guard.get_budget_state("agent-1")
+        assert state.current_spend == 5.0
+
+        guard.reset_budget("agent-1")
+        state = guard.get_budget_state("agent-1")
+        assert state.current_spend == 0.0
+        assert state.remaining_budget == 10.0
+
+    def test_reset_budget_preserves_limit(self) -> None:
+        """reset_budget() keeps the configured budget_limit."""
+        guard = TealTigerGuard()
+        guard.set_budget("agent-1", 15.0)
+        guard._budget_manager.track_cost("agent-1", 10.0)
+
+        guard.reset_budget("agent-1")
+        state = guard.get_budget_state("agent-1")
+        assert state.budget_limit == 15.0
+
+    def test_reset_budget_records_audit_entry(self) -> None:
+        """reset_budget() produces an audit entry with BUDGET_RESET reason code."""
+        guard = TealTigerGuard()
+        guard.set_budget("agent-1", 10.0)
+        guard._budget_manager.track_cost("agent-1", 5.0)
+
+        guard.reset_budget("agent-1")
+
+        # Find the BUDGET_RESET audit entry
+        reset_entries = [
+            e for e in guard.audit_trail
+            if "BUDGET_RESET" in e.reason_codes
+        ]
+        assert len(reset_entries) == 1
+        entry = reset_entries[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert entry.action_kind == ActionKind.BUDGET_CHANGE.value
+        assert entry.agent_id == "agent-1"
+
+
+# ── Tests: Budget Check in Reply Hook — ENFORCE Mode ─────────────────────────
+
+
+class TestBudgetCheckEnforceMode:
+    """Test budget enforcement in the reply hook flow (ENFORCE mode)."""
+
+    def test_budget_exceeded_denies_tool_call(self) -> None:
+        """When budget is exceeded in ENFORCE mode, tool call is denied."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # Set a small budget and exceed it
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)  # Exceed the limit
+
+        # Invoke reply hook — should deny
+        should_terminate, reply = _invoke(guard, agent)
+
+        assert should_terminate is True
+        assert reply is not None
+        assert "BUDGET_EXCEEDED" in str(reply)
+
+    def test_budget_exceeded_audit_entry_has_correct_reason_code(self) -> None:
+        """Budget denial produces audit entry with BUDGET_EXCEEDED reason code."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        _invoke(guard, agent)
+
+        # Find BUDGET_EXCEEDED audit entry
+        budget_entries = [
+            e for e in guard.audit_trail
+            if "BUDGET_EXCEEDED" in e.reason_codes
+        ]
+        assert len(budget_entries) == 1
+        entry = budget_entries[0]
+        assert entry.action == GovernanceAction.DENY.value
+        assert entry.agent_id == "coder"
+        assert entry.risk_score == 80
+
+    def test_budget_exceeded_does_not_call_engine(self) -> None:
+        """When budget is exceeded, TealEngine.evaluate() is NOT called."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        _invoke(guard, agent)
+
+        # Engine should not be invoked since budget check blocks first
+        assert engine.call_count == 0
+
+    def test_budget_not_exceeded_allows_through(self) -> None:
+        """When budget has remaining room, tool call proceeds to engine evaluation."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 100.0)
+
+        should_terminate, reply = _invoke(guard, agent)
+
+        # Should allow through
+        assert should_terminate is False
+        assert reply is None
+        # Engine was called
+        assert engine.call_count == 1
+
+    def test_no_budget_limit_allows_through(self) -> None:
+        """When no budget limit is configured, all calls pass through."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # No set_budget call — no limit configured
+
+        should_terminate, reply = _invoke(guard, agent)
+        assert should_terminate is False
+        assert reply is None
+        assert engine.call_count == 1
+
+
+# ── Tests: Budget Check in Reply Hook — MONITOR Mode ─────────────────────────
+
+
+class TestBudgetCheckMonitorMode:
+    """Test budget check behavior in MONITOR mode."""
+
+    def test_budget_exceeded_allows_through_in_monitor(self) -> None:
+        """When budget exceeded in MONITOR mode, log warning and allow."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        should_terminate, reply = _invoke(guard, agent)
+
+        # Should allow through in MONITOR mode
+        assert should_terminate is False
+        assert reply is None
+        # Engine should still be called
+        assert engine.call_count == 1
+
+    def test_budget_exceeded_allows_through_in_observe(self) -> None:
+        """When budget exceeded in OBSERVE mode (no engine), allow through."""
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        should_terminate, reply = _invoke(guard, agent)
+
+        # Should allow through in OBSERVE mode
+        assert should_terminate is False
+        assert reply is None
+
+
+# ── Tests: Cost Tracking After Tool Execution ─────────────────────────────────
+
+
+class TestCostTrackingAfterExecution:
+    """Test that cost is tracked after allowed tool execution in policy mode."""
+
+    def test_cost_tracked_after_allow_decision(self) -> None:
+        """After ALLOW decision in policy mode, cost is tracked in BudgetStateManager."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 100.0)
+        initial_spend = guard.get_budget_state("coder").current_spend
+
+        _invoke(guard, agent)
+
+        # Cost should have increased
+        final_spend = guard.get_budget_state("coder").current_spend
+        assert final_spend > initial_spend
+
+    def test_cost_accumulates_across_multiple_calls(self) -> None:
+        """Cost accumulates across multiple allowed tool calls."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 100.0)
+
+        # Multiple calls
+        _invoke(guard, agent)
+        spend_after_1 = guard.get_budget_state("coder").current_spend
+
+        _invoke(guard, agent)
+        spend_after_2 = guard.get_budget_state("coder").current_spend
+
+        _invoke(guard, agent)
+        spend_after_3 = guard.get_budget_state("coder").current_spend
+
+        assert spend_after_1 > 0
+        assert spend_after_2 > spend_after_1
+        assert spend_after_3 > spend_after_2
+
+    def test_budget_warning_emitted_at_80_percent(self) -> None:
+        """BUDGET_WARNING audit entry is emitted when 80% threshold is crossed."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # cost_per_1k_tokens = 0.002, estimated cost = 0.002/1000 * 50 = 0.0001 per call
+        # Set budget so that 80% threshold is below the cost of one call
+        # Budget = 0.0001, 80% threshold = 0.00008
+        # After one call (cost = 0.0001), current_spend (0.0001) >= threshold (0.00008)
+        guard.set_budget("coder", 0.0001)
+
+        _invoke(guard, agent)
+
+        # Check for BUDGET_WARNING in audit trail
+        warning_entries = [
+            e for e in guard.audit_trail
+            if "BUDGET_WARNING" in e.reason_codes
+        ]
+        assert len(warning_entries) == 1
+        assert warning_entries[0].action == GovernanceAction.ALLOW.value
+        assert warning_entries[0].action_kind == ActionKind.BUDGET_CHANGE.value
+
+    def test_cost_not_tracked_when_denied(self) -> None:
+        """When tool call is denied (BUDGET_EXCEEDED), no additional cost is tracked."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)  # Exceed budget
+
+        spend_before = guard.get_budget_state("coder").current_spend
+        _invoke(guard, agent)  # Should be denied
+        spend_after = guard.get_budget_state("coder").current_spend
+
+        # Spend should not increase (tool was denied, not executed)
+        assert spend_after == spend_before
+
+
+# ── Tests: Budget and Freeze Interaction ──────────────────────────────────────
+
+
+class TestBudgetFreezeInteraction:
+    """Test interaction between budget checks and freeze kill switch."""
+
+    def test_frozen_takes_priority_over_budget(self) -> None:
+        """Frozen check happens before budget check — frozen agent gets AGENT_FROZEN."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # Both frozen and over-budget
+        guard.freeze("coder")
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        should_terminate, reply = _invoke(guard, agent)
+
+        # Should get AGENT_FROZEN (not BUDGET_EXCEEDED)
+        assert should_terminate is True
+        assert "frozen" in str(reply).lower()
+
+    def test_budget_reset_allows_subsequent_calls(self) -> None:
+        """After reset_budget(), previously denied agent can make calls again."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        # First call should be denied
+        should_terminate, _ = _invoke(guard, agent)
+        assert should_terminate is True
+
+        # Reset budget
+        guard.reset_budget("coder")
+
+        # Now should be allowed
+        should_terminate, reply = _invoke(guard, agent)
+        assert should_terminate is False
+        assert reply is None
+
+
+# ── Tests: Budget Denial Message Format ───────────────────────────────────────
+
+
+class TestBudgetDenialMessage:
+    """Test the denial message format for budget exceeded."""
+
+    def test_denial_message_contains_budget_exceeded(self) -> None:
+        """Denial message includes BUDGET_EXCEEDED in its content."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        _, reply = _invoke(guard, agent)
+
+        assert "BUDGET_EXCEEDED" in str(reply)
+
+    def test_denial_message_contains_governance_denial_prefix(self) -> None:
+        """Denial message starts with [GOVERNANCE DENIAL] prefix."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        guard.set_budget("coder", 0.001)
+        guard._budget_manager.track_cost("coder", 0.01)
+
+        _, reply = _invoke(guard, agent)
+
+        assert "[GOVERNANCE DENIAL]" in str(reply)

--- a/packages/ag2-tealtiger/tests/test_guard_freeze.py
+++ b/packages/ag2-tealtiger/tests/test_guard_freeze.py
@@ -1,0 +1,483 @@
+"""Tests for TealTigerGuard freeze/unfreeze kill switch.
+
+Validates:
+- Task 6.2: freeze(), unfreeze(), is_frozen() methods
+- Requirements: 4.1, 4.2, 4.4, 4.5, 4.6
+
+Freeze is mode-independent: always blocks regardless of governance mode.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+class _MockConversableAgent:
+    """Lightweight mock of AG2's ConversableAgent for unit testing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self,
+        trigger: Any,
+        reply_func: Any,
+        position: int = 0,
+        config: Any = None,
+        reset_config: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._reply_funcs.insert(
+            position,
+            {
+                "trigger": trigger,
+                "reply_func": reply_func,
+                "config": config,
+                "reset_config": reset_config,
+            },
+        )
+
+
+# ── Test: freeze() ───────────────────────────────────────────────────────────
+
+
+class TestFreeze:
+    """Test TealTigerGuard.freeze() behavior."""
+
+    def test_freeze_adds_agent_to_frozen_set(self) -> None:
+        """freeze() adds the agent_id to internal frozen set."""
+        guard = TealTigerGuard()
+
+        guard.freeze("agent_a")
+
+        assert "agent_a" in guard._frozen_agents
+
+    def test_freeze_multiple_agents(self) -> None:
+        """freeze() can freeze multiple agents independently."""
+        guard = TealTigerGuard()
+
+        guard.freeze("agent_a")
+        guard.freeze("agent_b")
+        guard.freeze("agent_c")
+
+        assert "agent_a" in guard._frozen_agents
+        assert "agent_b" in guard._frozen_agents
+        assert "agent_c" in guard._frozen_agents
+
+    def test_freeze_same_agent_twice_is_idempotent(self) -> None:
+        """Freezing an already-frozen agent does not error; remains frozen."""
+        guard = TealTigerGuard()
+
+        guard.freeze("agent_a")
+        guard.freeze("agent_a")
+
+        assert "agent_a" in guard._frozen_agents
+        # Two audit entries are recorded (one per freeze call)
+        freeze_entries = [
+            e for e in guard.audit_trail
+            if e.agent_id == "agent_a" and "AGENT_FROZEN" in e.reason_codes
+        ]
+        assert len(freeze_entries) == 2
+
+    def test_freeze_records_audit_entry(self) -> None:
+        """freeze() records an AuditEntry in the audit trail. (Req 4.6)"""
+        guard = TealTigerGuard()
+
+        guard.freeze("agent_a")
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert isinstance(entry, AuditEntry)
+
+    def test_freeze_audit_entry_fields(self) -> None:
+        """freeze() audit entry has correct field values."""
+        guard = TealTigerGuard()
+        before_ms = time.time() * 1000
+
+        guard.freeze("coder")
+
+        after_ms = time.time() * 1000
+        entry = guard.audit_trail[0]
+
+        # Core fields
+        assert entry.agent_id == "coder"
+        assert entry.action == GovernanceAction.DENY.value
+        assert entry.action_kind == ActionKind.FREEZE.value
+        assert entry.mode == GovernanceMode.OBSERVE.value
+        assert entry.reason_codes == ["AGENT_FROZEN"]
+        assert entry.risk_score == 100
+        assert "frozen" in entry.reason.lower()
+
+        # Timestamp is realistic
+        assert before_ms <= entry.timestamp_ms <= after_ms
+
+        # IDs are populated
+        assert entry.correlation_id  # non-empty UUID
+        assert entry.decision_id  # non-empty UUID
+        assert entry.correlation_id != entry.decision_id
+
+    def test_freeze_audit_entry_has_teec_context(self) -> None:
+        """freeze() audit entry includes a TEEC context."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+
+        entry = guard.audit_trail[0]
+        assert entry.teec is not None
+        assert entry.teec.namespace == "teec.ag2"
+        assert entry.teec.conversation_id == guard._teec_builder.conversation_id
+        assert entry.teec.agent_role == "coder"
+        assert entry.teec.decision_id == entry.decision_id
+        assert entry.teec.decision_source == "default_mode"
+
+    def test_freeze_in_enforce_mode(self) -> None:
+        """freeze() works the same in ENFORCE mode — mode-independent."""
+        guard = TealTigerGuard(mode=GovernanceMode.ENFORCE)
+
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder")
+        entry = guard.audit_trail[0]
+        assert entry.mode == GovernanceMode.ENFORCE.value
+        assert entry.risk_score == 100
+
+    def test_freeze_in_monitor_mode(self) -> None:
+        """freeze() works the same in MONITOR mode — mode-independent."""
+        guard = TealTigerGuard(mode=GovernanceMode.MONITOR)
+
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder")
+        entry = guard.audit_trail[0]
+        assert entry.mode == GovernanceMode.MONITOR.value
+        assert entry.risk_score == 100
+
+    def test_freeze_evaluation_time_recorded(self) -> None:
+        """freeze() records evaluation_time_ms >= 0."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+
+        entry = guard.audit_trail[0]
+        assert entry.evaluation_time_ms >= 0
+
+
+# ── Test: unfreeze() ──────────────────────────────────────────────────────────
+
+
+class TestUnfreeze:
+    """Test TealTigerGuard.unfreeze() behavior."""
+
+    def test_unfreeze_removes_agent_from_frozen_set(self) -> None:
+        """unfreeze() removes the agent_id from the frozen set. (Req 4.4)"""
+        guard = TealTigerGuard()
+        guard.freeze("agent_a")
+
+        guard.unfreeze("agent_a")
+
+        assert "agent_a" not in guard._frozen_agents
+
+    def test_unfreeze_agent_not_frozen_is_safe(self) -> None:
+        """unfreeze() on a non-frozen agent does not error."""
+        guard = TealTigerGuard()
+
+        # Should not raise
+        guard.unfreeze("agent_a")
+
+        assert "agent_a" not in guard._frozen_agents
+
+    def test_unfreeze_records_audit_entry(self) -> None:
+        """unfreeze() records an AuditEntry in the audit trail. (Req 4.6)"""
+        guard = TealTigerGuard()
+        guard.freeze("agent_a")
+
+        guard.unfreeze("agent_a")
+
+        # Two entries: one freeze + one unfreeze
+        assert len(guard.audit_trail) == 2
+        unfreeze_entry = guard.audit_trail[1]
+        assert isinstance(unfreeze_entry, AuditEntry)
+
+    def test_unfreeze_audit_entry_fields(self) -> None:
+        """unfreeze() audit entry has correct field values."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+        before_ms = time.time() * 1000
+
+        guard.unfreeze("coder")
+
+        after_ms = time.time() * 1000
+        entry = guard.audit_trail[1]  # second entry is unfreeze
+
+        # Core fields
+        assert entry.agent_id == "coder"
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert entry.action_kind == ActionKind.FREEZE.value
+        assert entry.mode == GovernanceMode.OBSERVE.value
+        assert entry.reason_codes == ["AGENT_UNFROZEN"]
+        assert entry.risk_score == 0
+        assert "unfrozen" in entry.reason.lower()
+
+        # Timestamp is realistic
+        assert before_ms <= entry.timestamp_ms <= after_ms
+
+        # IDs are populated
+        assert entry.correlation_id  # non-empty
+        assert entry.decision_id  # non-empty
+        assert entry.correlation_id != entry.decision_id
+
+    def test_unfreeze_audit_entry_has_teec_context(self) -> None:
+        """unfreeze() audit entry includes a TEEC context."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+
+        guard.unfreeze("coder")
+
+        entry = guard.audit_trail[1]
+        assert entry.teec is not None
+        assert entry.teec.namespace == "teec.ag2"
+        assert entry.teec.conversation_id == guard._teec_builder.conversation_id
+        assert entry.teec.agent_role == "coder"
+        assert entry.teec.decision_id == entry.decision_id
+
+    def test_unfreeze_preserves_other_frozen_agents(self) -> None:
+        """unfreeze() only affects the specified agent."""
+        guard = TealTigerGuard()
+        guard.freeze("agent_a")
+        guard.freeze("agent_b")
+        guard.freeze("agent_c")
+
+        guard.unfreeze("agent_b")
+
+        assert guard.is_frozen("agent_a")
+        assert not guard.is_frozen("agent_b")
+        assert guard.is_frozen("agent_c")
+
+
+# ── Test: is_frozen() ─────────────────────────────────────────────────────────
+
+
+class TestIsFrozen:
+    """Test TealTigerGuard.is_frozen() behavior."""
+
+    def test_is_frozen_returns_false_for_unknown_agent(self) -> None:
+        """is_frozen() returns False for an agent never frozen."""
+        guard = TealTigerGuard()
+
+        assert guard.is_frozen("unknown_agent") is False
+
+    def test_is_frozen_returns_true_after_freeze(self) -> None:
+        """is_frozen() returns True after freeze is called."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder") is True
+
+    def test_is_frozen_returns_false_after_unfreeze(self) -> None:
+        """is_frozen() returns False after unfreeze is called."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+
+        assert guard.is_frozen("coder") is False
+
+    def test_is_frozen_independent_per_agent(self) -> None:
+        """is_frozen() is per-agent — freezing one doesn't affect others."""
+        guard = TealTigerGuard()
+        guard.freeze("agent_a")
+
+        assert guard.is_frozen("agent_a") is True
+        assert guard.is_frozen("agent_b") is False
+
+
+# ── Test: Freeze/Unfreeze Round-Trip ──────────────────────────────────────────
+
+
+class TestFreezeUnfreezeRoundTrip:
+    """Test freeze followed by unfreeze restores normal state. (Req 4.4)"""
+
+    def test_freeze_unfreeze_restores_state(self) -> None:
+        """Freeze then unfreeze restores the agent to non-frozen state."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+        assert guard.is_frozen("coder") is True
+
+        guard.unfreeze("coder")
+        assert guard.is_frozen("coder") is False
+
+    def test_multiple_freeze_unfreeze_cycles(self) -> None:
+        """Agent can be frozen and unfrozen multiple times."""
+        guard = TealTigerGuard()
+
+        for _ in range(5):
+            guard.freeze("coder")
+            assert guard.is_frozen("coder") is True
+
+            guard.unfreeze("coder")
+            assert guard.is_frozen("coder") is False
+
+    def test_freeze_unfreeze_audit_trail_ordering(self) -> None:
+        """Freeze/unfreeze events are recorded in order in audit trail."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+        guard.freeze("coder")
+
+        assert len(guard.audit_trail) == 3
+
+        # First: freeze
+        assert guard.audit_trail[0].reason_codes == ["AGENT_FROZEN"]
+        assert guard.audit_trail[0].action == GovernanceAction.DENY.value
+
+        # Second: unfreeze
+        assert guard.audit_trail[1].reason_codes == ["AGENT_UNFROZEN"]
+        assert guard.audit_trail[1].action == GovernanceAction.ALLOW.value
+
+        # Third: freeze again
+        assert guard.audit_trail[2].reason_codes == ["AGENT_FROZEN"]
+        assert guard.audit_trail[2].action == GovernanceAction.DENY.value
+
+    def test_freeze_unfreeze_timestamps_are_ordered(self) -> None:
+        """Audit timestamps are monotonically increasing across operations."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+
+        assert guard.audit_trail[0].timestamp_ms <= guard.audit_trail[1].timestamp_ms
+
+
+# ── Test: Frozen Agent Denial Behavior ────────────────────────────────────────
+
+
+class TestFrozenAgentDenial:
+    """Test that frozen agents receive DENY with AGENT_FROZEN regardless of mode."""
+
+    def test_frozen_denial_has_correct_reason_code(self) -> None:
+        """Frozen agent denial uses reason_code 'AGENT_FROZEN'. (Req 4.2)"""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+
+        # The freeze itself records a DENY with AGENT_FROZEN
+        entry = guard.audit_trail[0]
+        assert "AGENT_FROZEN" in entry.reason_codes
+
+    def test_frozen_denial_has_risk_score_100(self) -> None:
+        """Frozen agent denial always has risk_score 100. (Req 4.2)"""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+
+        entry = guard.audit_trail[0]
+        assert entry.risk_score == 100
+
+    def test_frozen_denial_mode_independent_observe(self) -> None:
+        """Freeze blocks in OBSERVE mode — mode-independent. (Req 4.1)"""
+        guard = TealTigerGuard(mode=GovernanceMode.OBSERVE)
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder")
+        entry = guard.audit_trail[0]
+        assert entry.risk_score == 100
+        assert "AGENT_FROZEN" in entry.reason_codes
+
+    def test_frozen_denial_mode_independent_monitor(self) -> None:
+        """Freeze blocks in MONITOR mode — mode-independent. (Req 4.1)"""
+        guard = TealTigerGuard(mode=GovernanceMode.MONITOR)
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder")
+        entry = guard.audit_trail[0]
+        assert entry.risk_score == 100
+        assert "AGENT_FROZEN" in entry.reason_codes
+
+    def test_frozen_denial_mode_independent_enforce(self) -> None:
+        """Freeze blocks in ENFORCE mode — mode-independent. (Req 4.1)"""
+        guard = TealTigerGuard(mode=GovernanceMode.ENFORCE)
+        guard.freeze("coder")
+
+        assert guard.is_frozen("coder")
+        entry = guard.audit_trail[0]
+        assert entry.risk_score == 100
+        assert "AGENT_FROZEN" in entry.reason_codes
+
+
+# ── Test: Audit Trail Completeness ────────────────────────────────────────────
+
+
+class TestFreezeAuditCompleteness:
+    """Test that freeze/unfreeze produce complete audit entries. (Req 4.6)"""
+
+    def test_freeze_entry_has_all_required_fields(self) -> None:
+        """freeze() audit entry has all AuditEntry required fields."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+
+        entry = guard.audit_trail[0]
+
+        # All required fields exist and are non-empty/non-None
+        assert entry.correlation_id
+        assert entry.decision_id
+        assert entry.timestamp_ms > 0
+        assert entry.action in ("ALLOW", "DENY", "MODIFY", "REFER")
+        assert entry.action_kind == ActionKind.FREEZE.value
+        assert entry.mode in ("ENFORCE", "MONITOR", "OBSERVE")
+        assert entry.agent_id == "coder"
+        assert entry.reason
+        assert isinstance(entry.reason_codes, list)
+        assert entry.risk_score >= 0
+        assert entry.evaluation_time_ms >= 0
+        assert entry.teec is not None
+
+    def test_unfreeze_entry_has_all_required_fields(self) -> None:
+        """unfreeze() audit entry has all AuditEntry required fields."""
+        guard = TealTigerGuard()
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+
+        entry = guard.audit_trail[1]
+
+        assert entry.correlation_id
+        assert entry.decision_id
+        assert entry.timestamp_ms > 0
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert entry.action_kind == ActionKind.FREEZE.value
+        assert entry.mode in ("ENFORCE", "MONITOR", "OBSERVE")
+        assert entry.agent_id == "coder"
+        assert entry.reason
+        assert isinstance(entry.reason_codes, list)
+        assert entry.risk_score == 0
+        assert entry.evaluation_time_ms >= 0
+        assert entry.teec is not None
+
+    def test_each_freeze_unfreeze_gets_unique_ids(self) -> None:
+        """Each freeze/unfreeze call gets its own correlation_id and decision_id."""
+        guard = TealTigerGuard()
+
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+        guard.freeze("reviewer")
+
+        ids = set()
+        for entry in guard.audit_trail:
+            ids.add(entry.correlation_id)
+            ids.add(entry.decision_id)
+
+        # 3 entries * 2 ids each = 6 unique IDs
+        assert len(ids) == 6

--- a/packages/ag2-tealtiger/tests/test_guard_message_governance.py
+++ b/packages/ag2-tealtiger/tests/test_guard_message_governance.py
@@ -1,0 +1,555 @@
+"""Tests for TealTigerGuard inter-agent message governance.
+
+Validates:
+- Task 6.6: Inter-agent message governance
+- Requirements: 17.1, 17.2, 17.3, 17.4, 17.5, 17.6, 17.7
+
+Tests verify:
+- Frozen sender blocked with "AGENT_FROZEN" regardless of mode
+- Message governance evaluates against TealEngine policies
+- Separate decision_ids for tool and message governance in the same turn
+- Correct action_kind="message" in audit entries for plain text messages
+- Engine receives sender/recipient agent_ids and message content
+- DENY in ENFORCE mode blocks message delivery
+- DENY in MONITOR mode logs but allows through
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+)
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for message governance tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+class _MockTealEngine:
+    """Mock TealEngine with configurable decisions."""
+
+    def __init__(
+        self,
+        default_action: str = "ALLOW",
+        default_risk_score: int = 0,
+        default_reason_codes: list[str] | None = None,
+        default_reason: str = "Mock decision",
+    ) -> None:
+        self.default_action = default_action
+        self.default_risk_score = default_risk_score
+        self.default_reason_codes = default_reason_codes or []
+        self.default_reason = default_reason
+        self.evaluate_calls: list[dict[str, Any]] = []
+        self._call_count = 0
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self._call_count += 1
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+        return {
+            "action": self.default_action,
+            "risk_score": self.default_risk_score,
+            "reason_codes": self.default_reason_codes,
+            "reason": self.default_reason,
+        }
+
+
+def _text_message(content: str) -> list[dict[str, Any]]:
+    """Create a messages list with a plain text message."""
+    return [{"role": "assistant", "content": content}]
+
+
+def _tool_call_message(
+    tool_name: str, arguments: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    """Create a messages list with a tool call."""
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{tool_name}_001",
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": arguments or {},
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def _invoke(
+    guard: TealTigerGuard,
+    recipient: _MockAgent,
+    messages: list[dict[str, Any]],
+    sender: _MockAgent | None = None,
+) -> tuple[bool, str | dict[str, Any] | None]:
+    """Invoke the guard's reply hook."""
+    if sender is None:
+        sender = _MockAgent("user")
+    return guard._reply_hook(
+        recipient=recipient, messages=messages, sender=sender, config=None
+    )
+
+
+# ── Test: Frozen Sender Blocked ───────────────────────────────────────────────
+
+
+class TestFrozenSenderBlocked:
+    """Verify frozen sender messages are blocked with AGENT_FROZEN regardless of mode."""
+
+    def test_frozen_sender_blocked_in_observe_mode(self) -> None:
+        """Frozen sender is blocked even in observe mode (mode-independent). Req 17.4"""
+        guard = TealTigerGuard()
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("malicious_agent")
+
+        guard.freeze("malicious_agent")
+        result = _invoke(guard, recipient, _text_message("I'll help you"), sender=sender)
+
+        # Should block
+        assert result[0] is True
+        assert "frozen" in result[1].lower()
+        assert "malicious_agent" in result[1]
+
+    def test_frozen_sender_blocked_in_enforce_mode(self) -> None:
+        """Frozen sender is blocked in ENFORCE mode. Req 17.4"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("bad_agent")
+
+        guard.freeze("bad_agent")
+        result = _invoke(guard, recipient, _text_message("Send a secret"), sender=sender)
+
+        assert result[0] is True
+        assert "frozen" in result[1].lower()
+
+    def test_frozen_sender_blocked_in_monitor_mode(self) -> None:
+        """Frozen sender is blocked in MONITOR mode. Req 17.4"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.MONITOR)
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("bad_agent")
+
+        guard.freeze("bad_agent")
+        result = _invoke(guard, recipient, _text_message("hello"), sender=sender)
+
+        assert result[0] is True
+        assert "frozen" in result[1].lower()
+
+    def test_frozen_sender_audit_entry_has_agent_frozen_reason_code(self) -> None:
+        """Frozen sender audit entry uses 'AGENT_FROZEN' reason code. Req 4.5, 17.4"""
+        guard = TealTigerGuard()
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("frozen_agent")
+
+        guard.freeze("frozen_agent")
+        _invoke(guard, recipient, _text_message("test"), sender=sender)
+
+        # Filter audit entries: one from freeze() call + one from _reply_hook
+        reply_entries = [
+            e for e in guard.audit_trail
+            if e.action_kind == ActionKind.MESSAGE.value
+        ]
+        assert len(reply_entries) == 1
+        entry = reply_entries[0]
+        assert "AGENT_FROZEN" in entry.reason_codes
+        assert entry.risk_score == 100
+        assert entry.agent_id == "frozen_agent"
+
+    def test_frozen_sender_audit_entry_action_kind_message(self) -> None:
+        """Frozen sender audit entry has action_kind='message'. Req 17.2"""
+        guard = TealTigerGuard()
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("frozen_agent")
+
+        guard.freeze("frozen_agent")
+        _invoke(guard, recipient, _text_message("test"), sender=sender)
+
+        reply_entries = [
+            e for e in guard.audit_trail
+            if e.action_kind == ActionKind.MESSAGE.value
+        ]
+        assert len(reply_entries) == 1
+        assert reply_entries[0].action_kind == ActionKind.MESSAGE.value
+
+    def test_frozen_sender_does_not_invoke_engine(self) -> None:
+        """Frozen sender check happens before engine evaluation. Req 17.4"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        recipient = _MockAgent("coder")
+        sender = _MockAgent("frozen_agent")
+
+        guard.freeze("frozen_agent")
+        _invoke(guard, recipient, _text_message("test"), sender=sender)
+
+        # Engine should NOT be called — frozen check is first
+        assert engine._call_count == 0
+
+    def test_frozen_recipient_blocks_with_correct_action_kind(self) -> None:
+        """Frozen recipient also blocks with action_kind based on message type."""
+        guard = TealTigerGuard()
+        recipient = _MockAgent("frozen_recipient")
+        sender = _MockAgent("user")
+
+        guard.freeze("frozen_recipient")
+        result = _invoke(guard, recipient, _text_message("hello"), sender=sender)
+
+        assert result[0] is True
+        # Check that the action_kind is MESSAGE for a plain text message
+        reply_entries = [
+            e for e in guard.audit_trail
+            if e.agent_id == "frozen_recipient" and e.action_kind == ActionKind.MESSAGE.value
+        ]
+        assert len(reply_entries) == 1
+
+
+# ── Test: Separate Decision IDs for Tool vs Message ───────────────────────────
+
+
+class TestSeparateDecisionIds:
+    """Verify tool and message governance produce independent decision_ids. Req 17.7"""
+
+    def test_tool_and_message_have_different_decision_ids(self) -> None:
+        """Tool call and plain message produce separate audit entries with different decision_ids."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        # First: a tool call
+        _invoke(guard, agent, _tool_call_message("run_code", {"code": "x=1"}), sender=sender)
+
+        # Second: a plain message
+        _invoke(guard, agent, _text_message("What did that code do?"), sender=sender)
+
+        # Should have 2 audit entries
+        assert len(guard.audit_trail) == 2
+        tool_entry = guard.audit_trail[0]
+        msg_entry = guard.audit_trail[1]
+
+        # Different decision_ids
+        assert tool_entry.decision_id != msg_entry.decision_id
+
+    def test_tool_entry_has_action_kind_tool_call(self) -> None:
+        """Tool call audit entry has action_kind='tool_call'."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _tool_call_message("read_file", {"path": "/x"}), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.TOOL_CALL.value
+
+    def test_message_entry_has_action_kind_message(self) -> None:
+        """Plain message audit entry has action_kind='message'. Req 17.2"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("Hello world"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.MESSAGE.value
+
+    def test_multiple_messages_each_get_unique_decision_id(self) -> None:
+        """Each message governance evaluation gets its own decision_id. Req 17.7"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("msg 1"), sender=sender)
+        _invoke(guard, agent, _text_message("msg 2"), sender=sender)
+        _invoke(guard, agent, _text_message("msg 3"), sender=sender)
+
+        decision_ids = [e.decision_id for e in guard.audit_trail]
+        assert len(set(decision_ids)) == 3  # All unique
+
+
+# ── Test: Correct action_kind in Audit Entries ────────────────────────────────
+
+
+class TestActionKindInAuditEntries:
+    """Verify action_kind correctly distinguishes tool_call from message."""
+
+    def test_observe_mode_text_message_action_kind_is_message(self) -> None:
+        """In observe mode, plain text produces action_kind='message'."""
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("How are you?"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.MESSAGE.value
+
+    def test_observe_mode_tool_call_action_kind_is_tool_call(self) -> None:
+        """In observe mode, tool call produces action_kind='tool_call'."""
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _tool_call_message("get_weather", {"city": "NYC"}), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.TOOL_CALL.value
+
+    def test_policy_mode_text_message_action_kind_is_message(self) -> None:
+        """In policy mode, plain text produces action_kind='message'. Req 17.2"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("Please do something"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.MESSAGE.value
+
+
+# ── Test: Engine Receives Correct Message Parameters ──────────────────────────
+
+
+class TestEngineMessageParameters:
+    """Verify TealEngine receives sender/recipient/content for message governance. Req 17.6"""
+
+    def test_engine_receives_message_content(self) -> None:
+        """Engine args contains message content."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("Please review this code"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["args"]["content"] == "Please review this code"
+
+    def test_engine_receives_sender_name(self) -> None:
+        """Engine args contains sender agent_id. Req 17.6"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("hello"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["args"]["sender"] == "reviewer"
+
+    def test_engine_receives_recipient_name(self) -> None:
+        """Engine args contains recipient agent_id. Req 17.6"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("hello"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["args"]["recipient"] == "coder"
+
+    def test_engine_receives_action_kind_message_in_context(self) -> None:
+        """Engine context contains action_kind='message'. Req 17.6"""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("hello"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["context"]["action_kind"] == "message"
+
+    def test_engine_receives_tool_name_none_for_messages(self) -> None:
+        """Engine tool_name is None for message governance."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("hello"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["tool_name"] is None
+
+
+# ── Test: Message DENY in ENFORCE Mode ────────────────────────────────────────
+
+
+class TestMessageDenyEnforce:
+    """Verify message denial in ENFORCE mode. Req 17.3"""
+
+    def test_message_denied_in_enforce_blocks_delivery(self) -> None:
+        """DENY in ENFORCE mode returns (True, denial_message). Req 17.3"""
+        engine = _MockTealEngine(
+            default_action="DENY",
+            default_risk_score=70,
+            default_reason_codes=["CONTENT_POLICY"],
+            default_reason="Message content violates policy",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = _invoke(guard, agent, _text_message("harmful content"), sender=sender)
+
+        assert result[0] is True  # Blocked
+        assert "GOVERNANCE DENIAL" in result[1]
+
+    def test_message_denied_audit_entry_has_message_denied_code(self) -> None:
+        """DENY audit entry includes 'MESSAGE_DENIED' reason code. Req 17.3"""
+        engine = _MockTealEngine(
+            default_action="DENY",
+            default_risk_score=70,
+            default_reason_codes=["CONTENT_POLICY"],
+            default_reason="Policy violation",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("bad content"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert "MESSAGE_DENIED" in entry.reason_codes
+        assert entry.action == GovernanceAction.DENY.value
+        assert entry.action_kind == ActionKind.MESSAGE.value
+
+
+# ── Test: Message DENY in MONITOR Mode ────────────────────────────────────────
+
+
+class TestMessageDenyMonitor:
+    """Verify message denial in MONITOR mode logs but allows through."""
+
+    def test_message_denied_in_monitor_allows_through(self) -> None:
+        """DENY in MONITOR mode returns (False, None) — message allowed."""
+        engine = _MockTealEngine(
+            default_action="DENY",
+            default_risk_score=70,
+            default_reason_codes=["CONTENT_POLICY"],
+            default_reason="Policy violation",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = _invoke(guard, agent, _text_message("bad content"), sender=sender)
+
+        assert result == (False, None)
+
+    def test_message_denied_in_monitor_records_audit_entry(self) -> None:
+        """DENY in MONITOR mode still records audit entry with correct action_kind."""
+        engine = _MockTealEngine(
+            default_action="DENY",
+            default_risk_score=70,
+            default_reason_codes=["CONTENT_POLICY"],
+            default_reason="Policy violation",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("bad content"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.DENY.value
+        assert entry.action_kind == ActionKind.MESSAGE.value
+        assert "MESSAGE_DENIED" in entry.reason_codes
+
+
+# ── Test: Message ALLOW ───────────────────────────────────────────────────────
+
+
+class TestMessageAllow:
+    """Verify message ALLOW passes through correctly."""
+
+    def test_message_allowed_passes_through(self) -> None:
+        """ALLOW returns (False, None) — message delivered."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = _invoke(guard, agent, _text_message("Hello!"), sender=sender)
+
+        assert result == (False, None)
+
+    def test_message_allowed_records_audit_entry(self) -> None:
+        """ALLOW records audit entry with action_kind='message'."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        _invoke(guard, agent, _text_message("Hello!"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert entry.action_kind == ActionKind.MESSAGE.value
+
+
+# ── Test: Originating Actor Identification ────────────────────────────────────
+
+
+class TestOriginatingActorIdentification:
+    """Verify the originating actor is correctly identified. Req 17.5"""
+
+    def test_audit_entry_identifies_recipient_as_agent_id(self) -> None:
+        """Audit entry agent_id is the recipient (the governed agent)."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("Please fix"), sender=sender)
+
+        entry = guard.audit_trail[0]
+        assert entry.agent_id == "coder"
+
+    def test_engine_context_identifies_agent(self) -> None:
+        """Engine context includes agent_id for policy scoping."""
+        engine = _MockTealEngine()
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("reviewer")
+
+        _invoke(guard, agent, _text_message("hello"), sender=sender)
+
+        call = engine.evaluate_calls[0]
+        assert call["context"]["agent_id"] == "coder"

--- a/packages/ag2-tealtiger/tests/test_guard_observe_mode.py
+++ b/packages/ag2-tealtiger/tests/test_guard_observe_mode.py
@@ -1,0 +1,904 @@
+"""Tests for TealTigerGuard._reply_hook — observe mode path.
+
+Validates:
+- Task 6.3: Observe mode produces correct audit entries
+- Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6
+
+Tests verify:
+- Cost estimation from text length heuristics
+- PII detection in tool call arguments
+- Tool name and argument summary recording
+- AuditEntry with action=ALLOW and reason_codes=["OBSERVE_PASSTHROUGH"]
+- Return (False, None) — never blocks
+- Frozen agent handling (mode-independent deny)
+- Turn_id monotonically increments
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+)
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for observe mode tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+def _tool_call_message(
+    tool_name: str, arguments: dict[str, Any] | str | None = None
+) -> list[dict[str, Any]]:
+    """Create a messages list with a single tool call in AG2 format."""
+    if arguments is None:
+        arguments = {}
+    if isinstance(arguments, dict):
+        args_value = arguments
+    else:
+        args_value = arguments
+
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{tool_name}_001",
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": args_value,
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def _text_message(content: str) -> list[dict[str, Any]]:
+    """Create a messages list with a plain text message."""
+    return [{"role": "assistant", "content": content}]
+
+
+# ── Observe Mode: Basic Behavior ─────────────────────────────────────────────
+
+
+class TestObserveModePassthrough:
+    """Verify observe mode always returns (False, None) — never blocks."""
+
+    def test_returns_false_none_for_tool_call(self) -> None:
+        """Observe mode passes through tool calls without blocking."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        assert result == (False, None)
+
+    def test_returns_false_none_for_text_message(self) -> None:
+        """Observe mode passes through text messages without blocking."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("Hello world"),
+            sender=sender,
+            config=None,
+        )
+
+        assert result == (False, None)
+
+    def test_returns_false_none_for_empty_tool_calls(self) -> None:
+        """Observe mode handles messages with empty tool_calls list."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        messages = [{"role": "assistant", "content": "test", "tool_calls": []}]
+        result = guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        assert result == (False, None)
+
+    def test_returns_false_none_with_none_messages(self) -> None:
+        """Observe mode handles None messages gracefully."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = guard._reply_hook(
+            recipient=agent, messages=None, sender=sender, config=None
+        )
+
+        assert result == (False, None)
+
+    def test_returns_false_none_with_empty_messages(self) -> None:
+        """Observe mode handles empty messages list gracefully."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        result = guard._reply_hook(
+            recipient=agent, messages=[], sender=sender, config=None
+        )
+
+        assert result == (False, None)
+
+
+# ── Observe Mode: AuditEntry Production ──────────────────────────────────────
+
+
+class TestObserveModeAuditEntry:
+    """Verify observe mode produces correct AuditEntry structure."""
+
+    def test_produces_audit_entry_for_tool_call(self) -> None:
+        """Each tool call produces exactly one AuditEntry."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        assert len(guard.audit_trail) == 1
+
+    def test_audit_entry_action_is_allow(self) -> None:
+        """Observe mode sets action=ALLOW in the audit entry."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.action == GovernanceAction.ALLOW.value
+
+    def test_audit_entry_reason_codes_observe_passthrough(self) -> None:
+        """Observe mode sets reason_codes=["OBSERVE_PASSTHROUGH"]."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "print('hi')"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.reason_codes == ["OBSERVE_PASSTHROUGH"]
+
+    def test_audit_entry_mode_is_observe(self) -> None:
+        """Observe mode sets mode=OBSERVE in the audit entry."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("search", {"query": "test"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.mode == GovernanceMode.OBSERVE.value
+
+    def test_audit_entry_risk_score_zero(self) -> None:
+        """Observe mode always sets risk_score=0."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("dangerous_tool", {"target": "prod"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.risk_score == 0
+
+    def test_audit_entry_action_kind_is_tool_call(self) -> None:
+        """Observe mode sets action_kind=TOOL_CALL for tool call messages."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "1+1"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.action_kind == ActionKind.TOOL_CALL.value
+
+    def test_audit_entry_agent_id_from_recipient(self) -> None:
+        """agent_id in the audit entry comes from recipient.name."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("my_special_agent")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("fetch", {"url": "http://example.com"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.agent_id == "my_special_agent"
+
+    def test_audit_entry_has_evaluation_time_ms(self) -> None:
+        """AuditEntry includes positive evaluation_time_ms."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.evaluation_time_ms > 0
+
+    def test_audit_entry_has_valid_teec_context(self) -> None:
+        """AuditEntry includes a valid TEEC context with conversation_id and turn_id."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        teec = entry.teec
+        assert teec.namespace == "teec.ag2"
+        assert teec.conversation_id  # non-empty
+        assert teec.turn_id == 1
+        assert teec.decision_id  # non-empty UUID
+        assert teec.agent_role == "coder"
+
+    def test_audit_entry_has_correlation_id(self) -> None:
+        """AuditEntry has a non-empty correlation_id (UUID)."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.correlation_id  # non-empty string
+        assert len(entry.correlation_id) == 36  # UUID format
+
+    def test_audit_entry_has_timestamp_ms(self) -> None:
+        """AuditEntry has a positive timestamp_ms."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.timestamp_ms > 0
+
+
+# ── Observe Mode: Tool Name and Argument Recording ───────────────────────────
+
+
+class TestObserveModeToolRecording:
+    """Verify observe mode records tool names and argument summaries."""
+
+    def test_records_tool_name(self) -> None:
+        """Audit entry records the tool name from the message."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("execute_shell", {"command": "ls"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.tool_name == "execute_shell"
+
+    def test_records_argument_summary_with_dict_args(self) -> None:
+        """Argument summary captures key names and value types."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message(
+                "send_email",
+                {"to": "user@example.com", "subject": "Hello", "count": 5},
+            ),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.tool_args_summary is not None
+        assert entry.tool_args_summary["to"] == "str"
+        assert entry.tool_args_summary["subject"] == "str"
+        assert entry.tool_args_summary["count"] == "int"
+
+    def test_records_argument_summary_with_json_string_args(self) -> None:
+        """Argument summary works with JSON-encoded string arguments."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        args_json = json.dumps({"query": "SELECT * FROM users", "limit": 10})
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_001",
+                        "type": "function",
+                        "function": {
+                            "name": "run_sql",
+                            "arguments": args_json,
+                        },
+                    }
+                ],
+            }
+        ]
+
+        guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.tool_name == "run_sql"
+        assert entry.tool_args_summary is not None
+        assert entry.tool_args_summary["query"] == "str"
+        assert entry.tool_args_summary["limit"] == "int"
+
+    def test_no_tool_name_for_text_message(self) -> None:
+        """No tool_name recorded for plain text messages."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("Just a regular message"),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.tool_name is None
+        assert entry.tool_args_summary is None
+
+
+# ── Observe Mode: Cost Tracking ──────────────────────────────────────────────
+
+
+class TestObserveModeCostTracking:
+    """Verify observe mode estimates and tracks costs from text length heuristics."""
+
+    def test_cost_tracked_is_positive_for_content(self) -> None:
+        """Cost is estimated and tracked for messages with content."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("A" * 4000),  # 4000 chars = ~1000 tokens
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.cost_tracked > 0
+
+    def test_cost_estimation_formula(self) -> None:
+        """Cost = (chars / 4) * cost_per_1k_tokens / 1000."""
+        guard = TealTigerGuard(cost_per_1k_tokens=0.002)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        # 4000 chars -> 1000 tokens -> 1000 * 0.002 / 1000 = 0.002
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("A" * 4000),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        expected_cost = (4000 / 4.0 * 0.002) / 1000.0
+        assert abs(entry.cost_tracked - expected_cost) < 1e-10
+
+    def test_cost_includes_tool_call_arguments(self) -> None:
+        """Cost estimation includes tool call argument character count."""
+        guard = TealTigerGuard(cost_per_1k_tokens=0.002)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        # Arguments add to total character count
+        args = {"data": "X" * 400}
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("process", args),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.cost_tracked > 0
+
+    def test_cumulative_cost_increases_across_calls(self) -> None:
+        """Cumulative cost in audit entries increases with each invocation."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("A" * 100),
+            sender=sender,
+            config=None,
+        )
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("B" * 100),
+            sender=sender,
+            config=None,
+        )
+
+        entry1 = guard.audit_trail[0]
+        entry2 = guard.audit_trail[1]
+        assert entry2.cumulative_cost > entry1.cumulative_cost
+        assert entry2.cumulative_cost == entry1.cost_tracked + entry2.cost_tracked
+
+    def test_cost_zero_for_empty_content_no_tools(self) -> None:
+        """Cost is zero when message has no content and no tool calls."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        messages = [{"role": "assistant", "content": None}]
+        guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.cost_tracked == 0.0
+
+    def test_custom_cost_rate_used(self) -> None:
+        """Custom cost_per_1k_tokens rate is used in estimation."""
+        guard = TealTigerGuard(cost_per_1k_tokens=0.01)
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("A" * 4000),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        expected_cost = (4000 / 4.0 * 0.01) / 1000.0
+        assert abs(entry.cost_tracked - expected_cost) < 1e-10
+
+
+# ── Observe Mode: PII Detection ──────────────────────────────────────────────
+
+
+class TestObserveModePiiDetection:
+    """Verify observe mode detects PII in tool call arguments."""
+
+    def test_detects_email_in_tool_args(self) -> None:
+        """PII detection finds email addresses in tool call arguments."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message(
+                "send_message", {"to": "john@example.com", "body": "Hello"}
+            ),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert len(entry.pii_detected) > 0
+        pii_types = [p["type"] for p in entry.pii_detected]
+        assert "email" in pii_types
+
+    def test_detects_ssn_in_tool_args(self) -> None:
+        """PII detection finds SSN patterns in tool arguments."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message(
+                "store_record", {"ssn": "123-45-6789", "name": "Alice"}
+            ),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        pii_types = [p["type"] for p in entry.pii_detected]
+        assert "ssn" in pii_types
+
+    def test_detects_pii_in_json_string_args(self) -> None:
+        """PII detection works with JSON-encoded string arguments."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        args_json = json.dumps({"email": "alice@corp.com", "phone": "555-123-4567"})
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_001",
+                        "type": "function",
+                        "function": {
+                            "name": "update_contact",
+                            "arguments": args_json,
+                        },
+                    }
+                ],
+            }
+        ]
+
+        guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        entry = guard.audit_trail[0]
+        pii_types = [p["type"] for p in entry.pii_detected]
+        assert "email" in pii_types
+        assert "phone_number" in pii_types
+
+    def test_no_pii_detected_for_clean_args(self) -> None:
+        """PII list is empty when arguments contain no PII."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("calculate", {"a": 5, "b": 10}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.pii_detected == []
+
+    def test_no_pii_detected_for_text_message(self) -> None:
+        """PII detection is only applied to tool call arguments."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        # PII in message content (not tool args) — not scanned in observe mode
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("My email is john@example.com"),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.pii_detected == []
+
+
+# ── Observe Mode: Turn ID Tracking ───────────────────────────────────────────
+
+
+class TestObserveModeTurnId:
+    """Verify turn_id increments monotonically per _reply_hook invocation."""
+
+    def test_turn_id_starts_at_one(self) -> None:
+        """First invocation produces turn_id=1."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.turn_id == 1
+
+    def test_turn_id_increments_monotonically(self) -> None:
+        """Subsequent invocations produce increasing turn_ids."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        for _ in range(5):
+            guard._reply_hook(
+                recipient=agent,
+                messages=_tool_call_message("run", {}),
+                sender=sender,
+                config=None,
+            )
+
+        for i, entry in enumerate(guard.audit_trail):
+            assert entry.teec.turn_id == i + 1
+
+    def test_turn_id_increments_across_different_agents(self) -> None:
+        """Turn_id increments globally across all agents sharing the guard."""
+        guard = TealTigerGuard()
+        agent_a = _MockAgent("coder")
+        agent_b = _MockAgent("reviewer")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent_a,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+        guard._reply_hook(
+            recipient=agent_b,
+            messages=_tool_call_message("review", {}),
+            sender=sender,
+            config=None,
+        )
+
+        assert guard.audit_trail[0].teec.turn_id == 1
+        assert guard.audit_trail[1].teec.turn_id == 2
+
+
+# ── Observe Mode: Frozen Agent Handling ──────────────────────────────────────
+
+
+class TestObserveModeFrozenAgent:
+    """Verify frozen agents are denied even in observe mode."""
+
+    def test_frozen_agent_returns_true_with_denial(self) -> None:
+        """Frozen agent causes (True, denial_message) — blocks even in observe mode."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard.freeze("coder")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+
+        should_terminate, reply = result
+        assert should_terminate is True
+        assert reply is not None
+        assert "frozen" in reply.lower()
+
+    def test_frozen_agent_audit_entry_deny(self) -> None:
+        """Frozen agent produces DENY audit entry with AGENT_FROZEN."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard.freeze("coder")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+
+        # The freeze itself adds one audit entry, then the reply_hook adds another
+        deny_entries = [
+            e for e in guard.audit_trail
+            if e.action_kind == ActionKind.TOOL_CALL.value
+            and e.action == GovernanceAction.DENY.value
+        ]
+        assert len(deny_entries) == 1
+        entry = deny_entries[0]
+        assert entry.reason_codes == ["AGENT_FROZEN"]
+        assert entry.risk_score == 100
+        assert entry.agent_id == "coder"
+
+    def test_unfrozen_agent_passes_through(self) -> None:
+        """After unfreeze, agent passes through in observe mode again."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard.freeze("coder")
+        guard.unfreeze("coder")
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+
+        assert result == (False, None)
+
+
+# ── Observe Mode: TEEC Context ───────────────────────────────────────────────
+
+
+class TestObserveModeTeecContext:
+    """Verify TEEC context is populated correctly in observe mode."""
+
+    def test_teec_has_stable_conversation_id(self) -> None:
+        """All entries from the same guard share conversation_id."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("build", {}),
+            sender=sender,
+            config=None,
+        )
+
+        conv_id_1 = guard.audit_trail[0].teec.conversation_id
+        conv_id_2 = guard.audit_trail[1].teec.conversation_id
+        assert conv_id_1 == conv_id_2
+        assert conv_id_1  # non-empty
+
+    def test_teec_has_unique_decision_ids(self) -> None:
+        """Each invocation gets a unique decision_id."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {"code": "x=1"}),
+            sender=sender,
+            config=None,
+        )
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {"code": "x=1"}),
+            sender=sender,
+            config=None,
+        )
+
+        id1 = guard.audit_trail[0].teec.decision_id
+        id2 = guard.audit_trail[1].teec.decision_id
+        assert id1 != id2
+
+    def test_teec_has_params_hash_for_tool_calls(self) -> None:
+        """TEEC includes params_hash when tool_args are present."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run_code", {"code": "x = 1"}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.params_hash is not None
+        assert len(entry.teec.params_hash) == 64  # SHA-256 hex
+
+    def test_teec_no_params_hash_for_text_message(self) -> None:
+        """TEEC has no params_hash when no tool call is present."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_text_message("Hello"),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.params_hash is None
+
+    def test_teec_decision_source_is_default_mode(self) -> None:
+        """In observe mode, decision_source is 'default_mode'."""
+        guard = TealTigerGuard()
+        agent = _MockAgent("coder")
+        sender = _MockAgent("user")
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=_tool_call_message("run", {}),
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.decision_source == "default_mode"

--- a/packages/ag2-tealtiger/tests/test_guard_policy_mode.py
+++ b/packages/ag2-tealtiger/tests/test_guard_policy_mode.py
@@ -1,0 +1,550 @@
+"""Tests for TealTigerGuard._reply_hook — policy evaluation path.
+
+Validates task 6.4:
+- TealEngine.evaluate() is called with correct tool_name, args, and framework context
+- ALLOW: pass through, record audit entry
+- DENY in ENFORCE mode: block, return DenialMessage.to_reply_string() as reply
+- DENY in MONITOR mode: log, allow through, record audit entry
+- REFER: suspend action, emit escalation receipt, record audit entry
+
+Requirements: 1.2, 1.3, 1.4, 1.5, 7.1, 7.2, 7.5, 7.6, 15.1, 15.2, 15.8
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    GovernanceMode,
+)
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for policy mode tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+def _make_tool_call_message(
+    tool_name: str,
+    arguments: dict[str, Any] | str | None = None,
+) -> dict[str, Any]:
+    """Create a mock tool call message in AG2 format."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}_001",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments if arguments is not None else {},
+                },
+            }
+        ],
+    }
+
+
+def _make_text_message(content: str) -> dict[str, Any]:
+    """Create a mock text message in AG2 format."""
+    return {"role": "assistant", "content": content}
+
+
+def _invoke(
+    guard: TealTigerGuard,
+    agent: _MockAgent,
+    messages: list[dict[str, Any]],
+) -> tuple[bool, str | dict[str, Any] | None]:
+    """Invoke the guard's reply hook with standard params."""
+    sender = _MockAgent("user")
+    return guard._reply_hook(
+        recipient=agent, messages=messages, sender=sender, config=None
+    )
+
+
+# ── Test: TealEngine.evaluate() is called correctly ──────────────────────────
+
+
+class TestPolicyModeEngineCall:
+    """Verify TealEngine.evaluate() is invoked with correct parameters."""
+
+    def test_evaluate_called_with_tool_name_and_args(
+        self, mock_engine
+    ) -> None:
+        """Engine receives the tool_name and args from the message."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"language": "python", "code": "x=1"})
+        _invoke(guard, agent, [msg])
+
+        assert mock_engine.call_count == 1
+        call = mock_engine.evaluate_calls[0]
+        assert call["tool_name"] == "run_code"
+        assert call["args"] == {"language": "python", "code": "x=1"}
+
+    def test_evaluate_called_with_framework_context(
+        self, mock_engine
+    ) -> None:
+        """Engine receives framework context with ag2, agent_id, conversation_id, cumulative_cost."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+
+        call = mock_engine.evaluate_calls[0]
+        ctx = call["context"]
+        assert ctx["framework"] == "ag2"
+        assert ctx["agent_id"] == "coder"
+        assert "conversation_id" in ctx
+        assert ctx["cumulative_cost"] == 0.0
+        assert ctx["action_kind"] == "tool_call"
+
+    def test_evaluate_not_called_when_no_engine(self) -> None:
+        """Without engine, observe mode runs instead of policy mode."""
+        guard = TealTigerGuard()  # No engine
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "x=1"})
+        result = _invoke(guard, agent, [msg])
+
+        # Should be observe mode passthrough
+        assert result == (False, None)
+        assert guard.audit_trail[-1].reason_codes == ["OBSERVE_PASSTHROUGH"]
+
+    def test_evaluate_handles_string_args(
+        self, mock_engine
+    ) -> None:
+        """Engine handles tool calls with JSON string arguments."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # AG2 sometimes passes args as JSON strings
+        msg = _make_tool_call_message("search", '{"query": "hello"}')
+        _invoke(guard, agent, [msg])
+
+        call = mock_engine.evaluate_calls[0]
+        assert call["tool_name"] == "search"
+        assert call["args"] == {"query": "hello"}
+
+    def test_evaluate_empty_tool_calls(
+        self, mock_engine
+    ) -> None:
+        """When no tool calls present, engine evaluates as message governance with sender/recipient."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_text_message("Hello, how are you?")
+        _invoke(guard, agent, [msg])
+
+        call = mock_engine.evaluate_calls[0]
+        assert call["tool_name"] is None
+        # Message governance passes content, sender, and recipient (Req 17.6)
+        assert call["args"] == {
+            "content": "Hello, how are you?",
+            "sender": "user",
+            "recipient": "coder",
+        }
+
+
+# ── Test: ALLOW Decision ──────────────────────────────────────────────────────
+
+
+class TestPolicyModeAllow:
+    """Verify ALLOW decision passes through and records audit entry."""
+
+    def test_allow_returns_passthrough(self, mock_engine) -> None:
+        """ALLOW decision returns (False, None) — agent continues."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        result = _invoke(guard, agent, [msg])
+
+        assert result == (False, None)
+
+    def test_allow_records_audit_entry(self, mock_engine) -> None:
+        """ALLOW decision produces an audit entry with action=ALLOW."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == "ALLOW"
+        assert entry.agent_id == "coder"
+        assert entry.tool_name == "read_file"
+        assert entry.mode == "ENFORCE"
+        assert entry.evaluation_time_ms > 0
+
+    def test_allow_audit_has_teec_context(self, mock_engine) -> None:
+        """ALLOW audit entry has valid TEEC context with conversation_id and decision_id."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.conversation_id != ""
+        assert entry.teec.decision_id != ""
+        assert entry.teec.namespace == "teec.ag2"
+
+    def test_allow_stores_decision_receipt(self, mock_engine) -> None:
+        """ALLOW decision creates a decision receipt in the manager."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+
+        decision_id = guard.audit_trail[0].teec.decision_id
+        assert guard._decision_manager.is_valid(decision_id)
+
+    def test_allow_in_monitor_mode(self, mock_engine) -> None:
+        """ALLOW works the same in MONITOR mode — pass through."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        result = _invoke(guard, agent, [msg])
+
+        assert result == (False, None)
+        assert guard.audit_trail[-1].action == "ALLOW"
+
+
+# ── Test: DENY Decision in ENFORCE Mode ───────────────────────────────────────
+
+
+class TestPolicyModeDenyEnforce:
+    """Verify DENY in ENFORCE mode blocks and returns DenialMessage."""
+
+    def test_deny_enforce_blocks_tool_call(self, deny_engine) -> None:
+        """DENY in ENFORCE mode returns (True, denial_string)."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "rm -rf /"})
+        should_terminate, reply = _invoke(guard, agent, [msg])
+
+        assert should_terminate is True
+        assert reply is not None
+
+    def test_deny_enforce_returns_denial_message_format(self, deny_engine) -> None:
+        """DENY reply is formatted as DenialMessage.to_reply_string()."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "rm -rf /"})
+        _, reply = _invoke(guard, agent, [msg])
+
+        # Verify the reply string format from DenialMessage.to_reply_string()
+        assert "[GOVERNANCE DENIAL]" in reply
+        assert "Tool: run_code" in reply
+        assert "Action: DENY" in reply
+        assert "Risk: 80" in reply
+        assert "POLICY_VIOLATION" in reply
+        assert "Decision:" in reply
+
+    def test_deny_enforce_records_audit_entry(self, deny_engine) -> None:
+        """DENY in ENFORCE records an audit entry with action=DENY."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "rm -rf /"})
+        _invoke(guard, agent, [msg])
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == "DENY"
+        assert entry.agent_id == "coder"
+        assert entry.tool_name == "run_code"
+        assert entry.risk_score == 80
+        assert "POLICY_VIOLATION" in entry.reason_codes
+        assert entry.mode == "ENFORCE"
+
+    def test_deny_enforce_denial_contains_decision_id(self, deny_engine) -> None:
+        """DENY reply contains the decision_id for audit lookup."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "x=1"})
+        _, reply = _invoke(guard, agent, [msg])
+
+        decision_id = guard.audit_trail[0].teec.decision_id
+        assert decision_id in reply
+
+    def test_deny_enforce_stores_decision_receipt(self, deny_engine) -> None:
+        """DENY in ENFORCE creates a DENY decision receipt."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "x=1"})
+        _invoke(guard, agent, [msg])
+
+        decision_id = guard.audit_trail[0].teec.decision_id
+        receipt = guard._decision_manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.action == GovernanceAction.DENY
+
+
+# ── Test: DENY Decision in MONITOR Mode ───────────────────────────────────────
+
+
+class TestPolicyModeDenyMonitor:
+    """Verify DENY in MONITOR mode logs but allows through."""
+
+    def test_deny_monitor_allows_through(self, deny_engine) -> None:
+        """DENY in MONITOR mode returns (False, None) — agent continues."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "rm -rf /"})
+        result = _invoke(guard, agent, [msg])
+
+        assert result == (False, None)
+
+    def test_deny_monitor_records_audit_entry(self, deny_engine) -> None:
+        """DENY in MONITOR still records an audit entry with action=DENY."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "rm -rf /"})
+        _invoke(guard, agent, [msg])
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == "DENY"
+        assert entry.mode == "MONITOR"
+        assert entry.agent_id == "coder"
+        assert entry.risk_score == 80
+
+    def test_deny_monitor_does_not_return_denial_string(self, deny_engine) -> None:
+        """DENY in MONITOR mode does not produce a denial reply string."""
+        guard = TealTigerGuard(engine=deny_engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "x=1"})
+        should_terminate, reply = _invoke(guard, agent, [msg])
+
+        assert should_terminate is False
+        assert reply is None
+
+
+# ── Test: REFER Decision ──────────────────────────────────────────────────────
+
+
+class TestPolicyModeRefer:
+    """Verify REFER decision suspends action and emits escalation receipt."""
+
+    def test_refer_suspends_action(self, refer_engine) -> None:
+        """REFER returns (True, 'Action pending review: {decision_id}')."""
+        guard = TealTigerGuard(engine=refer_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("deploy", {"env": "production"})
+        should_terminate, reply = _invoke(guard, agent, [msg])
+
+        assert should_terminate is True
+        assert "Action pending review:" in reply
+
+    def test_refer_reply_contains_decision_id(self, refer_engine) -> None:
+        """REFER reply includes the decision_id for reference."""
+        guard = TealTigerGuard(engine=refer_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("deploy", {"env": "production"})
+        _, reply = _invoke(guard, agent, [msg])
+
+        decision_id = guard.audit_trail[0].teec.decision_id
+        assert decision_id in reply
+
+    def test_refer_records_audit_entry(self, refer_engine) -> None:
+        """REFER records an audit entry with action=REFER."""
+        guard = TealTigerGuard(engine=refer_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("deploy", {"env": "production"})
+        _invoke(guard, agent, [msg])
+
+        assert len(guard.audit_trail) == 1
+        entry = guard.audit_trail[0]
+        assert entry.action == "REFER"
+        assert entry.agent_id == "coder"
+        assert entry.tool_name == "deploy"
+        assert entry.risk_score == 50
+        assert "REQUIRES_REVIEW" in entry.reason_codes
+
+    def test_refer_creates_decision_receipt(self, refer_engine) -> None:
+        """REFER creates a decision receipt with REFER action."""
+        guard = TealTigerGuard(engine=refer_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("deploy", {"env": "production"})
+        _invoke(guard, agent, [msg])
+
+        decision_id = guard.audit_trail[0].teec.decision_id
+        receipt = guard._decision_manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.action == GovernanceAction.REFER
+        assert receipt.execution_outcome == "pending_review"
+
+    def test_refer_audit_entry_has_teec_context(self, refer_engine) -> None:
+        """REFER audit entry has valid TEEC context."""
+        guard = TealTigerGuard(engine=refer_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("deploy", {"env": "production"})
+        _invoke(guard, agent, [msg])
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.conversation_id != ""
+        assert entry.teec.decision_id != ""
+        assert entry.teec.namespace == "teec.ag2"
+
+
+# ── Test: TEEC Context Built Correctly ────────────────────────────────────────
+
+
+class TestPolicyModeTEECContext:
+    """Verify TEEC context is built correctly for policy evaluations."""
+
+    def test_teec_has_params_hash_for_tool_calls(self, mock_engine) -> None:
+        """TEEC context includes params_hash when tool args are present."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+
+        entry = guard.audit_trail[0]
+        assert entry.teec.params_hash is not None
+        assert len(entry.teec.params_hash) == 64  # SHA-256 hex
+
+    def test_teec_decision_id_unique_per_evaluation(self, mock_engine) -> None:
+        """Each evaluation produces a unique decision_id."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+        _invoke(guard, agent, [msg])
+
+        ids = [e.teec.decision_id for e in guard.audit_trail]
+        assert len(set(ids)) == 2  # Both unique
+
+    def test_teec_conversation_id_stable_across_evaluations(self, mock_engine) -> None:
+        """Conversation ID stays the same across multiple evaluations."""
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        msg = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        _invoke(guard, agent, [msg])
+        _invoke(guard, agent, [msg])
+
+        conv_ids = [e.teec.conversation_id for e in guard.audit_trail]
+        assert conv_ids[0] == conv_ids[1]
+
+
+# ── Test: Per-Tool Decision Overrides ─────────────────────────────────────────
+
+
+class TestPolicyModeToolOverrides:
+    """Verify per-tool decision overrides work with MockTealEngine."""
+
+    def test_specific_tool_denied_while_others_allowed(self, mock_engine) -> None:
+        """Engine can deny a specific tool while allowing others."""
+        mock_engine.set_decision_for_tool(
+            "delete_file",
+            GovernanceAction.DENY,
+            risk_score=90,
+            reason_codes=["DESTRUCTIVE_ACTION"],
+            reason="Destructive file operation",
+        )
+
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("coder")
+        guard.attach(agent)
+
+        # Allowed tool
+        msg_read = _make_tool_call_message("read_file", {"path": "/tmp/x"})
+        result_read = _invoke(guard, agent, [msg_read])
+        assert result_read == (False, None)
+
+        # Denied tool
+        msg_delete = _make_tool_call_message("delete_file", {"path": "/tmp/x"})
+        should_terminate, reply = _invoke(guard, agent, [msg_delete])
+        assert should_terminate is True
+        assert "DESTRUCTIVE_ACTION" in reply
+
+    def test_per_agent_decision_isolation(self, mock_engine) -> None:
+        """Engine applies per-agent decisions independently."""
+        mock_engine.set_decision_for_agent(
+            "untrusted",
+            GovernanceAction.DENY,
+            risk_score=100,
+            reason_codes=["UNTRUSTED_AGENT"],
+        )
+
+        guard = TealTigerGuard(engine=mock_engine, mode=GovernanceMode.ENFORCE)
+        trusted_agent = _MockAgent("trusted")
+        untrusted_agent = _MockAgent("untrusted")
+        guard.attach(trusted_agent)
+        guard.attach(untrusted_agent)
+
+        msg = _make_tool_call_message("run_code", {"code": "x=1"})
+
+        # Trusted agent allowed
+        result_trusted = _invoke(guard, trusted_agent, [msg])
+        assert result_trusted == (False, None)
+
+        # Untrusted agent denied
+        should_terminate, reply = _invoke(guard, untrusted_agent, [msg])
+        assert should_terminate is True
+        assert "UNTRUSTED_AGENT" in reply

--- a/packages/ag2-tealtiger/tests/test_idempotency.py
+++ b/packages/ag2-tealtiger/tests/test_idempotency.py
@@ -1,0 +1,107 @@
+"""Unit tests for idempotency key and params hash utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from ag2_tealtiger.idempotency import compute_params_hash, derive_idempotency_key
+
+
+class TestComputeParamsHash:
+    """Tests for compute_params_hash function."""
+
+    def test_empty_dict(self) -> None:
+        """Empty dict produces consistent hash."""
+        result = compute_params_hash({})
+        expected = hashlib.sha256(b"{}").hexdigest()
+        assert result == expected
+
+    def test_deterministic_same_input(self) -> None:
+        """Same input always produces same hash."""
+        args = {"tool": "search", "query": "hello world"}
+        assert compute_params_hash(args) == compute_params_hash(args)
+
+    def test_key_order_independent(self) -> None:
+        """Different key orderings produce the same hash."""
+        args_a = {"b": 2, "a": 1}
+        args_b = {"a": 1, "b": 2}
+        assert compute_params_hash(args_a) == compute_params_hash(args_b)
+
+    def test_different_args_different_hash(self) -> None:
+        """Different arguments produce different hashes."""
+        args_a = {"query": "hello"}
+        args_b = {"query": "world"}
+        assert compute_params_hash(args_a) != compute_params_hash(args_b)
+
+    def test_nested_dict_sorted(self) -> None:
+        """Nested dicts have keys sorted at all levels."""
+        args_a = {"outer": {"z": 1, "a": 2}}
+        args_b = {"outer": {"a": 2, "z": 1}}
+        assert compute_params_hash(args_a) == compute_params_hash(args_b)
+
+    def test_compact_separators(self) -> None:
+        """Hash uses compact separators (no whitespace)."""
+        args = {"key": "value"}
+        canonical = json.dumps(args, sort_keys=True, separators=(",", ":"))
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert compute_params_hash(args) == expected
+
+    def test_returns_hex_string(self) -> None:
+        """Result is a valid hex-encoded SHA-256 digest (64 chars)."""
+        result = compute_params_hash({"x": 1})
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_various_value_types(self) -> None:
+        """Works with various JSON-serializable value types."""
+        args = {
+            "string": "hello",
+            "number": 42,
+            "float": 3.14,
+            "bool": True,
+            "null": None,
+            "list": [1, 2, 3],
+        }
+        result = compute_params_hash(args)
+        assert len(result) == 64
+
+
+class TestDeriveIdempotencyKey:
+    """Tests for derive_idempotency_key function."""
+
+    def test_deterministic_same_inputs(self) -> None:
+        """Same decision_id + params_hash always produces same key."""
+        decision_id = "dec-123"
+        params_hash = "abc123"
+        result_1 = derive_idempotency_key(decision_id, params_hash)
+        result_2 = derive_idempotency_key(decision_id, params_hash)
+        assert result_1 == result_2
+
+    def test_different_decision_id_different_key(self) -> None:
+        """Different decision_ids produce different keys."""
+        params_hash = "abc123"
+        key_a = derive_idempotency_key("dec-1", params_hash)
+        key_b = derive_idempotency_key("dec-2", params_hash)
+        assert key_a != key_b
+
+    def test_different_params_hash_different_key(self) -> None:
+        """Different params_hashes produce different keys."""
+        decision_id = "dec-123"
+        key_a = derive_idempotency_key(decision_id, "hash-a")
+        key_b = derive_idempotency_key(decision_id, "hash-b")
+        assert key_a != key_b
+
+    def test_returns_hex_string(self) -> None:
+        """Result is a valid hex-encoded SHA-256 digest (64 chars)."""
+        result = derive_idempotency_key("dec-1", "hash-1")
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_combines_with_colon_separator(self) -> None:
+        """Key is derived from 'decision_id:params_hash' format."""
+        decision_id = "my-decision"
+        params_hash = "my-hash"
+        combined = f"{decision_id}:{params_hash}"
+        expected = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+        assert derive_idempotency_key(decision_id, params_hash) == expected

--- a/packages/ag2-tealtiger/tests/test_integration.py
+++ b/packages/ag2-tealtiger/tests/test_integration.py
@@ -1,0 +1,833 @@
+"""Integration tests for ag2-tealtiger.
+
+Tests exercise multiple components working together — not individual
+unit-level behavior. Each scenario simulates a realistic multi-agent
+conversation with governance applied end-to-end.
+
+Validates Requirements: 1.1, 3.1, 4.1, 9.1, 15.1, 18.1
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger import (
+    GovernanceAction,
+    GovernanceMode,
+    GovernedGroupChat,
+    TealTigerAuditAgent,
+    TealTigerGuard,
+)
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+
+from tests.conftest import (
+    MockConversableAgent,
+    MockTealEngine,
+    make_mock_agent,
+    make_mock_engine,
+    make_tool_call_message,
+    make_text_message,
+)
+
+
+# ─── Scenario 1: Multi-Agent GroupChat with Governance ────────────────────────
+
+
+class TestMultiAgentGroupChatWithGovernance:
+    """Full conversation flow: GroupChat with 3-5 agents and governance.
+
+    Simulates a realistic multi-agent conversation where some agents
+    are allowed and others are denied by policy, verifying that the
+    GovernedGroupChat correctly routes turns and records audit entries.
+
+    Validates: Requirement 1.1, 3.1
+    """
+
+    def test_groupchat_allows_and_denies_agents(self):
+        """GroupChat selects speakers respecting governance decisions."""
+        # Setup: 4 agents with per-agent policy decisions
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        engine.set_decision_for_agent(
+            "coder",
+            GovernanceAction.ALLOW,
+            reason="Coder allowed",
+        )
+        engine.set_decision_for_agent(
+            "reviewer",
+            GovernanceAction.DENY,
+            risk_score=70,
+            reason_codes=["ROLE_RESTRICTED"],
+            reason="Reviewer denied by policy",
+        )
+        engine.set_decision_for_agent(
+            "executor",
+            GovernanceAction.ALLOW,
+            reason="Executor allowed",
+        )
+        engine.set_decision_for_agent(
+            "planner",
+            GovernanceAction.DENY,
+            risk_score=60,
+            reason_codes=["QUOTA_EXCEEDED"],
+            reason="Planner quota exceeded",
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("reviewer"),
+            make_mock_agent("planner"),
+            make_mock_agent("coder"),
+            make_mock_agent("executor"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        # Act: select speaker (should skip reviewer, planner → select coder)
+        speaker = ggc.select_speaker()
+        assert speaker is not None
+        assert speaker.name == "coder"
+
+        # Verify audit
+        audit = ggc.speaker_selection_audit
+        assert len(audit) == 1
+        entry = audit[0]
+        assert entry.selected_speaker == "coder"
+        # reviewer and planner should show up as DENY
+        denied = [c for c in entry.candidates_evaluated if c["decision"] == "DENY"]
+        assert len(denied) == 2
+
+    def test_groupchat_multiple_rounds(self):
+        """GroupChat operates across multiple rounds with governance."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("alice"),
+            make_mock_agent("bob"),
+            make_mock_agent("charlie"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        # Round 1: first speaker selected
+        speaker1 = ggc.select_speaker()
+        assert speaker1 is not None
+
+        # Round 2: different speaker (last speaker excluded)
+        speaker2 = ggc.select_speaker(last_speaker=speaker1)
+        assert speaker2 is not None
+        assert speaker2.name != speaker1.name
+
+        # Verify multiple audit rounds
+        assert len(ggc.speaker_selection_audit) == 2
+
+    def test_groupchat_tool_call_governance_after_speaker_selection(self):
+        """After speaker selection, tool calls on the selected agent are governed."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        coder = make_mock_agent("coder")
+        reviewer = make_mock_agent("reviewer")
+        guard.attach(coder)
+        guard.attach(reviewer)
+
+        ggc = GovernedGroupChat(agents=[coder, reviewer], guard=guard)
+
+        # Select speaker
+        speaker = ggc.select_speaker()
+        assert speaker is not None
+
+        # Now simulate a tool call on the selected speaker
+        messages = [make_tool_call_message("run_code", {"code": "print('hi')"})]
+        result = guard._reply_hook(
+            recipient=speaker,
+            messages=messages,
+            sender=reviewer,
+            config=None,
+        )
+        # Should allow through (returns False, None)
+        assert result == (False, None)
+
+        # Verify audit trail contains both speaker selection and tool call
+        assert len(guard.audit_trail) >= 1
+        tool_entries = [e for e in guard.audit_trail if e.tool_name == "run_code"]
+        assert len(tool_entries) == 1
+        assert tool_entries[0].action == "ALLOW"
+
+
+# ─── Scenario 2: Nested Chat Correlation ─────────────────────────────────────
+
+
+class TestNestedChatCorrelation:
+    """Verify parent-child conversation tracking via TEECContextBuilder.
+
+    Simulates a parent conversation spawning a nested sub-conversation,
+    verifying that correlation IDs are properly maintained across levels.
+
+    Validates: Requirement 9.1
+    """
+
+    def test_nested_chat_preserves_parent_correlation(self):
+        """Nested chat has new conversation_id but links to parent."""
+        guard = TealTigerGuard()
+
+        parent_agent = make_mock_agent("orchestrator")
+        child_agent = make_mock_agent("sub_worker")
+        guard.attach(parent_agent)
+        guard.attach(child_agent)
+
+        # Simulate parent conversation tool call
+        parent_messages = [make_tool_call_message("plan", {"task": "write code"})]
+        guard._reply_hook(
+            recipient=parent_agent,
+            messages=parent_messages,
+            sender=child_agent,
+            config=None,
+        )
+
+        parent_conversation_id = guard._teec_builder.conversation_id
+
+        # Enter nested chat via TEECContextBuilder
+        nested_builder = guard._teec_builder.enter_nested_chat()
+
+        # Verify nested chat gets distinct conversation_id
+        assert nested_builder.conversation_id != parent_conversation_id
+
+        # Verify parent_conversation_id is preserved in the nested builder
+        nested_ctx = nested_builder.build(
+            agent_id="sub_worker",
+            turn_id=1,
+            tool_name="execute",
+            tool_args={"cmd": "ls"},
+        )
+        assert nested_ctx.parent_conversation_id == parent_conversation_id
+        assert nested_ctx.conversation_id == nested_builder.conversation_id
+        assert nested_ctx.conversation_id != parent_conversation_id
+
+    def test_nested_chat_independent_turn_counter(self):
+        """Nested chats have independent turn_id counters."""
+        builder = TEECContextBuilder()
+
+        # Parent turn increments
+        ctx1 = builder.build(agent_id="parent", turn_id=1)
+        ctx2 = builder.build(agent_id="parent", turn_id=2)
+        assert ctx1.turn_id == 1
+        assert ctx2.turn_id == 2
+
+        # Nested builder starts fresh
+        nested = builder.enter_nested_chat()
+        nested_ctx1 = nested.build(agent_id="child", turn_id=1)
+        nested_ctx2 = nested.build(agent_id="child", turn_id=2)
+        assert nested_ctx1.turn_id == 1
+        assert nested_ctx2.turn_id == 2
+
+        # Parent's counter remains at its own value
+        ctx3 = builder.build(agent_id="parent", turn_id=3)
+        assert ctx3.turn_id == 3
+
+    def test_deep_nesting_preserves_ancestor_chain(self):
+        """Arbitrarily deep nesting levels preserve correlation chain."""
+        root = TEECContextBuilder()
+        level1 = root.enter_nested_chat()
+        level2 = level1.enter_nested_chat()
+
+        # Level 1 points to root
+        l1_ctx = level1.build(agent_id="l1_agent", turn_id=1)
+        assert l1_ctx.parent_conversation_id == root.conversation_id
+
+        # Level 2 points to level 1
+        l2_ctx = level2.build(agent_id="l2_agent", turn_id=1)
+        assert l2_ctx.parent_conversation_id == level1.conversation_id
+
+        # All have distinct conversation_ids
+        assert root.conversation_id != level1.conversation_id
+        assert level1.conversation_id != level2.conversation_id
+        assert root.conversation_id != level2.conversation_id
+
+
+# ─── Scenario 3: Governed Speaker Selection End-to-End ───────────────────────
+
+
+class TestGovernedSpeakerSelectionEndToEnd:
+    """Test GovernedGroupChat speaker selection with mixed agent states.
+
+    Simulates a GroupChat with frozen, over-budget, and policy-denied
+    agents, verifying the correct selection logic.
+
+    Validates: Requirement 3.1
+    """
+
+    def test_mixed_frozen_budget_denied_agents(self):
+        """Speaker selection correctly handles frozen, over-budget, and denied agents."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        # Deny 'critic' by policy
+        engine.set_decision_for_agent(
+            "critic",
+            GovernanceAction.DENY,
+            risk_score=90,
+            reason_codes=["RESTRICTED_ROLE"],
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("frozen_agent"),
+            make_mock_agent("over_budget_agent"),
+            make_mock_agent("critic"),
+            make_mock_agent("allowed_agent"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        # Freeze one agent
+        guard.freeze("frozen_agent")
+
+        # Set budget exceeded for another
+        guard.set_budget("over_budget_agent", 1.0)
+        guard._budget_manager.track_cost("over_budget_agent", 1.5)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        # Select speaker — should skip frozen, over-budget, critic → select allowed_agent
+        speaker = ggc.select_speaker()
+        assert speaker is not None
+        assert speaker.name == "allowed_agent"
+
+        # Verify audit shows all skips
+        audit_entry = ggc.speaker_selection_audit[0]
+        candidates = audit_entry.candidates_evaluated
+        assert len(candidates) == 4
+
+        # Check reasons
+        frozen_eval = next(c for c in candidates if c["agent_id"] == "frozen_agent")
+        assert frozen_eval["reason"] == "AGENT_FROZEN"
+
+        budget_eval = next(c for c in candidates if c["agent_id"] == "over_budget_agent")
+        assert budget_eval["reason"] == "BUDGET_EXCEEDED"
+
+        critic_eval = next(c for c in candidates if c["agent_id"] == "critic")
+        assert critic_eval["decision"] == "DENY"
+
+        allowed_eval = next(c for c in candidates if c["agent_id"] == "allowed_agent")
+        assert allowed_eval["decision"] == "ALLOW"
+
+    def test_no_engine_calls_for_frozen_or_budget_agents(self):
+        """Frozen and over-budget agents are skipped without TealEngine invocation."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("frozen_one"),
+            make_mock_agent("budget_one"),
+            make_mock_agent("normal_one"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        guard.freeze("frozen_one")
+        guard.set_budget("budget_one", 0.5)
+        guard._budget_manager.track_cost("budget_one", 0.6)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        initial_calls = engine.call_count
+        speaker = ggc.select_speaker()
+
+        # Only 1 engine call (for normal_one) — frozen and budget skipped
+        assert engine.call_count - initial_calls == 1
+        assert speaker is not None
+        assert speaker.name == "normal_one"
+
+    def test_all_speakers_denied_termination(self):
+        """When all agents are ineligible, round terminates with ALL_SPEAKERS_DENIED."""
+        engine = MockTealEngine(
+            default_action=GovernanceAction.DENY,
+            default_risk_score=80,
+            default_reason_codes=["ALL_BLOCKED"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent("a1"), make_mock_agent("a2"), make_mock_agent("a3")]
+        for a in agents:
+            guard.attach(a)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+        speaker = ggc.select_speaker()
+
+        assert speaker is None
+        audit_entry = ggc.speaker_selection_audit[0]
+        assert "ALL_SPEAKERS_DENIED" in audit_entry.reason_codes
+
+
+# ─── Scenario 4: Freeze Mid-Conversation with GroupChat Continuation ─────────
+
+
+class TestFreezeMidConversation:
+    """Freeze an agent mid-conversation, verify subsequent calls blocked, then unfreeze.
+
+    Validates: Requirement 4.1
+    """
+
+    def test_freeze_blocks_tool_calls_then_unfreeze_restores(self):
+        """Freezing blocks tool calls; unfreezing restores normal operation."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("executor")
+        other = make_mock_agent("user_proxy")
+        guard.attach(agent)
+        guard.attach(other)
+
+        # Tool call succeeds before freeze
+        messages = [make_tool_call_message("run_code", {"code": "x=1"})]
+        result_before = guard._reply_hook(
+            recipient=agent, messages=messages, sender=other, config=None
+        )
+        assert result_before == (False, None)  # Allowed through
+
+        # Freeze the agent
+        guard.freeze("executor")
+        assert guard.is_frozen("executor")
+
+        # Tool call is now blocked
+        messages2 = [make_tool_call_message("run_code", {"code": "x=2"})]
+        result_frozen = guard._reply_hook(
+            recipient=agent, messages=messages2, sender=other, config=None
+        )
+        assert result_frozen[0] is True  # Blocked
+        assert "frozen" in result_frozen[1].lower()
+
+        # Unfreeze the agent
+        guard.unfreeze("executor")
+        assert not guard.is_frozen("executor")
+
+        # Tool call succeeds again
+        messages3 = [make_tool_call_message("run_code", {"code": "x=3"})]
+        result_after = guard._reply_hook(
+            recipient=agent, messages=messages3, sender=other, config=None
+        )
+        assert result_after == (False, None)  # Allowed through
+
+    def test_freeze_agent_in_groupchat_skips_in_selection(self):
+        """Frozen agent is skipped in GovernedGroupChat speaker selection."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("agent_a"),
+            make_mock_agent("agent_b"),
+            make_mock_agent("agent_c"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        # Select first speaker (should be agent_a)
+        speaker1 = ggc.select_speaker()
+        assert speaker1 is not None
+        assert speaker1.name == "agent_a"
+
+        # Mid-conversation: freeze agent_a
+        guard.freeze("agent_a")
+
+        # Next round: agent_a should be skipped
+        speaker2 = ggc.select_speaker(last_speaker=speaker1)
+        assert speaker2 is not None
+        assert speaker2.name != "agent_a"
+
+        # Verify agent_a was recorded as AGENT_FROZEN
+        audit = ggc.speaker_selection_audit[-1]
+        frozen_candidates = [
+            c for c in audit.candidates_evaluated
+            if c["agent_id"] == "agent_a"
+        ]
+        # agent_a may or may not be in candidates (excluded as last_speaker)
+        # If present, it should be frozen
+        if frozen_candidates:
+            assert frozen_candidates[0]["reason"] == "AGENT_FROZEN"
+
+    def test_freeze_does_not_block_other_agents(self):
+        """Freezing one agent does not affect other agents in the group."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent_a = make_mock_agent("agent_a")
+        agent_b = make_mock_agent("agent_b")
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        # Freeze agent_a
+        guard.freeze("agent_a")
+
+        # agent_b should still work fine
+        messages = [make_tool_call_message("analyze", {"data": "test"})]
+        result = guard._reply_hook(
+            recipient=agent_b, messages=messages, sender=agent_a, config=None
+        )
+        # sender is frozen → blocked
+        assert result[0] is True
+
+        # But agent_b as recipient with non-frozen sender works
+        other = make_mock_agent("user_proxy")
+        guard.attach(other)
+        result2 = guard._reply_hook(
+            recipient=agent_b, messages=messages, sender=other, config=None
+        )
+        assert result2 == (False, None)
+
+    def test_freeze_audit_trail_records_events(self):
+        """Freeze and unfreeze events are recorded in the audit trail."""
+        guard = TealTigerGuard()
+        agent = make_mock_agent("target")
+        guard.attach(agent)
+
+        guard.freeze("target")
+        guard.unfreeze("target")
+
+        # Look for freeze/unfreeze audit entries
+        freeze_entries = [
+            e for e in guard.audit_trail
+            if "AGENT_FROZEN" in e.reason_codes or "AGENT_UNFROZEN" in e.reason_codes
+        ]
+        assert len(freeze_entries) >= 2
+
+
+# ─── Scenario 5: Budget Enforcement Across Multiple Tool Calls ───────────────
+
+
+class TestBudgetEnforcementMultipleToolCalls:
+    """Track costs across multiple tool calls until budget exceeded.
+
+    Validates: Requirement 18.1
+    """
+
+    def test_budget_exceeded_after_multiple_calls(self):
+        """Agent is denied after cumulative cost exceeds budget limit."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("expensive_agent")
+        sender = make_mock_agent("coordinator")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Set a tight budget
+        guard.set_budget("expensive_agent", 0.01)
+
+        # Simulate multiple tool calls that accumulate cost
+        for i in range(5):
+            messages = [make_tool_call_message(f"tool_{i}", {"step": i})]
+            guard._reply_hook(
+                recipient=agent, messages=messages, sender=sender, config=None
+            )
+
+        # Manually track cost to simulate real cost accumulation
+        # (since observe mode estimates cost from text length)
+        guard._budget_manager.track_cost("expensive_agent", 0.005)
+        guard._budget_manager.track_cost("expensive_agent", 0.006)
+
+        # Now budget is exceeded (0.011 > 0.01)
+        budget_state = guard.get_budget_state("expensive_agent")
+        assert budget_state.current_spend > budget_state.budget_limit
+
+        # Next tool call should be denied
+        messages = [make_tool_call_message("final_tool", {"data": "important"})]
+        result = guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+        assert result[0] is True  # Blocked
+        assert "BUDGET_EXCEEDED" in result[1]
+
+    def test_budget_exceeded_agent_skipped_in_groupchat(self):
+        """Over-budget agent is skipped in GovernedGroupChat speaker selection."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("expensive"),
+            make_mock_agent("cheap"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        # Set tight budget for expensive agent and exceed it
+        guard.set_budget("expensive", 0.5)
+        guard._budget_manager.track_cost("expensive", 0.6)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+        speaker = ggc.select_speaker()
+
+        assert speaker is not None
+        assert speaker.name == "cheap"
+
+        # Verify audit shows BUDGET_EXCEEDED
+        audit = ggc.speaker_selection_audit[0]
+        expensive_eval = next(
+            c for c in audit.candidates_evaluated if c["agent_id"] == "expensive"
+        )
+        assert expensive_eval["reason"] == "BUDGET_EXCEEDED"
+
+    def test_budget_warning_at_80_percent(self):
+        """Budget warning emitted when crossing 80% threshold."""
+        guard = TealTigerGuard()
+        agent = make_mock_agent("monitored")
+        guard.attach(agent)
+
+        guard.set_budget("monitored", 1.0)
+
+        # Track cost up to 80% threshold
+        guard._budget_manager.track_cost("monitored", 0.81)
+
+        budget_state = guard.get_budget_state("monitored")
+        assert budget_state.current_spend >= 0.8 * budget_state.budget_limit
+        assert budget_state.warning_emitted is True
+
+    def test_budget_reset_allows_resumption(self):
+        """Resetting budget allows the agent to resume operations."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("worker")
+        sender = make_mock_agent("user")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Exceed budget
+        guard.set_budget("worker", 0.5)
+        guard._budget_manager.track_cost("worker", 0.6)
+
+        # Verify denied
+        messages = [make_tool_call_message("work", {"task": "build"})]
+        result = guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+        assert result[0] is True  # Blocked
+
+        # Reset budget
+        guard.reset_budget("worker")
+
+        # Now allowed again
+        messages2 = [make_tool_call_message("work", {"task": "test"})]
+        result2 = guard._reply_hook(
+            recipient=agent, messages=messages2, sender=sender, config=None
+        )
+        assert result2 == (False, None)
+
+
+# ─── Scenario 6: REFER Escalation with Resolution ────────────────────────────
+
+
+class TestReferEscalationWithResolution:
+    """Test REFER decision lifecycle: trigger, resolve, verify audit trail.
+
+    Validates: Requirement 15.1, 18.1
+    """
+
+    def test_refer_triggers_suspension_and_resolution_allows(self):
+        """REFER suspends action, resolve_refer with ALLOW resumes it."""
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=50,
+            default_reason_codes=["REQUIRES_REVIEW"],
+            default_reason="Action requires human review",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("executor")
+        sender = make_mock_agent("manager")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Trigger tool call → should get REFER
+        messages = [make_tool_call_message("deploy", {"env": "production"})]
+        result = guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+        assert result[0] is True  # Suspended
+        assert "pending review" in result[1].lower() or "review" in result[1].lower()
+
+        # Find the decision_id from audit trail
+        refer_entries = [
+            e for e in guard.audit_trail if e.action == "REFER"
+        ]
+        assert len(refer_entries) == 1
+        decision_id = refer_entries[0].decision_id
+
+        # Resolve with ALLOW
+        resolution = guard.resolve_refer(
+            decision_id=decision_id,
+            resolution="ALLOW",
+            approval_id="reviewer-123",
+        )
+        assert resolution["action"] == "ALLOW"
+        assert resolution["approval_id"] == "reviewer-123"
+        assert resolution["already_resolved"] is False
+
+        # Verify audit trail shows complete lifecycle
+        all_entries = guard.audit_trail
+        refer_audit = [e for e in all_entries if e.action == "REFER"]
+        allow_audit = [e for e in all_entries if "REFER_RESOLVED" in e.reason_codes]
+        assert len(refer_audit) == 1
+        assert len(allow_audit) == 1
+
+    def test_refer_resolve_deny_permanently_blocks(self):
+        """REFER resolved with DENY permanently blocks the action."""
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=90,
+            default_reason_codes=["HIGH_RISK"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("risky_agent")
+        sender = make_mock_agent("user")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Trigger REFER
+        messages = [make_tool_call_message("delete_all", {"confirm": True})]
+        guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        # Get decision_id
+        refer_entries = [e for e in guard.audit_trail if e.action == "REFER"]
+        decision_id = refer_entries[0].decision_id
+
+        # Resolve with DENY
+        resolution = guard.resolve_refer(
+            decision_id=decision_id,
+            resolution="DENY",
+            approval_id="reviewer-456",
+        )
+        assert resolution["action"] == "DENY"
+        assert "REFER_DENIED" in resolution["reason_codes"]
+
+        # Verify audit trail shows DENY resolution
+        deny_entries = [
+            e for e in guard.audit_trail if "REFER_DENIED" in e.reason_codes
+        ]
+        assert len(deny_entries) == 1
+
+    def test_refer_in_groupchat_continues_with_other_agents(self):
+        """REFER for one agent doesn't stop the GroupChat — others continue."""
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        # Only the first agent gets REFER
+        engine.set_decision_for_agent(
+            "risky",
+            GovernanceAction.REFER,
+            risk_score=70,
+            reason_codes=["NEEDS_REVIEW"],
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [
+            make_mock_agent("risky"),
+            make_mock_agent("safe_one"),
+            make_mock_agent("safe_two"),
+        ]
+        for a in agents:
+            guard.attach(a)
+
+        ggc = GovernedGroupChat(agents=agents, guard=guard)
+
+        # Select speaker — risky gets REFER, should continue to safe_one
+        speaker = ggc.select_speaker()
+        assert speaker is not None
+        assert speaker.name == "safe_one"
+
+        # Verify audit records the REFER suspension
+        audit = ggc.speaker_selection_audit[0]
+        risky_eval = next(
+            c for c in audit.candidates_evaluated if c["agent_id"] == "risky"
+        )
+        assert risky_eval["decision"] == "REFER"
+        assert "REFER_SUSPENDED" in audit.reason_codes
+
+    def test_refer_retry_idempotency(self):
+        """Resolving the same REFER twice returns the prior outcome."""
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=60,
+            default_reason_codes=["REVIEW_NEEDED"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("agent_x")
+        sender = make_mock_agent("trigger")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Trigger REFER
+        messages = [make_tool_call_message("sensitive_op", {"target": "db"})]
+        guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+
+        refer_entries = [e for e in guard.audit_trail if e.action == "REFER"]
+        decision_id = refer_entries[0].decision_id
+
+        # Resolve once
+        result1 = guard.resolve_refer(decision_id, "ALLOW", "approver-1")
+        assert result1["already_resolved"] is False
+
+        # Resolve again — idempotent
+        result2 = guard.resolve_refer(decision_id, "ALLOW", "approver-1")
+        assert result2["already_resolved"] is True
+        assert result2["action"] == "ALLOW"
+
+    def test_refer_full_audit_lifecycle(self):
+        """Full REFER lifecycle: trigger → suspend → resolve → audit trail complete."""
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=55,
+            default_reason_codes=["ESCALATE"],
+            default_reason="Escalation required",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent = make_mock_agent("worker")
+        sender = make_mock_agent("orchestrator")
+        guard.attach(agent)
+        guard.attach(sender)
+
+        # Step 1: Trigger REFER via tool call
+        messages = [make_tool_call_message("external_api", {"url": "https://api.example.com"})]
+        result = guard._reply_hook(
+            recipient=agent, messages=messages, sender=sender, config=None
+        )
+        assert result[0] is True  # Suspended
+
+        # Step 2: Verify REFER audit entry has all required fields
+        refer_entries = [e for e in guard.audit_trail if e.action == "REFER"]
+        assert len(refer_entries) == 1
+        refer_entry = refer_entries[0]
+        assert refer_entry.agent_id == "worker"
+        assert refer_entry.tool_name == "external_api"
+        assert refer_entry.teec.conversation_id != ""
+        assert refer_entry.teec.decision_id != ""
+        assert refer_entry.evaluation_time_ms > 0
+
+        decision_id = refer_entry.decision_id
+
+        # Step 3: Resolve REFER
+        guard.resolve_refer(decision_id, "ALLOW", "human-reviewer-abc")
+
+        # Step 4: Verify complete audit lifecycle
+        all_entries = guard.audit_trail
+        # Should have: freeze/unfreeze entries (if any) + REFER + resolution
+        refer_related = [
+            e for e in all_entries
+            if e.decision_id == decision_id or "REFER_RESOLVED" in e.reason_codes
+        ]
+        # At minimum: the REFER entry and the resolution entry
+        assert len(refer_related) >= 2

--- a/packages/ag2-tealtiger/tests/test_package_exports.py
+++ b/packages/ag2-tealtiger/tests/test_package_exports.py
@@ -1,0 +1,131 @@
+"""Tests for top-level __init__.py exports.
+
+Verifies that all public API symbols are importable from ag2_tealtiger
+as specified in Requirement 14.3.
+"""
+
+import ag2_tealtiger
+
+
+class TestTopLevelImports:
+    """Verify all exports are accessible as top-level imports."""
+
+    def test_core_components_importable(self) -> None:
+        """TealTigerGuard, TealTigerAuditAgent, GovernedGroupChat are top-level."""
+        from ag2_tealtiger import TealTigerGuard
+        from ag2_tealtiger import TealTigerAuditAgent
+        from ag2_tealtiger import GovernedGroupChat
+
+        assert TealTigerGuard is not None
+        assert TealTigerAuditAgent is not None
+        assert GovernedGroupChat is not None
+
+    def test_managers_importable(self) -> None:
+        """DecisionReceiptManager and BudgetStateManager for advanced usage."""
+        from ag2_tealtiger import DecisionReceiptManager
+        from ag2_tealtiger import BudgetStateManager
+        from ag2_tealtiger import BudgetCheckResult
+
+        assert DecisionReceiptManager is not None
+        assert BudgetStateManager is not None
+        assert BudgetCheckResult is not None
+
+    def test_enums_importable(self) -> None:
+        """All enums are top-level exports."""
+        from ag2_tealtiger import GovernanceAction, GovernanceMode, ActionKind, DecisionSource
+
+        assert GovernanceAction.ALLOW == "ALLOW"
+        assert GovernanceMode.ENFORCE == "ENFORCE"
+        assert ActionKind.TOOL_CALL == "tool_call"
+        assert DecisionSource.POLICY_ENGINE == "policy_engine"
+
+    def test_data_types_importable(self) -> None:
+        """All dataclasses are top-level exports."""
+        from ag2_tealtiger import (
+            TEECContext,
+            AuditEntry,
+            DecisionReceipt,
+            RevalidationCondition,
+            EscalationReceipt,
+            BudgetState,
+            SpeakerSelectionAuditEntry,
+            DenialMessage,
+        )
+
+        assert TEECContext is not None
+        assert AuditEntry is not None
+        assert DecisionReceipt is not None
+        assert RevalidationCondition is not None
+        assert EscalationReceipt is not None
+        assert BudgetState is not None
+        assert SpeakerSelectionAuditEntry is not None
+        assert DenialMessage is not None
+
+    def test_exceptions_importable(self) -> None:
+        """All exceptions are top-level exports."""
+        from ag2_tealtiger import (
+            AG2TealTigerError,
+            GovernanceDenyError,
+            DecisionExpiredError,
+            BudgetExceededError,
+            AgentFrozenError,
+            EscalationPendingError,
+        )
+
+        assert issubclass(GovernanceDenyError, AG2TealTigerError)
+        assert issubclass(BudgetExceededError, GovernanceDenyError)
+        assert issubclass(AgentFrozenError, GovernanceDenyError)
+        assert issubclass(DecisionExpiredError, AG2TealTigerError)
+        assert issubclass(EscalationPendingError, AG2TealTigerError)
+
+    def test_utilities_importable(self) -> None:
+        """Utility functions are top-level exports."""
+        from ag2_tealtiger import compute_params_hash, derive_idempotency_key
+
+        # Quick smoke test
+        h = compute_params_hash({"key": "value"})
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex digest
+
+        k = derive_idempotency_key("decision-1", h)
+        assert isinstance(k, str)
+        assert len(k) == 64
+
+    def test_all_list_matches_exports(self) -> None:
+        """__all__ contains exactly the expected public API symbols."""
+        expected = {
+            "TealTigerGuard",
+            "TealTigerAuditAgent",
+            "GovernedGroupChat",
+            "DecisionReceiptManager",
+            "BudgetStateManager",
+            "BudgetCheckResult",
+            "GovernanceAction",
+            "GovernanceMode",
+            "ActionKind",
+            "DecisionSource",
+            "TEECContext",
+            "AuditEntry",
+            "DecisionReceipt",
+            "RevalidationCondition",
+            "EscalationReceipt",
+            "BudgetState",
+            "SpeakerSelectionAuditEntry",
+            "DenialMessage",
+            "AG2TealTigerError",
+            "GovernanceDenyError",
+            "DecisionExpiredError",
+            "BudgetExceededError",
+            "AgentFrozenError",
+            "EscalationPendingError",
+            "compute_params_hash",
+            "derive_idempotency_key",
+        }
+        assert set(ag2_tealtiger.__all__) == expected
+
+    def test_guard_instantiation_no_engine(self) -> None:
+        """TealTigerGuard can be instantiated in observe mode without args."""
+        from ag2_tealtiger import TealTigerGuard
+
+        guard = TealTigerGuard()
+        assert guard is not None

--- a/packages/ag2-tealtiger/tests/test_pii.py
+++ b/packages/ag2-tealtiger/tests/test_pii.py
@@ -1,0 +1,311 @@
+"""Unit tests for PII detection module.
+
+Tests regex-based PII pattern matching for email, phone_number,
+ssn, credit_card, and ip_address types across plain strings,
+dicts, and nested data structures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ag2_tealtiger.pii import detect_pii, detect_pii_in_text
+
+
+class TestEmailDetection:
+    """Tests for email address PII detection."""
+
+    def test_simple_email(self) -> None:
+        results = detect_pii("Contact me at user@example.com please")
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+        assert results[0]["value"] == "user@example.com"
+        assert results[0]["confidence"] == 0.95
+
+    def test_email_with_subdomain(self) -> None:
+        results = detect_pii("Send to admin@mail.company.co.uk")
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+        assert results[0]["value"] == "admin@mail.company.co.uk"
+
+    def test_email_with_plus_addressing(self) -> None:
+        results = detect_pii("Use user+tag@gmail.com for filtering")
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+        assert results[0]["value"] == "user+tag@gmail.com"
+
+    def test_multiple_emails(self) -> None:
+        text = "From alice@test.com to bob@example.org"
+        results = detect_pii(text)
+        emails = [r for r in results if r["type"] == "email"]
+        assert len(emails) == 2
+
+    def test_no_email(self) -> None:
+        results = detect_pii("No email here, just text")
+        emails = [r for r in results if r["type"] == "email"]
+        assert len(emails) == 0
+
+
+class TestPhoneNumberDetection:
+    """Tests for phone number PII detection."""
+
+    def test_us_phone_dashes(self) -> None:
+        results = detect_pii("Call me at 555-123-4567")
+        phones = [r for r in results if r["type"] == "phone_number"]
+        assert len(phones) == 1
+        assert phones[0]["value"] == "555-123-4567"
+        assert phones[0]["confidence"] == 0.80
+
+    def test_us_phone_dots(self) -> None:
+        results = detect_pii("Phone: 555.123.4567")
+        phones = [r for r in results if r["type"] == "phone_number"]
+        assert len(phones) == 1
+        assert phones[0]["value"] == "555.123.4567"
+
+    def test_us_phone_parentheses(self) -> None:
+        results = detect_pii("Phone: (555) 123-4567")
+        phones = [r for r in results if r["type"] == "phone_number"]
+        assert len(phones) == 1
+        assert "(555)" in phones[0]["value"]
+
+    def test_us_phone_with_country_code(self) -> None:
+        results = detect_pii("International: +1-555-123-4567")
+        phones = [r for r in results if r["type"] == "phone_number"]
+        assert len(phones) == 1
+        assert "+1-" in phones[0]["value"]
+
+    def test_no_phone(self) -> None:
+        results = detect_pii("Just a regular sentence")
+        phones = [r for r in results if r["type"] == "phone_number"]
+        assert len(phones) == 0
+
+
+class TestSSNDetection:
+    """Tests for Social Security Number PII detection."""
+
+    def test_standard_ssn(self) -> None:
+        results = detect_pii("SSN: 123-45-6789")
+        ssns = [r for r in results if r["type"] == "ssn"]
+        assert len(ssns) == 1
+        assert ssns[0]["value"] == "123-45-6789"
+        assert ssns[0]["confidence"] == 0.99
+
+    def test_ssn_in_text(self) -> None:
+        results = detect_pii("My social is 987-65-4321, don't share it")
+        ssns = [r for r in results if r["type"] == "ssn"]
+        assert len(ssns) == 1
+        assert ssns[0]["value"] == "987-65-4321"
+
+    def test_no_ssn(self) -> None:
+        results = detect_pii("Phone: 555-1234 and zip: 90210")
+        ssns = [r for r in results if r["type"] == "ssn"]
+        assert len(ssns) == 0
+
+
+class TestCreditCardDetection:
+    """Tests for credit card number PII detection."""
+
+    def test_credit_card_spaces(self) -> None:
+        results = detect_pii("Card: 4111 1111 1111 1111")
+        cards = [r for r in results if r["type"] == "credit_card"]
+        assert len(cards) == 1
+        assert cards[0]["value"] == "4111 1111 1111 1111"
+        assert cards[0]["confidence"] == 0.90
+
+    def test_credit_card_dashes(self) -> None:
+        results = detect_pii("Payment: 5500-0000-0000-0004")
+        cards = [r for r in results if r["type"] == "credit_card"]
+        assert len(cards) == 1
+        assert cards[0]["value"] == "5500-0000-0000-0004"
+
+    def test_credit_card_no_separator(self) -> None:
+        results = detect_pii("CC: 4111111111111111")
+        cards = [r for r in results if r["type"] == "credit_card"]
+        assert len(cards) == 1
+        assert cards[0]["value"] == "4111111111111111"
+
+    def test_no_credit_card(self) -> None:
+        results = detect_pii("Order number 12345")
+        cards = [r for r in results if r["type"] == "credit_card"]
+        assert len(cards) == 0
+
+
+class TestIPAddressDetection:
+    """Tests for IP address PII detection."""
+
+    def test_standard_ip(self) -> None:
+        results = detect_pii("Server at 192.168.1.100")
+        ips = [r for r in results if r["type"] == "ip_address"]
+        assert len(ips) == 1
+        assert ips[0]["value"] == "192.168.1.100"
+        assert ips[0]["confidence"] == 0.70
+
+    def test_localhost_ip(self) -> None:
+        results = detect_pii("Connect to 127.0.0.1")
+        ips = [r for r in results if r["type"] == "ip_address"]
+        assert len(ips) == 1
+        assert ips[0]["value"] == "127.0.0.1"
+
+    def test_boundary_ip(self) -> None:
+        results = detect_pii("Range: 255.255.255.255")
+        ips = [r for r in results if r["type"] == "ip_address"]
+        assert len(ips) == 1
+        assert ips[0]["value"] == "255.255.255.255"
+
+    def test_invalid_ip_not_detected(self) -> None:
+        results = detect_pii("Not an IP: 999.999.999.999")
+        ips = [r for r in results if r["type"] == "ip_address"]
+        assert len(ips) == 0
+
+    def test_no_ip(self) -> None:
+        results = detect_pii("Version 3.10.2 is out")
+        ips = [r for r in results if r["type"] == "ip_address"]
+        assert len(ips) == 0
+
+
+class TestRecursiveScanning:
+    """Tests for recursive dict/list scanning."""
+
+    def test_flat_dict(self) -> None:
+        data = {"email": "user@example.com", "name": "Alice"}
+        results = detect_pii(data)
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+        assert results[0]["location"] == "email"
+
+    def test_nested_dict(self) -> None:
+        data = {
+            "user": {
+                "contact": {
+                    "email": "admin@corp.io",
+                }
+            }
+        }
+        results = detect_pii(data)
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+        assert results[0]["location"] == "user.contact.email"
+
+    def test_list_values(self) -> None:
+        data = ["user@a.com", "nothing here", "other@b.org"]
+        results = detect_pii(data)
+        emails = [r for r in results if r["type"] == "email"]
+        assert len(emails) == 2
+        assert emails[0]["location"] == "[0]"
+        assert emails[1]["location"] == "[2]"
+
+    def test_dict_with_list(self) -> None:
+        data = {
+            "recipients": ["alice@test.com", "bob@test.com"],
+            "body": "No PII here",
+        }
+        results = detect_pii(data)
+        emails = [r for r in results if r["type"] == "email"]
+        assert len(emails) == 2
+        assert emails[0]["location"] == "recipients[0]"
+        assert emails[1]["location"] == "recipients[1]"
+
+    def test_mixed_types_in_dict(self) -> None:
+        data = {
+            "count": 42,
+            "active": True,
+            "email": "test@example.com",
+            "nothing": None,
+        }
+        results = detect_pii(data)
+        assert len(results) == 1
+        assert results[0]["type"] == "email"
+
+    def test_deeply_nested(self) -> None:
+        data = {
+            "level1": {
+                "level2": [
+                    {"ssn": "123-45-6789"},
+                ]
+            }
+        }
+        results = detect_pii(data)
+        assert len(results) == 1
+        assert results[0]["type"] == "ssn"
+        assert results[0]["location"] == "level1.level2[0].ssn"
+
+    def test_empty_structures(self) -> None:
+        assert detect_pii({}) == []
+        assert detect_pii([]) == []
+        assert detect_pii("") == []
+
+
+class TestMultiplePIITypes:
+    """Tests for detecting multiple PII types in the same input."""
+
+    def test_multiple_types_in_string(self) -> None:
+        text = "Email: user@test.com, SSN: 123-45-6789, IP: 10.0.0.1"
+        results = detect_pii(text)
+        types_found = {r["type"] for r in results}
+        assert "email" in types_found
+        assert "ssn" in types_found
+        assert "ip_address" in types_found
+
+    def test_multiple_types_in_dict(self) -> None:
+        data = {
+            "email": "admin@corp.com",
+            "phone": "555-123-4567",
+            "ssn": "111-22-3333",
+            "card": "4111 1111 1111 1111",
+            "server": "192.168.0.1",
+        }
+        results = detect_pii(data)
+        types_found = {r["type"] for r in results}
+        assert types_found == {"email", "phone_number", "ssn", "credit_card", "ip_address"}
+
+
+class TestDetectPIIInText:
+    """Tests for the detect_pii_in_text helper function."""
+
+    def test_with_location(self) -> None:
+        results = detect_pii_in_text("user@test.com", location="args.email")
+        assert len(results) == 1
+        assert results[0]["location"] == "args.email"
+
+    def test_without_location(self) -> None:
+        results = detect_pii_in_text("user@test.com")
+        assert len(results) == 1
+        assert results[0]["location"] == ""
+
+    def test_no_match(self) -> None:
+        results = detect_pii_in_text("just plain text")
+        assert results == []
+
+
+class TestResultStructure:
+    """Tests for the structure of detection result dicts."""
+
+    def test_result_has_required_fields(self) -> None:
+        results = detect_pii("user@example.com")
+        assert len(results) == 1
+        result = results[0]
+        assert "type" in result
+        assert "value" in result
+        assert "location" in result
+        assert "confidence" in result
+        assert "start" in result
+        assert "end" in result
+
+    def test_start_end_positions(self) -> None:
+        text = "Hello user@test.com world"
+        results = detect_pii(text)
+        assert len(results) == 1
+        result = results[0]
+        assert text[result["start"]:result["end"]] == "user@test.com"
+
+    def test_confidence_range(self) -> None:
+        data = {
+            "email": "a@b.com",
+            "phone": "555-123-4567",
+            "ssn": "123-45-6789",
+            "card": "4111111111111111",
+            "ip": "10.0.0.1",
+        }
+        results = detect_pii(data)
+        for result in results:
+            assert 0.0 < result["confidence"] <= 1.0

--- a/packages/ag2-tealtiger/tests/test_property_12_fail_closed.py
+++ b/packages/ag2-tealtiger/tests/test_property_12_fail_closed.py
@@ -1,0 +1,247 @@
+"""Property test: Fail-Closed in ENFORCE Mode (Property 12).
+
+**Property 12:** For any TealEngine exception during policy evaluation in ENFORCE
+mode, the governance decision SHALL be DENY with reason_codes containing both
+"ENGINE_ERROR" and "FAIL_CLOSED".
+
+**Validates: Requirements 7.3**
+
+Uses Hypothesis to generate arbitrary tool calls with an ErrorEngine that always
+raises, verifying that ENFORCE mode with fail_closed=True always produces a DENY
+decision with the correct reason codes and risk_score=100.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import make_mock_agent, make_tool_call_message
+from .strategies import agent_ids, tool_names, tool_args
+
+
+# ── ErrorEngine that always raises ────────────────────────────────────────────
+
+# Strategy for exception types to vary the error thrown
+exception_types = st.sampled_from([
+    RuntimeError,
+    ValueError,
+    TypeError,
+    OSError,
+    KeyError,
+    IOError,
+    ConnectionError,
+    TimeoutError,
+])
+
+# Strategy for error messages
+error_messages = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz _-.",
+    min_size=1,
+    max_size=80,
+)
+
+
+class ErrorEngine:
+    """Engine that always raises the configured exception on evaluate()."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+        self.call_count = 0
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.call_count += 1
+        raise self.error
+
+
+# ── Property 12: Fail-Closed in ENFORCE Mode ─────────────────────────────────
+
+
+@pytest.mark.property
+class TestFailClosedEnforceMode:
+    """Property 12: TealEngine exception in ENFORCE produces DENY with ENGINE_ERROR + FAIL_CLOSED."""
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+        exc_type=exception_types,
+        exc_msg=error_messages,
+    )
+    def test_engine_exception_produces_deny_with_fail_closed(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        exc_type: type,
+        exc_msg: str,
+    ) -> None:
+        """For any tool call where TealEngine raises, ENFORCE mode denies with ENGINE_ERROR + FAIL_CLOSED.
+
+        **Validates: Requirements 7.3**
+        """
+        # Setup: ErrorEngine that always raises the given exception
+        error = exc_type(exc_msg)
+        engine = ErrorEngine(error)
+
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+
+        # Create and attach agent
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Simulate a tool call
+        sender = make_mock_agent("user_proxy")
+        messages = [make_tool_call_message(tool_name, tool_arguments)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify: result is (True, denial_string) — blocked
+        assert result[0] is True, (
+            f"Fail-closed in ENFORCE mode must block (True), got {result[0]}"
+        )
+        assert isinstance(result[1], str), (
+            f"Denial result must be a string, got {type(result[1])}"
+        )
+
+        # Verify: audit entry has ENGINE_ERROR + FAIL_CLOSED + risk_score 100
+        assert len(guard.audit_trail) >= 1, "Must record at least one audit entry"
+
+        entry = guard.audit_trail[-1]
+        assert entry.action == GovernanceAction.DENY.value, (
+            f"Fail-closed must produce DENY, got {entry.action}"
+        )
+        assert "ENGINE_ERROR" in entry.reason_codes, (
+            f"Must contain ENGINE_ERROR in reason_codes, got {entry.reason_codes}"
+        )
+        assert "FAIL_CLOSED" in entry.reason_codes, (
+            f"Must contain FAIL_CLOSED in reason_codes, got {entry.reason_codes}"
+        )
+        assert entry.risk_score == 100, (
+            f"Fail-closed must have risk_score=100, got {entry.risk_score}"
+        )
+        assert entry.agent_id == agent_id, (
+            f"Audit entry must record correct agent_id, got {entry.agent_id}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+        exc_type=exception_types,
+        exc_msg=error_messages,
+    )
+    def test_engine_exception_denial_message_visible(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        exc_type: type,
+        exc_msg: str,
+    ) -> None:
+        """For any engine exception, the denial string contains GOVERNANCE DENIAL marker.
+
+        **Validates: Requirements 7.3**
+        """
+        error = exc_type(exc_msg)
+        engine = ErrorEngine(error)
+
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+        messages = [make_tool_call_message(tool_name, tool_arguments)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Denial message must be visible and identifiable
+        denial_str = result[1]
+        assert "GOVERNANCE DENIAL" in denial_str, (
+            f"Denial message must contain 'GOVERNANCE DENIAL', got: {denial_str}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+        exc_type=exception_types,
+        exc_msg=error_messages,
+    )
+    def test_engine_exception_audit_entry_has_valid_teec(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        exc_type: type,
+        exc_msg: str,
+    ) -> None:
+        """For any engine exception, the audit entry has valid TEEC context fields.
+
+        **Validates: Requirements 7.3**
+        """
+        error = exc_type(exc_msg)
+        engine = ErrorEngine(error)
+
+        guard = TealTigerGuard(
+            engine=engine,
+            mode=GovernanceMode.ENFORCE,
+            fail_closed=True,
+        )
+
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+        messages = [make_tool_call_message(tool_name, tool_arguments)]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[-1]
+
+        # TEEC context must be populated even on engine error
+        assert entry.teec.conversation_id is not None
+        assert len(entry.teec.conversation_id) > 0
+        assert entry.teec.decision_id is not None
+        assert len(entry.teec.decision_id) > 0
+        assert entry.teec.turn_id > 0
+        assert entry.evaluation_time_ms > 0
+        assert entry.mode == GovernanceMode.ENFORCE.value

--- a/packages/ag2-tealtiger/tests/test_property_13_fail_open.py
+++ b/packages/ag2-tealtiger/tests/test_property_13_fail_open.py
@@ -1,0 +1,273 @@
+"""Property-based test: Fail-Open in MONITOR/OBSERVE Mode (Property 13).
+
+# Feature: ag2-tealtiger-adapter, Property 13: Fail-Open in MONITOR/OBSERVE Mode
+
+*For any* TealEngine exception during policy evaluation in MONITOR or OBSERVE mode,
+the governance decision SHALL be ALLOW with reason_codes containing both
+"ENGINE_ERROR" and "FAIL_OPEN".
+
+**Validates: Requirements 7.4**
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import MockConversableAgent, make_tool_call_message
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── ErrorEngine: always raises on evaluate ────────────────────────────────────
+
+
+class ErrorEngine:
+    """A TealEngine mock that always raises an exception on evaluate().
+
+    Used to verify fail-open behavior in MONITOR/OBSERVE modes.
+    """
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error or RuntimeError("Engine evaluation failed")
+        self.evaluate_calls: list[dict[str, Any]] = []
+
+    def evaluate(
+        self,
+        tool_name: str | None = None,
+        args: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Always raises the configured exception."""
+        self.evaluate_calls.append(
+            {"tool_name": tool_name, "args": args, "context": context}
+        )
+        raise self.error
+
+
+# ── Strategy for MONITOR/OBSERVE modes ────────────────────────────────────────
+
+fail_open_modes: st.SearchStrategy[GovernanceMode] = st.sampled_from(
+    [GovernanceMode.MONITOR, GovernanceMode.OBSERVE]
+)
+
+# Strategy for various exception types that the engine might throw
+exception_types: st.SearchStrategy[Exception] = st.sampled_from(
+    [
+        RuntimeError("Engine evaluation failed"),
+        ValueError("Invalid policy configuration"),
+        TypeError("Unexpected argument type"),
+        OSError("Disk full"),
+        KeyError("missing_key"),
+        ConnectionError("Network unreachable"),
+        TimeoutError("Evaluation timed out"),
+    ]
+)
+
+
+@pytest.mark.property
+class TestFailOpenMonitorObserveMode:
+    """Property 13: Fail-Open in MONITOR/OBSERVE Mode.
+
+    For any TealEngine exception during policy evaluation in MONITOR or OBSERVE
+    mode, the governance decision SHALL be ALLOW with reason_codes containing
+    both "ENGINE_ERROR" and "FAIL_OPEN".
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        mode=fail_open_modes,
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_engine_exception_produces_allow_with_fail_open(
+        self,
+        mode: GovernanceMode,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 7.4
+
+        For any tool call in MONITOR or OBSERVE mode, when TealEngine raises
+        an exception, the result SHALL be (False, None) — meaning the tool call
+        is allowed to proceed — and the audit entry SHALL have action=ALLOW with
+        reason_codes containing "ENGINE_ERROR" and "FAIL_OPEN".
+        """
+        engine = ErrorEngine()
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = MockConversableAgent(name=agent_name)
+        sender = MockConversableAgent(name="sender")
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Fail-open: the tool call MUST be allowed through
+        assert should_terminate is False, (
+            f"Mode={mode.value}: Engine error should fail-open (allow), "
+            f"but got should_terminate=True"
+        )
+        assert reply is None, (
+            f"Mode={mode.value}: Fail-open should return None reply, got: {reply}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        mode=fail_open_modes,
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_audit_entry_has_engine_error_and_fail_open_reason_codes(
+        self,
+        mode: GovernanceMode,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 7.4
+
+        The audit entry produced on engine error in MONITOR/OBSERVE mode SHALL
+        contain both "ENGINE_ERROR" and "FAIL_OPEN" in reason_codes.
+        """
+        engine = ErrorEngine()
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = MockConversableAgent(name=agent_name)
+        sender = MockConversableAgent(name="sender")
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Must have at least one audit entry
+        assert len(guard.audit_trail) >= 1, (
+            "Expected at least 1 audit entry after engine error"
+        )
+
+        entry = guard.audit_trail[-1]
+
+        # Action must be ALLOW
+        assert entry.action == GovernanceAction.ALLOW.value, (
+            f"Mode={mode.value}: Expected action=ALLOW on engine error, "
+            f"got action={entry.action}"
+        )
+
+        # Reason codes must contain ENGINE_ERROR and FAIL_OPEN
+        assert "ENGINE_ERROR" in entry.reason_codes, (
+            f"Mode={mode.value}: 'ENGINE_ERROR' not found in reason_codes: "
+            f"{entry.reason_codes}"
+        )
+        assert "FAIL_OPEN" in entry.reason_codes, (
+            f"Mode={mode.value}: 'FAIL_OPEN' not found in reason_codes: "
+            f"{entry.reason_codes}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        mode=fail_open_modes,
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_audit_entry_risk_score_zero_on_fail_open(
+        self,
+        mode: GovernanceMode,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 7.4
+
+        The audit entry produced on engine error in MONITOR/OBSERVE mode SHALL
+        have risk_score=0, since the system is allowing through without blocking.
+        """
+        engine = ErrorEngine()
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = MockConversableAgent(name=agent_name)
+        sender = MockConversableAgent(name="sender")
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[-1]
+        assert entry.risk_score == 0, (
+            f"Mode={mode.value}: Expected risk_score=0 on fail-open, "
+            f"got risk_score={entry.risk_score}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        mode=fail_open_modes,
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        error=exception_types,
+    )
+    def test_fail_open_for_various_exception_types(
+        self,
+        mode: GovernanceMode,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+        error: Exception,
+    ) -> None:
+        """Validates: Requirements 7.4
+
+        For any type of exception raised by TealEngine (RuntimeError, ValueError,
+        TypeError, OSError, etc.), the fail-open behavior SHALL be consistent:
+        result is (False, None) and audit entry has ENGINE_ERROR + FAIL_OPEN.
+        """
+        engine = ErrorEngine(error=error)
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = MockConversableAgent(name=agent_name)
+        sender = MockConversableAgent(name="sender")
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        should_terminate, reply = guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Must fail-open: allow through
+        assert should_terminate is False, (
+            f"Mode={mode.value}, Error={type(error).__name__}: "
+            f"Should fail-open but got should_terminate=True"
+        )
+        assert reply is None
+
+        # Audit entry must have correct reason codes
+        entry = guard.audit_trail[-1]
+        assert entry.action == GovernanceAction.ALLOW.value
+        assert "ENGINE_ERROR" in entry.reason_codes
+        assert "FAIL_OPEN" in entry.reason_codes
+        assert entry.risk_score == 0

--- a/packages/ag2-tealtiger/tests/test_property_14_denial_parseability.py
+++ b/packages/ag2-tealtiger/tests/test_property_14_denial_parseability.py
@@ -1,0 +1,196 @@
+"""Property test: Denial Message Parseability (Property 14).
+
+**Property 14:** For any denied tool call in ENFORCE mode, the returned denial
+message SHALL contain the tool_name, reason, risk_score, reason_codes, and
+decision_id in a structured format that can be parsed to extract each field
+independently.
+
+**Validates: Requirements 7.6, 10.1, 10.2, 10.3**
+
+Uses Hypothesis to generate arbitrary DenialMessage instances and verify that
+the formatted string contains all fields in the expected parseable pattern:
+[GOVERNANCE DENIAL] Tool: {tool_name} | Action: {action} | Risk: {risk_score} | Reason: {reason} | Codes: {codes} | Decision: {decision_id}
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from hypothesis import given, settings
+
+from ag2_tealtiger.types import DenialMessage
+
+from .strategies import denial_messages
+
+
+# ── Parsing helpers ───────────────────────────────────────────────────────────
+
+# Regex pattern matching the expected denial message format
+DENIAL_PATTERN = re.compile(
+    r"\[GOVERNANCE DENIAL\] "
+    r"Tool: (?P<tool_name>.+?) \| "
+    r"Action: (?P<action>.+?) \| "
+    r"Risk: (?P<risk_score>\d+) \| "
+    r"Reason: (?P<reason>.+?) \| "
+    r"Codes: (?P<codes>.+?) \| "
+    r"Decision: (?P<decision_id>.+)"
+)
+
+
+def parse_denial_message(formatted: str) -> dict[str, str] | None:
+    """Parse a formatted denial message string back into its component fields.
+
+    Returns a dict with keys: tool_name, action, risk_score, reason, codes, decision_id.
+    Returns None if the string does not match the expected pattern.
+    """
+    match = DENIAL_PATTERN.match(formatted)
+    if match is None:
+        return None
+    return match.groupdict()
+
+
+# ── Property 14: Denial Message Parseability ──────────────────────────────────
+
+
+@pytest.mark.property
+class TestDenialMessageParseability:
+    """Property 14: Denied tool calls produce structured messages with parseable fields."""
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_matches_structured_pattern(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, to_reply_string() produces output matching the governance denial pattern.
+
+        **Validates: Requirements 7.6, 10.1, 10.2, 10.3**
+        """
+        formatted = denial.to_reply_string()
+
+        # The formatted string must match the structured pattern
+        parsed = parse_denial_message(formatted)
+        assert parsed is not None, (
+            f"Denial message does not match expected pattern.\n"
+            f"Got: {formatted!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_contains_tool_name(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, the formatted string contains the original tool_name extractable by parsing.
+
+        **Validates: Requirements 10.1**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None
+        assert parsed["tool_name"] == denial.tool_name, (
+            f"Parsed tool_name {parsed['tool_name']!r} != original {denial.tool_name!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_contains_risk_score(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, the formatted string contains the original risk_score as an integer.
+
+        **Validates: Requirements 10.1**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None
+        assert int(parsed["risk_score"]) == denial.risk_score, (
+            f"Parsed risk_score {parsed['risk_score']} != original {denial.risk_score}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_contains_reason(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, the formatted string contains the original reason.
+
+        **Validates: Requirements 10.1**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None
+        assert parsed["reason"] == denial.reason, (
+            f"Parsed reason {parsed['reason']!r} != original {denial.reason!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_contains_reason_codes(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, the formatted string contains comma-joined reason_codes that can be split back.
+
+        **Validates: Requirements 10.1, 10.2**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None
+        parsed_codes = parsed["codes"].split(",")
+        assert parsed_codes == denial.reason_codes, (
+            f"Parsed reason_codes {parsed_codes} != original {denial.reason_codes}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_contains_decision_id(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, the formatted string contains the decision_id for audit trail lookup.
+
+        **Validates: Requirements 10.3**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None
+        assert parsed["decision_id"] == denial.decision_id, (
+            f"Parsed decision_id {parsed['decision_id']!r} != original {denial.decision_id!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(denial=denial_messages())
+    def test_denial_message_all_fields_round_trip(
+        self,
+        denial: DenialMessage,
+    ) -> None:
+        """For any DenialMessage, all fields survive a format-then-parse round trip.
+
+        This is the comprehensive property: generating a denial message, formatting it,
+        then parsing it back yields the exact original values for all fields.
+
+        **Validates: Requirements 7.6, 10.1, 10.2, 10.3**
+        """
+        formatted = denial.to_reply_string()
+        parsed = parse_denial_message(formatted)
+
+        assert parsed is not None, (
+            f"Denial message not parseable: {formatted!r}"
+        )
+
+        # Verify all fields round-trip correctly
+        assert parsed["tool_name"] == denial.tool_name
+        assert parsed["action"] == denial.action
+        assert int(parsed["risk_score"]) == denial.risk_score
+        assert parsed["reason"] == denial.reason
+        assert parsed["codes"].split(",") == denial.reason_codes
+        assert parsed["decision_id"] == denial.decision_id

--- a/packages/ag2-tealtiger/tests/test_property_17_budget_enforcement.py
+++ b/packages/ag2-tealtiger/tests/test_property_17_budget_enforcement.py
@@ -1,0 +1,175 @@
+"""Property-based test: Budget Enforcement Threshold (Property 17).
+
+# Feature: ag2-tealtiger-adapter, Property 17: Budget Enforcement Threshold
+
+*For any* agent whose cumulative_cost exceeds its configured budget_limit, all
+subsequent tool calls SHALL be denied with reason_code "BUDGET_EXCEEDED", and
+budget_state.remaining_budget SHALL be <= 0.
+
+**Validates: Requirements 18.2, 18.4**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.budget_manager import BudgetStateManager
+
+from .strategies import agent_ids, budget_limits, cost_values
+
+
+# Strategy: cost sequences that guarantee the total exceeds the limit
+@st.composite
+def _exceeding_cost_sequence(draw: st.DrawFn) -> tuple[str, float, list[float]]:
+    """Generate (agent_id, budget_limit, cost_list) where sum(costs) > limit.
+
+    Ensures the total cost strictly exceeds the budget limit so that
+    the agent should be denied on subsequent checks.
+    """
+    agent_id = draw(agent_ids)
+    limit = draw(budget_limits)
+
+    # Generate costs that sum to more than the limit
+    # First, generate a partial sequence (may be under limit)
+    num_costs = draw(st.integers(min_value=1, max_value=10))
+    costs: list[float] = []
+    for _ in range(num_costs):
+        c = draw(
+            st.floats(min_value=0.001, max_value=limit * 2, allow_nan=False, allow_infinity=False)
+        )
+        costs.append(c)
+
+    # Ensure the sum exceeds the limit by adding a final cost if needed
+    total = sum(costs)
+    if total <= limit:
+        # Add enough to exceed
+        shortfall = limit - total
+        extra = draw(
+            st.floats(
+                min_value=shortfall + 0.001,
+                max_value=shortfall + limit,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        costs.append(extra)
+
+    return (agent_id, limit, costs)
+
+
+@pytest.mark.property
+class TestBudgetEnforcementThreshold:
+    """Property 17: Budget Enforcement Threshold.
+
+    For any agent whose cumulative_cost exceeds its configured budget_limit,
+    all subsequent tool calls SHALL be denied with reason_code "BUDGET_EXCEEDED",
+    and budget_state.remaining_budget SHALL be <= 0.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(data=_exceeding_cost_sequence())
+    def test_exceeded_budget_results_in_denial(
+        self, data: tuple[str, float, list[float]]
+    ) -> None:
+        """Validates: Requirements 18.2, 18.4
+
+        Once an agent's cumulative cost exceeds its budget_limit, check_budget
+        SHALL report exceeded=True with reason_code "BUDGET_EXCEEDED" semantics,
+        and all subsequent calls to check_budget SHALL continue to report exceeded.
+        """
+        agent_id, limit, costs = data
+
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, limit)
+
+        # Apply all costs
+        for cost in costs:
+            mgr.track_cost(agent_id, cost)
+
+        # After exceeding, check_budget must report exceeded=True
+        result = mgr.check_budget(agent_id)
+        assert result.exceeded is True, (
+            f"Expected exceeded=True after cumulative cost "
+            f"{sum(costs):.4f} > limit {limit:.4f}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(data=_exceeding_cost_sequence())
+    def test_exceeded_budget_remaining_is_non_positive(
+        self, data: tuple[str, float, list[float]]
+    ) -> None:
+        """Validates: Requirements 18.2, 18.4
+
+        When an agent's cumulative_cost exceeds its budget_limit,
+        budget_state.remaining_budget SHALL be <= 0.
+        """
+        agent_id, limit, costs = data
+
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, limit)
+
+        # Apply all costs
+        for cost in costs:
+            mgr.track_cost(agent_id, cost)
+
+        # Remaining budget must be <= 0
+        state = mgr.get_state(agent_id)
+        assert state.remaining_budget is not None
+        assert state.remaining_budget <= 0, (
+            f"Expected remaining_budget <= 0, got {state.remaining_budget:.4f} "
+            f"(spend={state.current_spend:.4f}, limit={limit:.4f})"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(data=_exceeding_cost_sequence())
+    def test_subsequent_checks_remain_exceeded(
+        self, data: tuple[str, float, list[float]]
+    ) -> None:
+        """Validates: Requirements 18.2, 18.4
+
+        Once budget is exceeded, ALL subsequent check_budget calls SHALL
+        continue to report exceeded=True (the denial is persistent until
+        reset or limit increase).
+        """
+        agent_id, limit, costs = data
+
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, limit)
+
+        # Apply costs until we exceed
+        for cost in costs:
+            mgr.track_cost(agent_id, cost)
+
+        # Verify multiple subsequent checks all report exceeded
+        for _ in range(5):
+            result = mgr.check_budget(agent_id)
+            assert result.exceeded is True, (
+                "Budget exceeded state must persist across multiple checks"
+            )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(data=_exceeding_cost_sequence())
+    def test_additional_costs_after_exceeded_stay_exceeded(
+        self, data: tuple[str, float, list[float]]
+    ) -> None:
+        """Validates: Requirements 18.2, 18.4
+
+        After budget is exceeded, tracking additional costs SHALL keep
+        the agent in exceeded state with remaining_budget further decreasing.
+        """
+        agent_id, limit, costs = data
+
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, limit)
+
+        # Apply all costs to exceed budget
+        for cost in costs:
+            mgr.track_cost(agent_id, cost)
+
+        # Track one more cost — should still be exceeded
+        additional = mgr.track_cost(agent_id, 0.01)
+        assert additional.exceeded is True
+        assert additional.remaining is not None
+        assert additional.remaining <= 0

--- a/packages/ag2-tealtiger/tests/test_property_18_budget_warning.py
+++ b/packages/ag2-tealtiger/tests/test_property_18_budget_warning.py
@@ -1,0 +1,289 @@
+"""Property-based test: Budget Warning at 80% (Property 18).
+
+# Feature: ag2-tealtiger-adapter, Property 18: Budget Warning at 80%
+
+Verifies that when an agent's cumulative_cost crosses 80% of its budget_limit,
+the system emits a BUDGET_WARNING without blocking the triggering operation.
+The warning is emitted exactly once per budget cycle (resets after reset()).
+
+**Validates: Requirements 18.5**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from ag2_tealtiger.budget_manager import BudgetStateManager
+
+from tests.strategies import agent_ids, budget_limits
+
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+# Budget limits constrained to reasonable positive values
+_budget_limits = st.floats(min_value=1.0, max_value=10000.0, allow_nan=False, allow_infinity=False)
+
+# Cost fractions relative to budget limit
+_sub_threshold_fraction = st.floats(
+    min_value=0.0, max_value=0.79, allow_nan=False, allow_infinity=False
+)
+
+_crossing_fraction = st.floats(
+    min_value=0.80, max_value=1.5, allow_nan=False, allow_infinity=False
+)
+
+
+@pytest.mark.property
+class TestBudgetWarningAt80Percent:
+    """Property 18: Budget Warning at 80%.
+
+    *For any* agent whose cumulative_cost crosses 80% of its budget_limit,
+    the system SHALL emit a BUDGET_WARNING audit entry without blocking
+    the triggering operation.
+
+    **Validates: Requirements 18.5**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+        crossing_fraction=_crossing_fraction,
+    )
+    def test_warning_emitted_when_crossing_80_percent(
+        self,
+        agent_id: str,
+        budget_limit: float,
+        crossing_fraction: float,
+    ) -> None:
+        """Warning is emitted when cumulative cost crosses 80% of limit.
+
+        For any agent with a budget limit, when their cumulative cost
+        reaches or exceeds 80% of the limit, a warning flag is set
+        in the BudgetCheckResult.
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        # Add cost that crosses the 80% threshold in a single call
+        cost = budget_limit * crossing_fraction
+        result = mgr.track_cost(agent_id, cost)
+
+        assert result.warning is True, (
+            f"Expected warning=True when cost ({cost:.4f}) crosses "
+            f"80% threshold ({budget_limit * 0.80:.4f}) of limit ({budget_limit:.4f})"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+        sub_fraction=_sub_threshold_fraction,
+    )
+    def test_no_warning_below_80_percent(
+        self,
+        agent_id: str,
+        budget_limit: float,
+        sub_fraction: float,
+    ) -> None:
+        """No warning when cumulative cost is below 80% of limit.
+
+        For any cost that keeps the agent below the 80% threshold,
+        the warning flag remains False.
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        cost = budget_limit * sub_fraction
+        # Ensure we're strictly below threshold due to floating point
+        assume(cost < budget_limit * 0.80)
+
+        result = mgr.track_cost(agent_id, cost)
+
+        assert result.warning is False, (
+            f"Expected warning=False when cost ({cost:.4f}) is below "
+            f"80% threshold ({budget_limit * 0.80:.4f}) of limit ({budget_limit:.4f})"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+        crossing_fraction=_crossing_fraction,
+    )
+    def test_warning_does_not_block_operation(
+        self,
+        agent_id: str,
+        budget_limit: float,
+        crossing_fraction: float,
+    ) -> None:
+        """Warning does not block the triggering operation.
+
+        When the 80% threshold is crossed, the track_cost call still
+        succeeds — the cost is accumulated and a result is returned.
+        The warning is informational, not a denial.
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        cost = budget_limit * crossing_fraction
+        result = mgr.track_cost(agent_id, cost)
+
+        # The operation completed — cost was tracked
+        state = mgr.get_state(agent_id)
+        assert state.current_spend == cost, (
+            f"Cost not tracked: expected {cost:.4f}, got {state.current_spend:.4f}"
+        )
+
+        # Budget check result is returned (operation not blocked)
+        assert result is not None
+        assert result.remaining is not None
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+    )
+    def test_warning_emitted_only_once_per_cycle(
+        self,
+        agent_id: str,
+        budget_limit: float,
+    ) -> None:
+        """Warning is emitted only once per budget cycle.
+
+        After the first crossing of 80%, subsequent track_cost calls
+        do NOT re-emit the warning (warning=False on subsequent calls).
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        # First call crosses 80%
+        cost_to_cross = budget_limit * 0.85
+        result1 = mgr.track_cost(agent_id, cost_to_cross)
+        assert result1.warning is True, "First crossing should emit warning"
+
+        # Subsequent calls should NOT re-emit warning
+        small_cost = budget_limit * 0.05
+        result2 = mgr.track_cost(agent_id, small_cost)
+        assert result2.warning is False, (
+            "Warning should only be emitted once per cycle"
+        )
+
+        # Even another call — still no re-emission
+        result3 = mgr.track_cost(agent_id, small_cost)
+        assert result3.warning is False, (
+            "Warning should not re-emit on third call"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+    )
+    def test_warning_re_emits_after_reset(
+        self,
+        agent_id: str,
+        budget_limit: float,
+    ) -> None:
+        """Warning can be emitted again after a budget reset.
+
+        The reset() operation clears the warning_emitted flag,
+        allowing the warning to fire again when the threshold
+        is crossed in the next budget cycle.
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        # Cross 80% — warning emitted
+        cost_to_cross = budget_limit * 0.85
+        result1 = mgr.track_cost(agent_id, cost_to_cross)
+        assert result1.warning is True
+
+        # Reset clears the cycle
+        mgr.reset(agent_id)
+        state = mgr.get_state(agent_id)
+        assert state.warning_emitted is False, "Reset should clear warning flag"
+
+        # Cross 80% again — warning re-emitted
+        result2 = mgr.track_cost(agent_id, cost_to_cross)
+        assert result2.warning is True, (
+            "Warning should re-emit after reset when threshold crossed again"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+        num_steps=st.integers(min_value=2, max_value=10),
+    )
+    def test_incremental_crossing_triggers_warning(
+        self,
+        agent_id: str,
+        budget_limit: float,
+        num_steps: int,
+    ) -> None:
+        """Warning triggers when 80% is crossed incrementally.
+
+        For any sequence of small cost increments that eventually
+        cross the 80% threshold, the warning is emitted exactly
+        on the call that crosses the threshold.
+        """
+        mgr = BudgetStateManager()
+        mgr.set_limit(agent_id, budget_limit)
+
+        threshold = budget_limit * 0.80
+        # Divide cost to cross threshold across num_steps
+        step_cost = (threshold + budget_limit * 0.01) / num_steps
+
+        warning_seen = False
+        warning_count = 0
+
+        for i in range(num_steps):
+            result = mgr.track_cost(agent_id, step_cost)
+            if result.warning:
+                warning_seen = True
+                warning_count += 1
+
+        assert warning_seen is True, (
+            f"Warning should be emitted when crossing 80% threshold "
+            f"({threshold:.4f}) with incremental steps"
+        )
+        assert warning_count == 1, (
+            f"Warning should be emitted exactly once, got {warning_count}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        budget_limit=_budget_limits,
+    )
+    def test_warning_callback_invoked_at_threshold(
+        self,
+        agent_id: str,
+        budget_limit: float,
+    ) -> None:
+        """The on_budget_warning callback is invoked when threshold crossed.
+
+        When a callback is configured, it receives the correct agent_id,
+        current_spend, and budget_limit when the 80% threshold is crossed.
+        """
+        warnings: list[tuple[str, float, float]] = []
+
+        def on_warning(aid: str, spend: float, limit: float) -> None:
+            warnings.append((aid, spend, limit))
+
+        mgr = BudgetStateManager(on_budget_warning=on_warning)
+        mgr.set_limit(agent_id, budget_limit)
+
+        # Cross the threshold
+        cost = budget_limit * 0.85
+        mgr.track_cost(agent_id, cost)
+
+        assert len(warnings) == 1, (
+            f"Expected exactly 1 warning callback, got {len(warnings)}"
+        )
+        assert warnings[0][0] == agent_id
+        assert warnings[0][1] == cost  # current_spend
+        assert warnings[0][2] == budget_limit

--- a/packages/ag2-tealtiger/tests/test_property_19_budget_arithmetic.py
+++ b/packages/ag2-tealtiger/tests/test_property_19_budget_arithmetic.py
@@ -1,0 +1,141 @@
+"""Property-based test: Budget State Arithmetic Consistency (Property 19).
+
+# Feature: ag2-tealtiger-adapter, Property 19: Budget State Arithmetic Consistency
+
+*For any* agent with a configured budget_limit and tracked costs, the budget state
+SHALL maintain the invariant: remaining_budget = budget_limit - current_spend.
+
+**Validates: Requirements 18.4**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.budget_manager import BudgetStateManager
+
+# ── Custom Strategies ─────────────────────────────────────────────────────────
+
+# Budget limits: positive floats (matches strategies.py budget_limits)
+budget_limits = st.floats(
+    min_value=0.01, max_value=10000.0, allow_nan=False, allow_infinity=False
+)
+
+# Cost values: non-negative floats (matches strategies.py cost_values)
+cost_values = st.floats(
+    min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False
+)
+
+# Agent IDs: realistic identifiers
+agent_ids = st.from_regex(r"[a-z][a-z0-9_]{2,29}", fullmatch=True)
+
+# Lists of costs to accumulate
+cost_sequences = st.lists(
+    cost_values,
+    min_size=1,
+    max_size=20,
+)
+
+
+@pytest.mark.property
+class TestBudgetStateArithmeticConsistency:
+    """Property 19: Budget State Arithmetic Consistency.
+
+    For any agent with a configured budget_limit and tracked costs, the
+    budget state SHALL maintain the invariant:
+        remaining_budget = budget_limit - current_spend
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        limit=budget_limits,
+        costs=cost_sequences,
+    )
+    def test_remaining_budget_equals_limit_minus_spend(
+        self, agent_id: str, limit: float, costs: list[float]
+    ) -> None:
+        """Validates: Requirements 18.4
+
+        After setting a budget limit and tracking any sequence of costs,
+        the invariant remaining_budget = budget_limit - current_spend
+        must hold at every step.
+        """
+        manager = BudgetStateManager()
+        manager.set_limit(agent_id, limit)
+
+        # Verify invariant after setting limit (before any costs)
+        state = manager.get_state(agent_id)
+        assert state.remaining_budget is not None
+        assert state.remaining_budget == pytest.approx(
+            state.budget_limit - state.current_spend
+        )
+
+        # Verify invariant holds after each cost is tracked
+        for cost in costs:
+            manager.track_cost(agent_id, cost)
+            state = manager.get_state(agent_id)
+
+            assert state.budget_limit == pytest.approx(limit)
+            assert state.remaining_budget is not None
+            assert state.remaining_budget == pytest.approx(
+                state.budget_limit - state.current_spend
+            )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        limit=budget_limits,
+        cost=cost_values,
+    )
+    def test_single_cost_arithmetic(
+        self, agent_id: str, limit: float, cost: float
+    ) -> None:
+        """Validates: Requirements 18.4
+
+        After a single cost is tracked, remaining_budget must equal
+        budget_limit - cost (the total current_spend).
+        """
+        manager = BudgetStateManager()
+        manager.set_limit(agent_id, limit)
+        manager.track_cost(agent_id, cost)
+
+        state = manager.get_state(agent_id)
+
+        assert state.current_spend == pytest.approx(cost)
+        assert state.remaining_budget == pytest.approx(limit - cost)
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        limit=budget_limits,
+        costs=cost_sequences,
+    )
+    def test_invariant_holds_after_reset(
+        self, agent_id: str, limit: float, costs: list[float]
+    ) -> None:
+        """Validates: Requirements 18.4
+
+        After tracking costs and then resetting, the invariant
+        remaining_budget = budget_limit - current_spend must hold
+        (with current_spend reset to 0).
+        """
+        manager = BudgetStateManager()
+        manager.set_limit(agent_id, limit)
+
+        # Accumulate some costs
+        for cost in costs:
+            manager.track_cost(agent_id, cost)
+
+        # Reset and verify invariant
+        manager.reset(agent_id)
+        state = manager.get_state(agent_id)
+
+        assert state.current_spend == 0.0
+        assert state.budget_limit == pytest.approx(limit)
+        assert state.remaining_budget == pytest.approx(limit)
+        assert state.remaining_budget == pytest.approx(
+            state.budget_limit - state.current_spend
+        )

--- a/packages/ag2-tealtiger/tests/test_property_1_audit_completeness.py
+++ b/packages/ag2-tealtiger/tests/test_property_1_audit_completeness.py
@@ -1,0 +1,407 @@
+"""Property-based test: Audit Entry Structural Completeness (Property 1).
+
+# Feature: ag2-tealtiger-adapter, Property 1: Audit Entry Structural Completeness
+
+*For any* governance evaluation (tool call, message send, or speaker selection),
+the resulting AuditEntry SHALL contain a valid teec.ag2 namespace with
+conversation_id, turn_id, agent_id, decision_id, and evaluation_time_ms > 0,
+regardless of the governance decision outcome.
+
+**Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5**
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    AuditEntry,
+    GovernanceAction,
+    GovernanceMode,
+)
+
+from .conftest import MockTealEngine, make_mock_engine
+from .strategies import agent_ids, governance_actions, governance_modes, tool_args, tool_names
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for property tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+def _make_tool_call_messages(
+    tool_name: str, arguments: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Create a messages list with a single tool call in AG2 format."""
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{tool_name}_001",
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def _make_text_messages(content: str) -> list[dict[str, Any]]:
+    """Create a messages list with a plain text message (for message governance)."""
+    return [{"role": "assistant", "content": content}]
+
+
+def _assert_audit_entry_structurally_complete(entry: AuditEntry) -> None:
+    """Assert that an AuditEntry has all required structural fields populated."""
+    # teec namespace must be "teec.ag2"
+    assert entry.teec.namespace == "teec.ag2", (
+        f"Expected namespace 'teec.ag2', got '{entry.teec.namespace}'"
+    )
+
+    # conversation_id must be a non-empty string (UUID v4 format)
+    assert entry.teec.conversation_id, (
+        "conversation_id must be a non-empty string"
+    )
+    assert len(entry.teec.conversation_id) > 0
+
+    # turn_id must be a positive integer
+    assert isinstance(entry.teec.turn_id, int), (
+        f"turn_id must be int, got {type(entry.teec.turn_id)}"
+    )
+    assert entry.teec.turn_id > 0, (
+        f"turn_id must be > 0, got {entry.teec.turn_id}"
+    )
+
+    # agent_id must be a non-empty string
+    assert entry.agent_id, "agent_id must be a non-empty string"
+    assert len(entry.agent_id) > 0
+
+    # decision_id must be a non-empty string (UUID v4 format)
+    assert entry.teec.decision_id, (
+        "decision_id must be a non-empty string"
+    )
+    assert len(entry.teec.decision_id) > 0
+
+    # evaluation_time_ms must be > 0
+    assert entry.evaluation_time_ms > 0, (
+        f"evaluation_time_ms must be > 0, got {entry.evaluation_time_ms}"
+    )
+
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+
+# Governance modes to test across
+_all_modes = st.sampled_from(list(GovernanceMode))
+
+# Engine decision outcomes for policy mode
+_engine_actions = st.sampled_from([
+    GovernanceAction.ALLOW,
+    GovernanceAction.DENY,
+    GovernanceAction.REFER,
+])
+
+# Simple text content for message sends
+_message_content = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz ",
+    min_size=1,
+    max_size=100,
+)
+
+
+# ── Property Tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.property
+class TestAuditEntryStructuralCompleteness:
+    """Property 1: Audit Entry Structural Completeness.
+
+    For any governance evaluation (tool call, message send, or speaker selection),
+    the resulting AuditEntry SHALL contain a valid teec.ag2 namespace with
+    conversation_id, turn_id, agent_id, decision_id, and evaluation_time_ms > 0.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_observe_mode_tool_call_audit_completeness(
+        self, agent_name: str, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        In observe mode (no engine), tool call evaluations SHALL produce
+        structurally complete AuditEntries with all required TEEC fields.
+        """
+        guard = TealTigerGuard()
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_tool_call_messages(tool_name, args)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # At least one audit entry should be produced
+        assert len(guard.audit_trail) >= 1, (
+            "Observe mode tool call should produce at least one AuditEntry"
+        )
+
+        # Verify structural completeness of the last audit entry
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        engine_action=_engine_actions,
+    )
+    def test_enforce_mode_tool_call_audit_completeness(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+        engine_action: GovernanceAction,
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        In ENFORCE mode, any TealEngine decision (ALLOW, DENY, REFER) for
+        a tool call SHALL produce a structurally complete AuditEntry.
+        """
+        engine = make_mock_engine(
+            action=engine_action,
+            risk_score=50,
+            reason_codes=["TEST_POLICY"],
+            reason="Test policy decision",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_tool_call_messages(tool_name, args)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # At least one audit entry should be produced
+        assert len(guard.audit_trail) >= 1, (
+            f"ENFORCE mode with {engine_action.value} decision should produce "
+            f"at least one AuditEntry"
+        )
+
+        # Verify structural completeness of the last audit entry
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        engine_action=_engine_actions,
+    )
+    def test_monitor_mode_tool_call_audit_completeness(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+        engine_action: GovernanceAction,
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        In MONITOR mode, any TealEngine decision (ALLOW, DENY, REFER) for
+        a tool call SHALL produce a structurally complete AuditEntry.
+        """
+        engine = make_mock_engine(
+            action=engine_action,
+            risk_score=30,
+            reason_codes=["TEST_MONITOR"],
+            reason="Monitor mode test",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.MONITOR)
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_tool_call_messages(tool_name, args)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # At least one audit entry should be produced
+        assert len(guard.audit_trail) >= 1, (
+            f"MONITOR mode with {engine_action.value} decision should produce "
+            f"at least one AuditEntry"
+        )
+
+        # Verify structural completeness of the last audit entry
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        content=_message_content,
+    )
+    def test_observe_mode_message_send_audit_completeness(
+        self, agent_name: str, content: str
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        In observe mode, text message evaluations (message sends) SHALL
+        produce structurally complete AuditEntries.
+        """
+        guard = TealTigerGuard()
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_text_messages(content)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # At least one audit entry should be produced
+        assert len(guard.audit_trail) >= 1, (
+            "Observe mode message send should produce at least one AuditEntry"
+        )
+
+        # Verify structural completeness of the last audit entry
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        content=_message_content,
+        engine_action=_engine_actions,
+    )
+    def test_policy_mode_message_send_audit_completeness(
+        self, agent_name: str, content: str, engine_action: GovernanceAction
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        In policy mode (ENFORCE), text message evaluations SHALL produce
+        structurally complete AuditEntries regardless of the decision outcome.
+        """
+        engine = make_mock_engine(
+            action=engine_action,
+            risk_score=40,
+            reason_codes=["MSG_POLICY"],
+            reason="Message governance test",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_text_messages(content)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # At least one audit entry should be produced
+        assert len(guard.audit_trail) >= 1, (
+            f"Policy mode with {engine_action.value} for message should produce "
+            f"at least one AuditEntry"
+        )
+
+        # Verify structural completeness of the last audit entry
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_frozen_agent_tool_call_audit_completeness(
+        self, agent_name: str, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        When a frozen agent attempts a tool call, the resulting DENY AuditEntry
+        SHALL still be structurally complete with all required TEEC fields.
+        """
+        guard = TealTigerGuard()
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        # Freeze the agent
+        guard.freeze(agent_name)
+
+        messages = _make_tool_call_messages(tool_name, args)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        # The freeze event produces an audit entry, and the denied tool call
+        # produces another. We want the denial entry (last one after freeze).
+        # Filter audit entries for this agent's tool call denial
+        denial_entries = [
+            e for e in guard.audit_trail
+            if e.agent_id == agent_name and e.action == GovernanceAction.DENY.value
+            and "AGENT_FROZEN" in e.reason_codes
+        ]
+        assert len(denial_entries) >= 1, (
+            "Frozen agent tool call should produce at least one DENY AuditEntry"
+        )
+
+        entry = denial_entries[-1]
+        _assert_audit_entry_structurally_complete(entry)
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        mode=_all_modes,
+    )
+    def test_all_modes_produce_complete_audit_entries(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+        mode: GovernanceMode,
+    ) -> None:
+        """Validates: Requirements 1.6, 5.1, 5.7, 12.1, 12.2, 12.5, 13.5
+
+        Regardless of governance mode (OBSERVE, MONITOR, ENFORCE), every
+        governance evaluation SHALL produce a structurally complete AuditEntry.
+        """
+        if mode == GovernanceMode.OBSERVE:
+            guard = TealTigerGuard(mode=mode)
+        else:
+            engine = make_mock_engine(
+                action=GovernanceAction.ALLOW,
+                risk_score=0,
+                reason_codes=["TEST"],
+                reason="Test",
+            )
+            guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent("user")
+
+        messages = _make_tool_call_messages(tool_name, args)
+        guard._reply_hook(recipient=agent, messages=messages, sender=sender, config=None)
+
+        assert len(guard.audit_trail) >= 1, (
+            f"Mode {mode.value} should produce at least one AuditEntry"
+        )
+
+        entry = guard.audit_trail[-1]
+        _assert_audit_entry_structurally_complete(entry)

--- a/packages/ag2-tealtiger/tests/test_property_20_cost_monotonicity.py
+++ b/packages/ag2-tealtiger/tests/test_property_20_cost_monotonicity.py
@@ -1,0 +1,156 @@
+"""Property-based test: Cumulative Cost Monotonicity (Property 20).
+
+# Feature: ag2-tealtiger-adapter, Property 20: Cumulative Cost Monotonicity
+
+*For any* sequence of tool calls and message sends by an agent, the
+cumulative_cost SHALL be monotonically non-decreasing, and per-agent cost
+totals SHALL equal the sum of individual operation costs.
+
+**Validates: Requirements 6.2, 6.4, 18.1**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.budget_manager import BudgetStateManager
+
+
+# Strategy for non-negative cost values (simulates individual operation costs)
+_cost_values = st.floats(min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False)
+
+# Strategy for sequences of costs (simulates a sequence of tool calls/messages)
+_cost_sequences = st.lists(_cost_values, min_size=1, max_size=50)
+
+# Strategy for agent IDs
+_agent_ids = st.from_regex(r"[a-z][a-z0-9_]{2,19}", fullmatch=True)
+
+
+@pytest.mark.property
+class TestCumulativeCostMonotonicity:
+    """Property 20: Cumulative Cost Monotonicity.
+
+    For any sequence of tool calls and message sends by an agent,
+    cumulative_cost is monotonically non-decreasing, and per-agent cost
+    totals equal the sum of individual operation costs.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(agent_id=_agent_ids, costs=_cost_sequences)
+    def test_cumulative_cost_monotonically_non_decreasing(
+        self, agent_id: str, costs: list[float]
+    ) -> None:
+        """Validates: Requirements 6.2, 6.4, 18.1
+
+        After each track_cost call, the cumulative_cost (current_spend)
+        SHALL be >= the previous cumulative_cost, ensuring monotonic
+        non-decreasing behavior.
+        """
+        manager = BudgetStateManager()
+        previous_spend = 0.0
+
+        for cost in costs:
+            manager.track_cost(agent_id, cost)
+            state = manager.get_state(agent_id)
+
+            # Cumulative cost must be non-decreasing
+            assert state.current_spend >= previous_spend, (
+                f"Cumulative cost decreased: {state.current_spend} < {previous_spend} "
+                f"after adding cost={cost}"
+            )
+            previous_spend = state.current_spend
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(agent_id=_agent_ids, costs=_cost_sequences)
+    def test_cumulative_cost_equals_sum_of_individual_costs(
+        self, agent_id: str, costs: list[float]
+    ) -> None:
+        """Validates: Requirements 6.2, 6.4, 18.1
+
+        The final cumulative_cost for an agent SHALL equal the sum of
+        all individual operation costs tracked for that agent.
+        """
+        manager = BudgetStateManager()
+
+        for cost in costs:
+            manager.track_cost(agent_id, cost)
+
+        state = manager.get_state(agent_id)
+        expected_total = sum(costs)
+
+        # Allow small floating-point tolerance
+        assert abs(state.current_spend - expected_total) < 1e-9, (
+            f"Cumulative cost {state.current_spend} != sum of costs {expected_total} "
+            f"(difference: {abs(state.current_spend - expected_total)})"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_id_a=_agent_ids,
+        agent_id_b=_agent_ids,
+        costs_a=_cost_sequences,
+        costs_b=_cost_sequences,
+    )
+    def test_per_agent_cost_totals_independent(
+        self,
+        agent_id_a: str,
+        agent_id_b: str,
+        costs_a: list[float],
+        costs_b: list[float],
+    ) -> None:
+        """Validates: Requirements 6.2, 6.4, 18.1
+
+        Per-agent cost totals SHALL be tracked independently — costs
+        tracked for Agent A SHALL NOT affect Agent B's cumulative cost,
+        and each agent's total SHALL equal the sum of its own costs.
+        """
+        from hypothesis import assume
+
+        assume(agent_id_a != agent_id_b)
+
+        manager = BudgetStateManager()
+
+        for cost in costs_a:
+            manager.track_cost(agent_id_a, cost)
+        for cost in costs_b:
+            manager.track_cost(agent_id_b, cost)
+
+        state_a = manager.get_state(agent_id_a)
+        state_b = manager.get_state(agent_id_b)
+
+        expected_a = sum(costs_a)
+        expected_b = sum(costs_b)
+
+        assert abs(state_a.current_spend - expected_a) < 1e-9, (
+            f"Agent A cost {state_a.current_spend} != sum {expected_a}"
+        )
+        assert abs(state_b.current_spend - expected_b) < 1e-9, (
+            f"Agent B cost {state_b.current_spend} != sum {expected_b}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(agent_id=_agent_ids, costs=_cost_sequences)
+    def test_each_step_increases_by_exact_cost(
+        self, agent_id: str, costs: list[float]
+    ) -> None:
+        """Validates: Requirements 6.2, 6.4, 18.1
+
+        After each track_cost(agent_id, cost) call, the cumulative cost
+        SHALL increase by exactly the tracked cost amount (within
+        floating-point tolerance).
+        """
+        manager = BudgetStateManager()
+        previous_spend = 0.0
+
+        for cost in costs:
+            manager.track_cost(agent_id, cost)
+            state = manager.get_state(agent_id)
+
+            expected_spend = previous_spend + cost
+            assert abs(state.current_spend - expected_spend) < 1e-9, (
+                f"After adding {cost}, expected spend={expected_spend} "
+                f"but got {state.current_spend}"
+            )
+            previous_spend = state.current_spend

--- a/packages/ag2-tealtiger/tests/test_property_24_decision_expiry.py
+++ b/packages/ag2-tealtiger/tests/test_property_24_decision_expiry.py
@@ -1,0 +1,215 @@
+"""Property-based test: Decision Receipt Expiry Enforcement (Property 24).
+
+# Feature: ag2-tealtiger-adapter, Property 24: Decision Receipt Expiry Enforcement
+
+*For any* ALLOW decision receipt whose expires_at timestamp has passed, any subsequent
+attempt to use that receipt SHALL be rejected and trigger fresh TealEngine evaluation,
+with an audit entry containing reason_code "DECISION_EXPIRED".
+
+**Validates: Requirements 16.3, 16.6**
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.types import GovernanceAction
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+# Generate positive expiry offsets in seconds (representing how far in the past
+# the expiry was set relative to "now"). Min 1 second to ensure clear expiry.
+_past_expiry_offsets = st.integers(min_value=1, max_value=86400)
+
+# Generate future expiry offsets (receipts that are NOT expired)
+_future_expiry_offsets = st.integers(min_value=1, max_value=86400)
+
+# Generate decision IDs as UUID v4 strings
+_decision_ids = st.builds(lambda: str(uuid_mod.uuid4()))
+
+# Default expiry seconds configuration
+_default_expiry_seconds = st.integers(min_value=60, max_value=7200)
+
+
+@pytest.mark.property
+class TestDecisionReceiptExpiryEnforcement:
+    """Property 24: Decision Receipt Expiry Enforcement.
+
+    For any ALLOW decision receipt whose expires_at timestamp has passed,
+    is_valid() SHALL return False (receipt rejected), and expire() SHALL
+    record "DECISION_EXPIRED" in execution_outcome, enabling an audit
+    entry with reason_code "DECISION_EXPIRED" to be produced.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        past_offset=_past_expiry_offsets,
+    )
+    def test_expired_receipt_is_rejected(
+        self, decision_id: str, past_offset: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        Any ALLOW decision receipt whose expires_at timestamp is in the past
+        SHALL be rejected by is_valid(), returning False.
+        """
+        manager = DecisionReceiptManager()
+        # Create receipt with an expiry in the past
+        expired_time = datetime.now(timezone.utc) - timedelta(seconds=past_offset)
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=expired_time,
+        )
+
+        # The receipt MUST be invalid (rejected)
+        assert manager.is_valid(decision_id) is False
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        past_offset=_past_expiry_offsets,
+    )
+    def test_expired_receipt_marked_is_expired(
+        self, decision_id: str, past_offset: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        When a receipt's expires_at has passed and is_valid() is called,
+        the receipt SHALL be marked as is_expired=True for future checks.
+        """
+        manager = DecisionReceiptManager()
+        expired_time = datetime.now(timezone.utc) - timedelta(seconds=past_offset)
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=expired_time,
+        )
+
+        # Trigger validity check
+        manager.is_valid(decision_id)
+
+        # Receipt must be marked expired
+        receipt = manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.is_expired is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        past_offset=_past_expiry_offsets,
+    )
+    def test_expired_receipt_records_decision_expired_reason(
+        self, decision_id: str, past_offset: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        When an expired receipt is explicitly expired via expire() with
+        reason "DECISION_EXPIRED", the execution_outcome SHALL contain
+        "DECISION_EXPIRED" enabling the audit trail to record this reason code.
+        """
+        manager = DecisionReceiptManager()
+        expired_time = datetime.now(timezone.utc) - timedelta(seconds=past_offset)
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=expired_time,
+        )
+
+        # Expire with the standard reason code
+        manager.expire(decision_id, "DECISION_EXPIRED")
+
+        receipt = manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.execution_outcome == "DECISION_EXPIRED"
+        assert receipt.is_expired is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        future_offset=_future_expiry_offsets,
+    )
+    def test_non_expired_receipt_remains_valid(
+        self, decision_id: str, future_offset: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        Receipts whose expires_at is in the future SHALL remain valid
+        (is_valid returns True) — only expired receipts are rejected.
+        """
+        manager = DecisionReceiptManager()
+        future_time = datetime.now(timezone.utc) + timedelta(seconds=future_offset)
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=future_time,
+        )
+
+        # The receipt MUST be valid
+        assert manager.is_valid(decision_id) is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        default_expiry=_default_expiry_seconds,
+    )
+    def test_default_expiry_applied_when_none_specified(
+        self, decision_id: str, default_expiry: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        When expires_at is not specified, the manager SHALL apply a
+        configurable default expiry, and the receipt SHALL be valid
+        immediately after creation (not yet expired).
+        """
+        manager = DecisionReceiptManager(default_expiry_seconds=default_expiry)
+
+        receipt = manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=None,
+        )
+
+        # Receipt should be valid (default expiry is in the future)
+        assert manager.is_valid(decision_id) is True
+        # expires_at should be set (not None)
+        assert receipt.expires_at is not None
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        past_offset=_past_expiry_offsets,
+    )
+    def test_repeated_validity_checks_on_expired_consistently_false(
+        self, decision_id: str, past_offset: int
+    ) -> None:
+        """Validates: Requirements 16.3, 16.6
+
+        Once a receipt is expired, repeated calls to is_valid SHALL
+        consistently return False — expiry is irreversible without
+        fresh evaluation.
+        """
+        manager = DecisionReceiptManager()
+        expired_time = datetime.now(timezone.utc) - timedelta(seconds=past_offset)
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            expires_at=expired_time,
+        )
+
+        # Multiple checks must all return False
+        assert manager.is_valid(decision_id) is False
+        assert manager.is_valid(decision_id) is False
+        assert manager.is_valid(decision_id) is False

--- a/packages/ag2-tealtiger/tests/test_property_25_revalidation.py
+++ b/packages/ag2-tealtiger/tests/test_property_25_revalidation.py
@@ -1,0 +1,362 @@
+"""Property-based test: Revalidation Condition Triggering (Property 25).
+
+# Feature: ag2-tealtiger-adapter, Property 25: Revalidation Condition Triggering
+
+*For any* ALLOW decision receipt with revalidate_if conditions, when a condition
+is met, the system SHALL trigger re-evaluation before permitting execution,
+recording an audit entry with reason_code "REVALIDATION_TRIGGERED".
+
+**Validates: Requirements 16.4, 16.6**
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.decision_manager import DecisionReceiptManager
+from ag2_tealtiger.types import GovernanceAction, RevalidationCondition
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+# Decision IDs as UUID v4 strings
+_decision_ids = st.builds(lambda: str(uuid_mod.uuid4()))
+
+# Cost thresholds for "cost_exceeded" conditions
+_cost_thresholds = st.floats(min_value=0.01, max_value=10000.0, allow_nan=False, allow_infinity=False)
+
+# Time thresholds in seconds for "time_elapsed" conditions
+_time_thresholds = st.integers(min_value=1, max_value=86400)
+
+# Context hash strings for "context_changed" conditions
+_context_hashes = st.text(
+    alphabet="0123456789abcdef",
+    min_size=8,
+    max_size=64,
+)
+
+# Amounts to exceed thresholds by (positive deltas)
+_positive_deltas = st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False)
+
+# Amounts below thresholds (fractions 0.0 to 0.99 of threshold)
+_below_fractions = st.floats(min_value=0.0, max_value=0.99, allow_nan=False, allow_infinity=False)
+
+
+@pytest.mark.property
+class TestRevalidationConditionTriggering:
+    """Property 25: Revalidation Condition Triggering.
+
+    For any ALLOW decision receipt with revalidate_if conditions, when a
+    condition is met, check_revalidation() SHALL return True indicating
+    re-evaluation is needed, and expire() SHALL record
+    "REVALIDATION_TRIGGERED" in execution_outcome enabling an audit entry
+    with that reason code.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        threshold=_cost_thresholds,
+        delta=_positive_deltas,
+    )
+    def test_cost_exceeded_condition_triggers_revalidation(
+        self, decision_id: str, threshold: float, delta: float
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a "cost_exceeded" revalidation condition is attached and the
+        current context cost meets or exceeds the threshold, check_revalidation
+        SHALL return True indicating re-evaluation is needed.
+        """
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="cost_exceeded",
+            threshold=threshold,
+            description="Re-evaluate when cost exceeds threshold",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Current cost meets or exceeds threshold
+        current_cost = threshold + delta
+        result = manager.check_revalidation(
+            decision_id, {"cost": current_cost}
+        )
+
+        assert result is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        threshold=_time_thresholds,
+        extra_seconds=st.integers(min_value=0, max_value=3600),
+    )
+    def test_time_elapsed_condition_triggers_revalidation(
+        self, decision_id: str, threshold: int, extra_seconds: int
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a "time_elapsed" revalidation condition is attached and the
+        current context elapsed_seconds meets or exceeds the threshold,
+        check_revalidation SHALL return True indicating re-evaluation is needed.
+        """
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="time_elapsed",
+            threshold=threshold,
+            description="Re-evaluate after time threshold",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Elapsed time meets or exceeds threshold
+        elapsed = threshold + extra_seconds
+        result = manager.check_revalidation(
+            decision_id, {"elapsed_seconds": elapsed}
+        )
+
+        assert result is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        original_hash=_context_hashes,
+        new_hash=_context_hashes,
+    )
+    def test_context_changed_condition_triggers_revalidation(
+        self, decision_id: str, original_hash: str, new_hash: str
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a "context_changed" revalidation condition is attached and the
+        current context_hash differs from the threshold (original hash),
+        check_revalidation SHALL return True indicating re-evaluation is needed.
+        """
+        # Only test when hashes actually differ
+        from hypothesis import assume
+
+        assume(original_hash != new_hash)
+
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="context_changed",
+            threshold=original_hash,
+            description="Re-evaluate when context changes",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Context hash is different from original
+        result = manager.check_revalidation(
+            decision_id, {"context_hash": new_hash}
+        )
+
+        assert result is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        threshold=_cost_thresholds,
+        below_fraction=_below_fractions,
+    )
+    def test_unmet_cost_condition_does_not_trigger(
+        self, decision_id: str, threshold: float, below_fraction: float
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a "cost_exceeded" condition is attached but the current cost
+        is below the threshold, check_revalidation SHALL return False
+        (no re-evaluation needed).
+        """
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="cost_exceeded",
+            threshold=threshold,
+            description="Re-evaluate when cost exceeds threshold",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Current cost is strictly below threshold
+        current_cost = threshold * below_fraction
+        result = manager.check_revalidation(
+            decision_id, {"cost": current_cost}
+        )
+
+        assert result is False
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        original_hash=_context_hashes,
+    )
+    def test_unchanged_context_does_not_trigger(
+        self, decision_id: str, original_hash: str
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a "context_changed" condition is attached but the current
+        context_hash matches the threshold (original), check_revalidation
+        SHALL return False (no re-evaluation needed).
+        """
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="context_changed",
+            threshold=original_hash,
+            description="Re-evaluate when context changes",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Context hash is same as original — no change
+        result = manager.check_revalidation(
+            decision_id, {"context_hash": original_hash}
+        )
+
+        assert result is False
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        threshold=_cost_thresholds,
+        delta=_positive_deltas,
+    )
+    def test_revalidation_triggered_records_reason_code(
+        self, decision_id: str, threshold: float, delta: float
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a revalidation condition is met and expire() is called with
+        "REVALIDATION_TRIGGERED", the execution_outcome SHALL contain
+        "REVALIDATION_TRIGGERED" enabling an audit entry with that reason code.
+        """
+        manager = DecisionReceiptManager()
+
+        condition = RevalidationCondition(
+            condition_type="cost_exceeded",
+            threshold=threshold,
+            description="Re-evaluate when cost exceeds threshold",
+        )
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[condition],
+        )
+
+        # Verify condition is met
+        current_cost = threshold + delta
+        assert manager.check_revalidation(decision_id, {"cost": current_cost}) is True
+
+        # Expire with REVALIDATION_TRIGGERED reason
+        manager.expire(decision_id, "REVALIDATION_TRIGGERED")
+
+        receipt = manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.execution_outcome == "REVALIDATION_TRIGGERED"
+        assert receipt.is_expired is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+        cost_threshold=_cost_thresholds,
+        time_threshold=_time_thresholds,
+        cost_delta=_positive_deltas,
+    )
+    def test_any_single_met_condition_triggers_revalidation(
+        self,
+        decision_id: str,
+        cost_threshold: float,
+        time_threshold: int,
+        cost_delta: float,
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When multiple revalidation conditions are attached, meeting ANY
+        single condition SHALL trigger revalidation (logical OR semantics).
+        """
+        manager = DecisionReceiptManager()
+
+        conditions = [
+            RevalidationCondition(
+                condition_type="cost_exceeded",
+                threshold=cost_threshold,
+                description="Cost limit",
+            ),
+            RevalidationCondition(
+                condition_type="time_elapsed",
+                threshold=time_threshold,
+                description="Time limit",
+            ),
+        ]
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=conditions,
+        )
+
+        # Only cost condition is met, time is not
+        result = manager.check_revalidation(
+            decision_id,
+            {"cost": cost_threshold + cost_delta, "elapsed_seconds": 0},
+        )
+
+        assert result is True
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        decision_id=_decision_ids,
+    )
+    def test_no_conditions_never_triggers(
+        self, decision_id: str
+    ) -> None:
+        """Validates: Requirements 16.4, 16.6
+
+        When a receipt has no revalidation conditions (empty list),
+        check_revalidation SHALL always return False regardless of context.
+        """
+        manager = DecisionReceiptManager()
+
+        manager.create_receipt(
+            decision_id=decision_id,
+            action=GovernanceAction.ALLOW,
+            revalidate_if=[],
+        )
+
+        # Any context should not trigger revalidation
+        result = manager.check_revalidation(
+            decision_id,
+            {"cost": 99999.0, "elapsed_seconds": 99999, "context_hash": "changed"},
+        )
+
+        assert result is False

--- a/packages/ag2-tealtiger/tests/test_property_2_observe_passthrough.py
+++ b/packages/ag2-tealtiger/tests/test_property_2_observe_passthrough.py
@@ -1,0 +1,286 @@
+"""Property-based test: Observe Mode Passthrough Invariant (Property 2).
+
+# Feature: ag2-tealtiger-adapter, Property 2: Observe Mode Passthrough Invariant
+
+*For any* tool call or message evaluated in observe mode (no TealEngine configured),
+the governance decision SHALL be ALLOW with reason_codes containing "OBSERVE_PASSTHROUGH",
+and no GovernanceDenyError SHALL be raised.
+
+**Validates: Requirements 6.5, 6.6**
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.exceptions import GovernanceDenyError
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for property tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+def _make_tool_call_messages(
+    tool_name: str, arguments: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Create a messages list with a single tool call in AG2 format."""
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{tool_name}_001",
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def _make_text_messages(content: str) -> list[dict[str, Any]]:
+    """Create a messages list with a plain text message in AG2 format."""
+    return [{"role": "assistant", "content": content}]
+
+
+# ── Strategy: Text content for messages ───────────────────────────────────────
+
+_text_content: st.SearchStrategy[str] = st.text(
+    alphabet=st.characters(categories=("L", "N", "P", "S", "Z")),
+    min_size=0,
+    max_size=500,
+)
+
+
+# ── Property Test Class ───────────────────────────────────────────────────────
+
+
+@pytest.mark.property
+class TestObserveModePassthroughInvariant:
+    """Property 2: Observe Mode Passthrough Invariant.
+
+    For any tool call or message evaluated in observe mode (no TealEngine
+    configured), the governance decision SHALL be ALLOW with reason_codes
+    containing "OBSERVE_PASSTHROUGH", and no GovernanceDenyError SHALL be raised.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        sender_name=agent_ids,
+        tool_name=tool_names,
+        arguments=tool_args,
+    )
+    def test_tool_call_always_allowed_in_observe_mode(
+        self,
+        agent_name: str,
+        sender_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        """**Validates: Requirements 6.5, 6.6**
+
+        For any tool call in observe mode, the guard SHALL:
+        - Return (False, None) — never block
+        - Produce an AuditEntry with action=ALLOW
+        - Include "OBSERVE_PASSTHROUGH" in reason_codes
+        - Never raise GovernanceDenyError
+        """
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent(sender_name)
+
+        messages = _make_tool_call_messages(tool_name, arguments)
+
+        # SHALL NOT raise GovernanceDenyError
+        try:
+            result = guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+        except GovernanceDenyError:
+            pytest.fail(
+                f"GovernanceDenyError raised in observe mode for tool '{tool_name}' "
+                f"with agent '{agent_name}'"
+            )
+
+        # SHALL return (False, None) — never blocks
+        assert result == (False, None), (
+            f"Expected (False, None) in observe mode, got {result} "
+            f"for tool '{tool_name}', agent '{agent_name}'"
+        )
+
+        # SHALL produce an AuditEntry with action=ALLOW
+        assert len(guard.audit_trail) >= 1, "Expected at least one audit entry"
+        entry = guard.audit_trail[-1]
+        assert entry.action == GovernanceAction.ALLOW.value, (
+            f"Expected action=ALLOW, got {entry.action}"
+        )
+
+        # SHALL have "OBSERVE_PASSTHROUGH" in reason_codes
+        assert "OBSERVE_PASSTHROUGH" in entry.reason_codes, (
+            f"Expected 'OBSERVE_PASSTHROUGH' in reason_codes, got {entry.reason_codes}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        sender_name=agent_ids,
+        content=_text_content,
+    )
+    def test_text_message_always_allowed_in_observe_mode(
+        self,
+        agent_name: str,
+        sender_name: str,
+        content: str,
+    ) -> None:
+        """**Validates: Requirements 6.5, 6.6**
+
+        For any text message in observe mode, the guard SHALL:
+        - Return (False, None) — never block
+        - Produce an AuditEntry with action=ALLOW
+        - Include "OBSERVE_PASSTHROUGH" in reason_codes
+        - Never raise GovernanceDenyError
+        """
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent(sender_name)
+
+        messages = _make_text_messages(content)
+
+        # SHALL NOT raise GovernanceDenyError
+        try:
+            result = guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+        except GovernanceDenyError:
+            pytest.fail(
+                f"GovernanceDenyError raised in observe mode for text message "
+                f"from agent '{agent_name}'"
+            )
+
+        # SHALL return (False, None) — never blocks
+        assert result == (False, None), (
+            f"Expected (False, None) in observe mode, got {result} "
+            f"for text message from agent '{agent_name}'"
+        )
+
+        # SHALL produce an AuditEntry with action=ALLOW
+        assert len(guard.audit_trail) >= 1, "Expected at least one audit entry"
+        entry = guard.audit_trail[-1]
+        assert entry.action == GovernanceAction.ALLOW.value, (
+            f"Expected action=ALLOW, got {entry.action}"
+        )
+
+        # SHALL have "OBSERVE_PASSTHROUGH" in reason_codes
+        assert "OBSERVE_PASSTHROUGH" in entry.reason_codes, (
+            f"Expected 'OBSERVE_PASSTHROUGH' in reason_codes, got {entry.reason_codes}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        sender_name=agent_ids,
+        tool_name=tool_names,
+        arguments=tool_args,
+    )
+    def test_no_governance_deny_error_raised_for_any_tool_call(
+        self,
+        agent_name: str,
+        sender_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        """**Validates: Requirements 6.5, 6.6**
+
+        For any arbitrary tool call in observe mode, no GovernanceDenyError
+        SHALL be raised regardless of tool name or arguments provided.
+        """
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent(sender_name)
+
+        messages = _make_tool_call_messages(tool_name, arguments)
+
+        # This must not raise any GovernanceDenyError subclass
+        try:
+            guard._reply_hook(
+                recipient=agent,
+                messages=messages,
+                sender=sender,
+                config=None,
+            )
+        except GovernanceDenyError as e:
+            pytest.fail(
+                f"GovernanceDenyError raised in observe mode: {e} "
+                f"(tool='{tool_name}', agent='{agent_name}', args keys={list(arguments.keys())})"
+            )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        sender_name=agent_ids,
+        tool_name=tool_names,
+        arguments=tool_args,
+    )
+    def test_audit_entry_mode_is_observe(
+        self,
+        agent_name: str,
+        sender_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        """**Validates: Requirements 6.5, 6.6**
+
+        For any governance evaluation in observe mode, the resulting AuditEntry
+        SHALL have mode set to "OBSERVE".
+        """
+        guard = TealTigerGuard()  # No engine = observe mode
+        agent = _MockAgent(agent_name)
+        sender = _MockAgent(sender_name)
+
+        messages = _make_tool_call_messages(tool_name, arguments)
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        entry = guard.audit_trail[-1]
+        assert entry.mode == GovernanceMode.OBSERVE.value, (
+            f"Expected mode=OBSERVE, got {entry.mode}"
+        )

--- a/packages/ag2-tealtiger/tests/test_property_3_frozen_denial.py
+++ b/packages/ag2-tealtiger/tests/test_property_3_frozen_denial.py
@@ -1,0 +1,238 @@
+"""Property test: Frozen Agent Complete Denial (Property 3).
+
+**Property 3:** For any frozen agent, all subsequent operations (tool calls
+and inter-agent messages) SHALL be denied with reason_code "AGENT_FROZEN"
+and risk_score 100, regardless of the tool name, arguments, or message content.
+
+**Validates: Requirements 4.1, 4.2, 4.5, 17.4**
+
+Uses Hypothesis to generate arbitrary tool calls and messages, verifying
+that a frozen agent is always denied regardless of operation type or content.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import MockTealEngine, make_mock_agent, make_tool_call_message, make_text_message
+from .strategies import agent_ids, tool_names, tool_args, governance_modes
+
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+# Message content: arbitrary text that could contain anything
+message_content = st.text(min_size=0, max_size=500)
+
+
+# ── Property 3: Frozen Agent Complete Denial ──────────────────────────────────
+
+
+@pytest.mark.property
+class TestFrozenAgentCompleteDenial:
+    """Property 3: Frozen agents are always denied with AGENT_FROZEN and risk_score 100."""
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+        mode=governance_modes,
+    )
+    def test_frozen_agent_tool_calls_always_denied(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        mode: GovernanceMode,
+    ) -> None:
+        """For any frozen agent, tool calls are denied with AGENT_FROZEN and risk_score 100.
+
+        Validates: Requirements 4.1, 4.2
+        """
+        # Setup: create guard in the given mode (with engine for non-observe modes)
+        engine = MockTealEngine() if mode != GovernanceMode.OBSERVE else None
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        # Create and attach agent
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze the agent
+        guard.freeze(agent_id)
+
+        # Clear the freeze audit entry to isolate tool call denial entries
+        freeze_entries_count = len(guard.audit_trail)
+
+        # Simulate a tool call from the frozen agent
+        sender = make_mock_agent("user_proxy")
+        messages = [make_tool_call_message(tool_name, tool_arguments)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify: result is (True, denial_string) — blocked
+        assert result[0] is True, "Frozen agent tool call should be blocked (True)"
+        assert isinstance(result[1], str), "Denial result should be a string"
+        assert "GOVERNANCE DENIAL" in result[1], "Should contain GOVERNANCE DENIAL marker"
+
+        # Verify: audit entry has AGENT_FROZEN and risk_score 100
+        # The new entry is after the freeze event entries
+        new_entries = guard.audit_trail[freeze_entries_count:]
+        assert len(new_entries) >= 1, "Should record at least one audit entry"
+
+        denial_entry = new_entries[0]
+        assert denial_entry.action == GovernanceAction.DENY.value
+        assert "AGENT_FROZEN" in denial_entry.reason_codes
+        assert denial_entry.risk_score == 100
+        assert denial_entry.agent_id == agent_id
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        content=message_content,
+        mode=governance_modes,
+    )
+    def test_frozen_agent_messages_always_denied(
+        self,
+        agent_id: str,
+        content: str,
+        mode: GovernanceMode,
+    ) -> None:
+        """For any frozen agent, inter-agent messages are denied with AGENT_FROZEN and risk_score 100.
+
+        Validates: Requirements 4.1, 4.5, 17.4
+        """
+        # Setup: create guard in the given mode
+        engine = MockTealEngine() if mode != GovernanceMode.OBSERVE else None
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        # Create and attach agent
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze the agent
+        guard.freeze(agent_id)
+
+        # Clear the freeze audit entry to isolate message denial entries
+        freeze_entries_count = len(guard.audit_trail)
+
+        # Simulate a plain text message (no tool_calls) to the frozen agent
+        sender = make_mock_agent("other_agent")
+        messages = [make_text_message(content)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify: result is (True, denial_string) — blocked
+        assert result[0] is True, "Frozen agent message should be blocked (True)"
+        assert isinstance(result[1], str), "Denial result should be a string"
+        assert "frozen" in result[1].lower(), "Denial message should mention frozen"
+
+        # Verify: audit entry has AGENT_FROZEN and risk_score 100
+        new_entries = guard.audit_trail[freeze_entries_count:]
+        assert len(new_entries) >= 1, "Should record at least one audit entry"
+
+        denial_entry = new_entries[0]
+        assert denial_entry.action == GovernanceAction.DENY.value
+        assert "AGENT_FROZEN" in denial_entry.reason_codes
+        assert denial_entry.risk_score == 100
+        assert denial_entry.agent_id == agent_id
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+        content=message_content,
+        mode=governance_modes,
+    )
+    def test_frozen_agent_denied_regardless_of_content(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        content: str,
+        mode: GovernanceMode,
+    ) -> None:
+        """For any frozen agent, ALL operations are denied regardless of tool name, args, or message content.
+
+        This test combines tool calls and messages to verify universality of the denial.
+
+        Validates: Requirements 4.1, 4.2, 4.5, 17.4
+        """
+        # Setup: create guard with an engine configured to ALLOW everything
+        # This proves that freeze overrides even permissive engine decisions
+        engine = MockTealEngine(
+            default_action=GovernanceAction.ALLOW,
+            default_risk_score=0,
+            default_reason_codes=["ALLOWED"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=mode)
+
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze the agent
+        guard.freeze(agent_id)
+        freeze_entries_count = len(guard.audit_trail)
+
+        sender = make_mock_agent("orchestrator")
+
+        # Test tool call
+        tool_messages = [make_tool_call_message(tool_name, tool_arguments)]
+        tool_result = guard._reply_hook(
+            recipient=agent,
+            messages=tool_messages,
+            sender=sender,
+            config=None,
+        )
+
+        assert tool_result[0] is True, "Frozen agent tool call must be blocked"
+        assert isinstance(tool_result[1], str)
+
+        # Test message
+        text_messages = [make_text_message(content)]
+        msg_result = guard._reply_hook(
+            recipient=agent,
+            messages=text_messages,
+            sender=sender,
+            config=None,
+        )
+
+        assert msg_result[0] is True, "Frozen agent message must be blocked"
+        assert isinstance(msg_result[1], str)
+
+        # Verify all new audit entries are DENY with AGENT_FROZEN and risk_score 100
+        new_entries = guard.audit_trail[freeze_entries_count:]
+        assert len(new_entries) >= 2, "Should have entries for both tool call and message"
+
+        for entry in new_entries:
+            assert entry.action == GovernanceAction.DENY.value, (
+                f"All operations on frozen agent must be DENY, got {entry.action}"
+            )
+            assert "AGENT_FROZEN" in entry.reason_codes, (
+                f"All denials for frozen agent must have AGENT_FROZEN, got {entry.reason_codes}"
+            )
+            assert entry.risk_score == 100, (
+                f"All denials for frozen agent must have risk_score 100, got {entry.risk_score}"
+            )
+
+        # Verify engine was never called (freeze short-circuits before engine evaluation)
+        assert engine.call_count == 0, (
+            "TealEngine should NOT be invoked for frozen agents"
+        )

--- a/packages/ag2-tealtiger/tests/test_property_4_freeze_roundtrip.py
+++ b/packages/ag2-tealtiger/tests/test_property_4_freeze_roundtrip.py
@@ -1,0 +1,287 @@
+"""Property test: Freeze/Unfreeze Round-Trip (Property 4).
+
+**Property 4:** For any agent, calling freeze followed by unfreeze SHALL restore
+normal governance evaluation — subsequent tool calls SHALL be evaluated against
+policies (not auto-denied) and the agent SHALL be eligible for speaker selection.
+
+**Validates: Requirements 4.4**
+
+Uses Hypothesis with max_examples=100 to verify the round-trip property
+across generated agent_ids.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    GovernanceMode,
+)
+
+from .conftest import (
+    MockConversableAgent,
+    MockTealEngine,
+    make_mock_agent,
+    make_mock_engine,
+    make_tool_call_message,
+)
+from .strategies import agent_ids, tool_names, tool_args
+
+
+# ── Property 4: Freeze/Unfreeze Round-Trip ────────────────────────────────────
+
+
+class TestProperty4FreezeUnfreezeRoundTrip:
+    """Property 4: Freeze/Unfreeze Round-Trip.
+
+    For any agent, calling freeze followed by unfreeze SHALL restore normal
+    governance evaluation — subsequent tool calls SHALL be evaluated against
+    policies (not auto-denied) and the agent SHALL be eligible for speaker
+    selection.
+
+    Validates: Requirements 4.4
+    """
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(agent_id=agent_ids)
+    def test_freeze_unfreeze_restores_non_frozen_state(
+        self, agent_id: str
+    ) -> None:
+        """After freeze+unfreeze, agent is no longer frozen.
+
+        **Validates: Requirements 4.4**
+        """
+        guard = TealTigerGuard()
+
+        # Freeze the agent
+        guard.freeze(agent_id)
+        assert guard.is_frozen(agent_id) is True
+
+        # Unfreeze the agent
+        guard.unfreeze(agent_id)
+        assert guard.is_frozen(agent_id) is False
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(agent_id=agent_ids, tool_name=tool_names, args=tool_args)
+    def test_freeze_unfreeze_tool_calls_not_auto_denied(
+        self, agent_id: str, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """After freeze+unfreeze in observe mode, tool calls pass through (not denied).
+
+        In observe mode (no engine), the _reply_hook should return (False, None)
+        indicating the tool call is allowed to proceed, not (True, denial_message)
+        which would indicate AGENT_FROZEN auto-denial.
+
+        **Validates: Requirements 4.4**
+        """
+        guard = TealTigerGuard()  # observe mode, no engine
+
+        # Create a mock agent and attach the guard
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze then unfreeze
+        guard.freeze(agent_id)
+        guard.unfreeze(agent_id)
+
+        # Simulate a tool call through the reply hook
+        sender = make_mock_agent("user")
+        messages = [make_tool_call_message(tool_name, args, sender_name=agent_id)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should pass through (False, None) — not denied
+        should_terminate, reply = result
+        assert should_terminate is False, (
+            f"Tool call was blocked after freeze+unfreeze for agent '{agent_id}'. "
+            f"Reply: {reply}"
+        )
+        assert reply is None
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(agent_id=agent_ids, tool_name=tool_names, args=tool_args)
+    def test_freeze_unfreeze_policy_evaluation_not_frozen_denial(
+        self, agent_id: str, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """After freeze+unfreeze in ENFORCE mode, tool calls are evaluated by engine (not auto-denied as AGENT_FROZEN).
+
+        With a mock engine returning ALLOW, the tool call should pass through
+        rather than being blocked with reason_code AGENT_FROZEN.
+
+        **Validates: Requirements 4.4**
+        """
+        engine = make_mock_engine(
+            action=GovernanceAction.ALLOW,
+            risk_score=0,
+            reason_codes=["POLICY_ALLOW"],
+            reason="Allowed by policy",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Create a mock agent and attach the guard
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze then unfreeze
+        guard.freeze(agent_id)
+        guard.unfreeze(agent_id)
+
+        # Simulate a tool call through the reply hook
+        sender = make_mock_agent("user")
+        messages = [make_tool_call_message(tool_name, args, sender_name=agent_id)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Should pass through (engine returns ALLOW) — not denied as AGENT_FROZEN
+        should_terminate, reply = result
+        assert should_terminate is False, (
+            f"Tool call was blocked after freeze+unfreeze for agent '{agent_id}'. "
+            f"Expected engine evaluation (ALLOW), got denial. Reply: {reply}"
+        )
+        assert reply is None
+
+        # Verify the engine was actually called (not short-circuited by frozen check)
+        assert engine.call_count >= 1, (
+            "TealEngine was not called — agent may still be treated as frozen"
+        )
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(agent_id=agent_ids, tool_name=tool_names, args=tool_args)
+    def test_freeze_unfreeze_no_agent_frozen_reason_code_in_post_unfreeze_audit(
+        self, agent_id: str, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """After freeze+unfreeze, subsequent tool call audit entries do NOT contain AGENT_FROZEN reason code.
+
+        This verifies that the governance evaluation after unfreeze treats the
+        agent normally, producing audit entries with reason codes from the actual
+        evaluation path (e.g., OBSERVE_PASSTHROUGH) rather than AGENT_FROZEN.
+
+        **Validates: Requirements 4.4**
+        """
+        guard = TealTigerGuard()  # observe mode
+
+        # Create a mock agent and attach the guard
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Freeze then unfreeze
+        guard.freeze(agent_id)
+        guard.unfreeze(agent_id)
+
+        # Count audit entries before the tool call
+        entries_before = len(guard.audit_trail)
+
+        # Simulate a tool call
+        sender = make_mock_agent("user")
+        messages = [make_tool_call_message(tool_name, args, sender_name=agent_id)]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Check audit entries added after the tool call
+        new_entries = guard.audit_trail[entries_before:]
+        assert len(new_entries) >= 1, "No audit entry was produced for the tool call"
+
+        for entry in new_entries:
+            assert "AGENT_FROZEN" not in entry.reason_codes, (
+                f"Post-unfreeze tool call produced AGENT_FROZEN reason code. "
+                f"Agent '{agent_id}' is being treated as frozen after unfreeze. "
+                f"Entry reason_codes: {entry.reason_codes}"
+            )
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(agent_id=agent_ids)
+    def test_freeze_unfreeze_agent_eligible_for_speaker_selection(
+        self, agent_id: str
+    ) -> None:
+        """After freeze+unfreeze, agent is eligible for speaker selection (not skipped as frozen).
+
+        GovernedGroupChat skips frozen agents without TealEngine evaluation.
+        After unfreeze, the agent should NOT be skipped — is_frozen returns False.
+
+        **Validates: Requirements 4.4**
+        """
+        guard = TealTigerGuard()
+
+        # Freeze then unfreeze
+        guard.freeze(agent_id)
+        guard.unfreeze(agent_id)
+
+        # The agent should not be frozen — eligible for speaker selection
+        assert guard.is_frozen(agent_id) is False, (
+            f"Agent '{agent_id}' is still frozen after unfreeze — "
+            f"would be skipped during speaker selection"
+        )
+
+    @pytest.mark.property
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        num_cycles=st.integers(min_value=1, max_value=5),
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_multiple_freeze_unfreeze_cycles_restore_evaluation(
+        self, agent_id: str, num_cycles: int, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """Multiple freeze/unfreeze cycles still restore normal evaluation.
+
+        After any number of freeze+unfreeze cycles, the agent should
+        be in a non-frozen state and tool calls should pass through.
+
+        **Validates: Requirements 4.4**
+        """
+        guard = TealTigerGuard()  # observe mode
+
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        # Perform multiple freeze/unfreeze cycles
+        for _ in range(num_cycles):
+            guard.freeze(agent_id)
+            assert guard.is_frozen(agent_id) is True
+            guard.unfreeze(agent_id)
+            assert guard.is_frozen(agent_id) is False
+
+        # After all cycles, tool call should pass through
+        sender = make_mock_agent("user")
+        messages = [make_tool_call_message(tool_name, args, sender_name=agent_id)]
+
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        should_terminate, reply = result
+        assert should_terminate is False, (
+            f"Tool call blocked after {num_cycles} freeze/unfreeze cycles "
+            f"for agent '{agent_id}'. Reply: {reply}"
+        )
+        assert reply is None

--- a/packages/ag2-tealtiger/tests/test_property_5_agent_isolation.py
+++ b/packages/ag2-tealtiger/tests/test_property_5_agent_isolation.py
@@ -1,0 +1,256 @@
+"""Property-based test: Per-Agent Governance Isolation (Property 5).
+
+# Feature: ag2-tealtiger-adapter, Property 5: Per-Agent Governance Isolation
+
+*For any* two distinct agents sharing a TealTigerGuard instance, an ALLOW
+decision for Agent A SHALL NOT authorize the same action for Agent B — Agent B's
+request SHALL be evaluated independently, producing its own distinct decision_id.
+
+**Validates: Requirements 1.7, 8.1, 8.2, 8.3**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import MockConversableAgent, MockTealEngine, make_tool_call_message
+from .strategies import agent_ids, tool_args, tool_names
+
+
+@st.composite
+def _distinct_agent_pair(draw: st.DrawFn) -> tuple[str, str]:
+    """Generate two distinct agent IDs guaranteed to be different."""
+    agent_a = draw(agent_ids)
+    agent_b = draw(agent_ids.filter(lambda x: x != agent_a))
+    return (agent_a, agent_b)
+
+
+@pytest.mark.property
+class TestPerAgentGovernanceIsolation:
+    """Property 5: Per-Agent Governance Isolation.
+
+    For any two distinct agents sharing a TealTigerGuard instance, an ALLOW
+    decision for Agent A SHALL NOT authorize the same action for Agent B —
+    Agent B's request SHALL be evaluated independently, producing its own
+    distinct decision_id.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_pair=_distinct_agent_pair(),
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_same_tool_call_produces_independent_decision_ids(
+        self,
+        agent_pair: tuple[str, str],
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 1.7, 8.1, 8.2, 8.3
+
+        When two distinct agents make the same tool call through the same
+        TealTigerGuard, each SHALL receive an independent decision_id. The
+        ALLOW decision for Agent A does not authorize Agent B's identical call.
+        """
+        agent_a_name, agent_b_name = agent_pair
+
+        # Create a single guard with a mock engine that allows everything
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Create two distinct agents and attach both to the same guard
+        agent_a = MockConversableAgent(name=agent_a_name)
+        agent_b = MockConversableAgent(name=agent_b_name)
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        # Make the same tool call from Agent A
+        msg_a = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent_a,
+            messages=[msg_a],
+            sender=agent_b,
+            config=None,
+        )
+
+        # Make the same tool call from Agent B
+        msg_b = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent_b,
+            messages=[msg_b],
+            sender=agent_a,
+            config=None,
+        )
+
+        # Both calls should produce audit entries with distinct decision_ids
+        trail = guard.audit_trail
+        assert len(trail) >= 2, (
+            f"Expected at least 2 audit entries, got {len(trail)}"
+        )
+
+        # Get the last two entries (corresponding to Agent A and Agent B calls)
+        entry_a = trail[-2]
+        entry_b = trail[-1]
+
+        # Verify they have different decision_ids
+        assert entry_a.decision_id != entry_b.decision_id, (
+            f"Agent A and Agent B must have distinct decision_ids, "
+            f"but both got '{entry_a.decision_id}'"
+        )
+
+        # Verify agent_ids are correctly scoped
+        assert entry_a.agent_id == agent_a_name
+        assert entry_b.agent_id == agent_b_name
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_pair=_distinct_agent_pair(),
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_engine_called_independently_for_each_agent(
+        self,
+        agent_pair: tuple[str, str],
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 1.7, 8.1, 8.2, 8.3
+
+        When two distinct agents make the same tool call, the TealEngine
+        SHALL be invoked separately for each agent — the engine evaluate()
+        is called once per agent with the respective agent_id in the context.
+        """
+        agent_a_name, agent_b_name = agent_pair
+
+        # Create a single guard with a mock engine
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Attach two agents
+        agent_a = MockConversableAgent(name=agent_a_name)
+        agent_b = MockConversableAgent(name=agent_b_name)
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        # Record engine call count before
+        initial_count = engine.call_count
+
+        # Agent A makes a tool call
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent_a,
+            messages=[msg],
+            sender=agent_b,
+            config=None,
+        )
+
+        # Agent B makes the same tool call
+        guard._reply_hook(
+            recipient=agent_b,
+            messages=[msg],
+            sender=agent_a,
+            config=None,
+        )
+
+        # Engine should have been called once for each agent (2 total new calls)
+        assert engine.call_count - initial_count == 2, (
+            f"Expected engine to be called 2 times (once per agent), "
+            f"but was called {engine.call_count - initial_count} times"
+        )
+
+        # Verify that each call included the correct agent_id in context
+        recent_calls = engine.evaluate_calls[-2:]
+        agent_ids_in_calls = [
+            call["context"]["agent_id"] for call in recent_calls
+        ]
+        assert agent_a_name in agent_ids_in_calls, (
+            f"Expected agent_id '{agent_a_name}' in engine calls"
+        )
+        assert agent_b_name in agent_ids_in_calls, (
+            f"Expected agent_id '{agent_b_name}' in engine calls"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_pair=_distinct_agent_pair(),
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_allow_for_agent_a_does_not_prevent_deny_for_agent_b(
+        self,
+        agent_pair: tuple[str, str],
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 1.7, 8.1, 8.2, 8.3
+
+        When the engine allows Agent A but denies Agent B for the same tool
+        call, both decisions SHALL be independently enforced — Agent A proceeds
+        while Agent B is blocked.
+        """
+        agent_a_name, agent_b_name = agent_pair
+
+        # Create engine that allows Agent A but denies Agent B
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        engine.set_decision_for_agent(
+            agent_b_name,
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+            reason="Agent B denied",
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agent_a = MockConversableAgent(name=agent_a_name)
+        agent_b = MockConversableAgent(name=agent_b_name)
+        guard.attach(agent_a)
+        guard.attach(agent_b)
+
+        # Agent A's call should be allowed (return False, None)
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        result_a = guard._reply_hook(
+            recipient=agent_a,
+            messages=[msg],
+            sender=agent_b,
+            config=None,
+        )
+
+        # Agent B's identical call should be denied (return True, denial_message)
+        result_b = guard._reply_hook(
+            recipient=agent_b,
+            messages=[msg],
+            sender=agent_a,
+            config=None,
+        )
+
+        # Agent A should pass through
+        assert result_a[0] is False, (
+            f"Agent A should be allowed (False, None), got terminate={result_a[0]}"
+        )
+
+        # Agent B should be blocked
+        assert result_b[0] is True, (
+            f"Agent B should be denied (True, message), got terminate={result_b[0]}"
+        )
+
+        # Verify audit trail reflects the per-agent scoping
+        trail = guard.audit_trail
+        agent_a_entries = [e for e in trail if e.agent_id == agent_a_name]
+        agent_b_entries = [e for e in trail if e.agent_id == agent_b_name]
+
+        # Agent A should have an ALLOW entry
+        assert any(e.action == GovernanceAction.ALLOW.value for e in agent_a_entries), (
+            "Agent A should have an ALLOW audit entry"
+        )
+
+        # Agent B should have a DENY entry
+        assert any(e.action == GovernanceAction.DENY.value for e in agent_b_entries), (
+            "Agent B should have a DENY audit entry"
+        )

--- a/packages/ag2-tealtiger/tests/test_property_7_decision_uniqueness.py
+++ b/packages/ag2-tealtiger/tests/test_property_7_decision_uniqueness.py
@@ -1,0 +1,228 @@
+"""Property-based test: Decision Identity Uniqueness Across Turns (Property 7).
+
+# Feature: ag2-tealtiger-adapter, Property 7: Decision Identity Uniqueness Across Turns
+
+*For any* two governance evaluations in different turns (even with identical
+agent_id, tool_name, and tool_args), the system SHALL produce two distinct
+decision_ids, even when params_hash is identical.
+
+**Validates: Requirements 5.7, 11.4**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import MockConversableAgent, MockTealEngine, make_tool_call_message
+from .strategies import agent_ids, tool_args, tool_names
+
+
+@pytest.mark.property
+class TestDecisionIdentityUniquenessAcrossTurns:
+    """Property 7: Decision Identity Uniqueness Across Turns.
+
+    For any two governance evaluations in different turns (even with identical
+    agent_id, tool_name, and tool_args), the system SHALL produce two distinct
+    decision_ids, even when params_hash is identical.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_identical_calls_in_different_turns_produce_distinct_decision_ids(
+        self,
+        agent_id: str,
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 5.7, 11.4
+
+        When the same agent calls the same tool with identical arguments in
+        two different turns, each evaluation SHALL produce a distinct
+        decision_id even though params_hash is the same.
+        """
+        # Create guard with a mock engine returning ALLOW
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Create agent and attach
+        agent = MockConversableAgent(name=agent_id)
+        sender = MockConversableAgent(name="sender_agent")
+        guard.attach(agent)
+
+        # Build identical tool call message
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+
+        # Turn 1: First invocation
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Turn 2: Identical invocation (same agent, tool, args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Both calls should produce audit entries
+        trail = guard.audit_trail
+        assert len(trail) >= 2, (
+            f"Expected at least 2 audit entries, got {len(trail)}"
+        )
+
+        # Get the two entries corresponding to the tool call evaluations
+        entry_1 = trail[-2]
+        entry_2 = trail[-1]
+
+        # Verify they have distinct decision_ids
+        assert entry_1.decision_id != entry_2.decision_id, (
+            f"Same agent/tool/args in different turns must produce distinct "
+            f"decision_ids, but both got '{entry_1.decision_id}'"
+        )
+
+        # Verify that params_hash is the same (since args are identical)
+        if entry_1.teec.params_hash and entry_2.teec.params_hash:
+            assert entry_1.teec.params_hash == entry_2.teec.params_hash, (
+                f"Same args should produce same params_hash, but got "
+                f"'{entry_1.teec.params_hash}' vs '{entry_2.teec.params_hash}'"
+            )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        num_turns=st.integers(min_value=2, max_value=10),
+    )
+    def test_n_identical_calls_produce_n_distinct_decision_ids(
+        self,
+        agent_id: str,
+        tool_name: str,
+        args: dict,
+        num_turns: int,
+    ) -> None:
+        """Validates: Requirements 5.7, 11.4
+
+        When the same agent calls the same tool with identical arguments
+        across N different turns, all N evaluations SHALL produce N distinct
+        decision_ids.
+        """
+        # Create guard with a mock engine returning ALLOW
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Create agent and attach
+        agent = MockConversableAgent(name=agent_id)
+        sender = MockConversableAgent(name="sender_agent")
+        guard.attach(agent)
+
+        # Build identical tool call message
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+
+        # Execute N identical turns
+        for _ in range(num_turns):
+            guard._reply_hook(
+                recipient=agent,
+                messages=[msg],
+                sender=sender,
+                config=None,
+            )
+
+        # Collect all decision_ids from the audit trail
+        trail = guard.audit_trail
+        assert len(trail) >= num_turns, (
+            f"Expected at least {num_turns} audit entries, got {len(trail)}"
+        )
+
+        # Get the last N entries
+        recent_entries = trail[-num_turns:]
+        decision_ids = [entry.decision_id for entry in recent_entries]
+
+        # All decision_ids must be unique
+        assert len(set(decision_ids)) == num_turns, (
+            f"Expected {num_turns} distinct decision_ids across {num_turns} turns, "
+            f"but got {len(set(decision_ids))} unique: {decision_ids}"
+        )
+
+        # Verify params_hash consistency (same args -> same hash)
+        params_hashes = [
+            entry.teec.params_hash
+            for entry in recent_entries
+            if entry.teec.params_hash is not None
+        ]
+        if params_hashes:
+            assert len(set(params_hashes)) == 1, (
+                f"Same args should produce same params_hash across all turns, "
+                f"but got {len(set(params_hashes))} unique hashes"
+            )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+    )
+    def test_decision_ids_are_valid_uuids(
+        self,
+        agent_id: str,
+        tool_name: str,
+        args: dict,
+    ) -> None:
+        """Validates: Requirements 5.7, 11.4
+
+        Each decision_id SHALL be a valid UUID v4 string, ensuring global
+        uniqueness across governance evaluations.
+        """
+        import uuid as uuid_mod
+
+        # Create guard with a mock engine returning ALLOW
+        engine = MockTealEngine(default_action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Create agent and attach
+        agent = MockConversableAgent(name=agent_id)
+        sender = MockConversableAgent(name="sender_agent")
+        guard.attach(agent)
+
+        # Build identical tool call message
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+
+        # Execute two turns
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=sender,
+            config=None,
+        )
+
+        # Verify both decision_ids are valid UUIDs
+        trail = guard.audit_trail
+        for entry in trail[-2:]:
+            try:
+                parsed = uuid_mod.UUID(entry.decision_id)
+                assert parsed.version == 4, (
+                    f"decision_id should be UUID v4, got version {parsed.version}"
+                )
+            except ValueError:
+                pytest.fail(
+                    f"decision_id '{entry.decision_id}' is not a valid UUID"
+                )

--- a/packages/ag2-tealtiger/tests/test_property_8_idempotency_key_determinism.py
+++ b/packages/ag2-tealtiger/tests/test_property_8_idempotency_key_determinism.py
@@ -1,0 +1,65 @@
+"""Property-based test: Idempotency Key Determinism (Property 8).
+
+# Feature: ag2-tealtiger-adapter, Property 8: Idempotency Key Determinism
+
+*For any* decision_id and params_hash pair, the derived idempotency_key SHALL be
+deterministic — the same inputs always produce the same key.
+
+**Validates: Requirements 5.8, 11.2**
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.idempotency import derive_idempotency_key
+
+# Fast strategies for UUID v4 and SHA-256 hashes (avoid slow from_regex)
+_fast_uuids = st.builds(lambda: str(uuid_mod.uuid4()))
+_fast_sha256 = st.binary(min_size=32, max_size=32).map(lambda b: b.hex())
+
+
+@pytest.mark.property
+class TestIdempotencyKeyDeterminism:
+    """Property 8: Idempotency Key Determinism.
+
+    For any decision_id and params_hash pair, calling derive_idempotency_key
+    multiple times with the same inputs SHALL always produce the same output.
+    """
+
+    @settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+    @given(decision_id=_fast_uuids, params_hash=_fast_sha256)
+    def test_same_inputs_produce_same_key(
+        self, decision_id: str, params_hash: str
+    ) -> None:
+        """Validates: Requirements 5.8, 11.2
+
+        The idempotency_key derived from a given decision_id and params_hash
+        pair is deterministic — invoking derive_idempotency_key multiple times
+        with the same inputs always returns the same result.
+        """
+        key_1 = derive_idempotency_key(decision_id, params_hash)
+        key_2 = derive_idempotency_key(decision_id, params_hash)
+        key_3 = derive_idempotency_key(decision_id, params_hash)
+
+        assert key_1 == key_2
+        assert key_2 == key_3
+
+    @settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+    @given(decision_id=_fast_uuids, params_hash=_fast_sha256)
+    def test_idempotency_key_is_valid_sha256_hex(
+        self, decision_id: str, params_hash: str
+    ) -> None:
+        """Validates: Requirements 5.8, 11.2
+
+        The derived idempotency_key SHALL be a valid 64-character hex-encoded
+        SHA-256 digest for all valid decision_id and params_hash inputs.
+        """
+        key = derive_idempotency_key(decision_id, params_hash)
+
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)

--- a/packages/ag2-tealtiger/tests/test_property_9_retry_idempotency.py
+++ b/packages/ag2-tealtiger/tests/test_property_9_retry_idempotency.py
@@ -1,0 +1,307 @@
+"""Property-based test: Retry Idempotency (Property 9).
+
+# Feature: ag2-tealtiger-adapter, Property 9: Retry Idempotency
+
+*For any* governance decision that is retried with the same decision_id,
+the system SHALL return the prior outcome without generating a new decision_id
+or triggering duplicate side effects.
+
+**Validates: Requirements 11.1, 11.5**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+from .conftest import MockConversableAgent, MockTealEngine, make_tool_call_message
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── Strategy: resolution choices ─────────────────────────────────────────────
+
+resolutions: st.SearchStrategy[str] = st.sampled_from(["ALLOW", "DENY"])
+
+approval_ids: st.SearchStrategy[str] = st.from_regex(
+    r"approval-[a-z0-9]{4,12}", fullmatch=True
+)
+
+
+@pytest.mark.property
+class TestRetryIdempotency:
+    """Property 9: Retry Idempotency.
+
+    For any governance decision that is retried with the same decision_id,
+    the system SHALL return the prior outcome without generating a new
+    decision_id or triggering duplicate side effects.
+    """
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        resolution=resolutions,
+        approval_id=approval_ids,
+    )
+    def test_retry_after_resolve_returns_prior_outcome_with_already_resolved(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+        resolution: str,
+        approval_id: str,
+    ) -> None:
+        """Validates: Requirements 11.1, 11.5
+
+        Trigger a REFER decision, resolve it, then retry the resolution with
+        the same decision_id. The retry SHALL return the prior outcome with
+        already_resolved=True, without generating a new decision_id.
+        """
+        # Set up guard with REFER engine
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=50,
+            default_reason_codes=["REQUIRES_REVIEW"],
+            default_reason="Action requires human review",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Attach agent and trigger a REFER
+        agent = MockConversableAgent(name=agent_name)
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=agent,
+            config=None,
+        )
+
+        # The hook should suspend the action (True = terminate with reply)
+        assert result[0] is True, "REFER should suspend the action"
+
+        # Extract decision_id from the REFER audit entry
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        assert len(refer_entries) >= 1, "Should have at least one REFER entry"
+        decision_id = refer_entries[-1].decision_id
+
+        # First resolution
+        outcome_1 = guard.resolve_refer(decision_id, resolution, approval_id)
+        assert outcome_1["already_resolved"] is False
+        assert outcome_1["decision_id"] == decision_id
+
+        # Retry with same decision_id — should return prior outcome
+        outcome_2 = guard.resolve_refer(decision_id, resolution, approval_id)
+        assert outcome_2["already_resolved"] is True
+        assert outcome_2["decision_id"] == decision_id
+        assert outcome_2["action"] == outcome_1["action"]
+        assert outcome_2["approval_id"] == outcome_1["approval_id"]
+        assert outcome_2["reason_codes"] == outcome_1["reason_codes"]
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        resolution=resolutions,
+        approval_id=approval_ids,
+    )
+    def test_retry_does_not_create_duplicate_audit_entries(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+        resolution: str,
+        approval_id: str,
+    ) -> None:
+        """Validates: Requirements 11.1, 11.5
+
+        Retrying with same decision_id SHALL NOT produce duplicate audit
+        entries — no new side effects are triggered.
+        """
+        # Set up guard with REFER engine
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=50,
+            default_reason_codes=["REQUIRES_REVIEW"],
+            default_reason="Action requires human review",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Attach agent and trigger REFER
+        agent = MockConversableAgent(name=agent_name)
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=agent,
+            config=None,
+        )
+
+        # Extract decision_id
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[-1].decision_id
+
+        # First resolution — produces 1 audit entry
+        guard.resolve_refer(decision_id, resolution, approval_id)
+        trail_len_after_first = len(guard.audit_trail)
+
+        # Retry — should NOT produce additional audit entries
+        guard.resolve_refer(decision_id, resolution, approval_id)
+        trail_len_after_retry = len(guard.audit_trail)
+
+        assert trail_len_after_retry == trail_len_after_first, (
+            f"Retry should not create duplicate audit entries. "
+            f"Trail grew from {trail_len_after_first} to {trail_len_after_retry}"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        resolution=resolutions,
+        approval_id=approval_ids,
+    )
+    def test_get_prior_outcome_returns_cached_resolution(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+        resolution: str,
+        approval_id: str,
+    ) -> None:
+        """Validates: Requirements 11.1, 11.5
+
+        After a REFER is resolved, get_prior_outcome(decision_id) SHALL return
+        the cached resolution — proving the outcome is stored for idempotent
+        retrieval without re-evaluation.
+        """
+        # Set up guard with REFER engine
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=50,
+            default_reason_codes=["REQUIRES_REVIEW"],
+            default_reason="Action requires human review",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Attach agent and trigger REFER
+        agent = MockConversableAgent(name=agent_name)
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=agent,
+            config=None,
+        )
+
+        # Extract decision_id
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[-1].decision_id
+
+        # Resolve the REFER
+        outcome = guard.resolve_refer(decision_id, resolution, approval_id)
+
+        # Verify get_prior_outcome returns the cached decision
+        cached = guard.get_prior_outcome(decision_id)
+        assert cached is not None, (
+            "get_prior_outcome should return cached outcome after resolution"
+        )
+        assert cached["decision_id"] == decision_id
+        assert cached["action"] == outcome["action"]
+        assert cached["approval_id"] == approval_id
+
+        # The cached outcome should reflect the final resolution (not REFER)
+        expected_action = (
+            GovernanceAction.ALLOW.value
+            if resolution == "ALLOW"
+            else GovernanceAction.DENY.value
+        )
+        assert cached["action"] == expected_action, (
+            f"Cached action should be '{expected_action}' after resolution "
+            f"'{resolution}', got '{cached['action']}'"
+        )
+
+    @settings(max_examples=100, deadline=5000, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        agent_name=agent_ids,
+        tool_name=tool_names,
+        args=tool_args,
+        approval_id=approval_ids,
+        retry_count=st.integers(min_value=2, max_value=5),
+    )
+    def test_multiple_retries_all_return_same_prior_outcome(
+        self,
+        agent_name: str,
+        tool_name: str,
+        args: dict,
+        approval_id: str,
+        retry_count: int,
+    ) -> None:
+        """Validates: Requirements 11.1, 11.5
+
+        Multiple retries with the same decision_id SHALL all return the
+        identical prior outcome, confirming stable idempotent behavior.
+        """
+        # Set up guard with REFER engine
+        engine = MockTealEngine(
+            default_action=GovernanceAction.REFER,
+            default_risk_score=50,
+            default_reason_codes=["REQUIRES_REVIEW"],
+            default_reason="Action requires human review",
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        # Attach agent and trigger REFER
+        agent = MockConversableAgent(name=agent_name)
+        guard.attach(agent)
+
+        msg = make_tool_call_message(tool_name=tool_name, arguments=args)
+        guard._reply_hook(
+            recipient=agent,
+            messages=[msg],
+            sender=agent,
+            config=None,
+        )
+
+        # Extract decision_id
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[-1].decision_id
+
+        # First resolution
+        first_outcome = guard.resolve_refer(decision_id, "ALLOW", approval_id)
+        assert first_outcome["already_resolved"] is False
+
+        # Multiple retries — all should return identical prior outcome
+        for i in range(retry_count):
+            retry_outcome = guard.resolve_refer(decision_id, "ALLOW", approval_id)
+            assert retry_outcome["already_resolved"] is True, (
+                f"Retry {i + 1} should have already_resolved=True"
+            )
+            assert retry_outcome["decision_id"] == first_outcome["decision_id"]
+            assert retry_outcome["action"] == first_outcome["action"]
+            assert retry_outcome["approval_id"] == first_outcome["approval_id"]
+            assert retry_outcome["reason_codes"] == first_outcome["reason_codes"]

--- a/packages/ag2-tealtiger/tests/test_property_conversation_id_stability.py
+++ b/packages/ag2-tealtiger/tests/test_property_conversation_id_stability.py
@@ -1,0 +1,190 @@
+"""Property test: Conversation ID Stability (Property 10).
+
+# Feature: ag2-tealtiger-adapter, Property 10: Conversation ID Stability
+
+For any sequence of governance evaluations within a single top-level conversation,
+all AuditEntries SHALL share the same conversation_id, and turn_id SHALL be
+monotonically increasing.
+
+**Validates: Requirements 5.2, 5.3**
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── Strategy: sorted list of unique turn_ids (monotonically increasing) ───────
+
+# Generate a sorted list of unique positive integers to simulate increasing turn_ids
+_increasing_turn_ids = st.lists(
+    st.integers(min_value=1, max_value=10000),
+    min_size=2,
+    max_size=20,
+    unique=True,
+).map(sorted)
+
+
+@pytest.mark.property
+class TestConversationIdStability:
+    """Property 10: Conversation ID Stability.
+
+    Verifies that all TEECContext objects produced by a single TEECContextBuilder
+    share the same conversation_id, and that turn_ids are monotonically increasing.
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        turn_ids=_increasing_turn_ids,
+        agents=st.lists(agent_ids, min_size=2, max_size=20),
+        tools=st.lists(
+            st.one_of(st.none(), tool_names),
+            min_size=2,
+            max_size=20,
+        ),
+        args_list=st.lists(
+            st.one_of(st.none(), tool_args),
+            min_size=2,
+            max_size=20,
+        ),
+    )
+    def test_all_entries_share_conversation_id(
+        self,
+        turn_ids: list[int],
+        agents: list[str],
+        tools: list[str | None],
+        args_list: list[dict | None],
+    ) -> None:
+        """All TEECContext objects from the same builder share conversation_id.
+
+        **Validates: Requirements 5.2**
+        """
+        builder = TEECContextBuilder()
+        contexts = []
+
+        # Build contexts with increasing turn_ids
+        for i, turn_id in enumerate(turn_ids):
+            agent_id = agents[i % len(agents)]
+            tool_name = tools[i % len(tools)]
+            tool_arg = args_list[i % len(args_list)]
+
+            ctx = builder.build(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args=tool_arg,
+            )
+            contexts.append(ctx)
+
+        # All contexts must share the same conversation_id
+        conversation_ids = {ctx.conversation_id for ctx in contexts}
+        assert len(conversation_ids) == 1, (
+            f"Expected a single conversation_id across all entries, "
+            f"got {len(conversation_ids)}: {conversation_ids}"
+        )
+
+        # The shared conversation_id must match the builder's conversation_id
+        assert contexts[0].conversation_id == builder.conversation_id
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        turn_ids=_increasing_turn_ids,
+        agents=st.lists(agent_ids, min_size=2, max_size=20),
+    )
+    def test_turn_id_monotonically_increasing(
+        self,
+        turn_ids: list[int],
+        agents: list[str],
+    ) -> None:
+        """turn_id values in built contexts are monotonically increasing.
+
+        **Validates: Requirements 5.3**
+        """
+        builder = TEECContextBuilder()
+        recorded_turn_ids = []
+
+        for i, turn_id in enumerate(turn_ids):
+            agent_id = agents[i % len(agents)]
+            ctx = builder.build(
+                agent_id=agent_id,
+                turn_id=turn_id,
+            )
+            recorded_turn_ids.append(ctx.turn_id)
+
+        # Verify the turn_ids in contexts match what we passed in (increasing)
+        assert recorded_turn_ids == turn_ids
+
+        # Verify monotonically increasing
+        for i in range(1, len(recorded_turn_ids)):
+            assert recorded_turn_ids[i] > recorded_turn_ids[i - 1], (
+                f"turn_id not monotonically increasing at index {i}: "
+                f"{recorded_turn_ids[i - 1]} >= {recorded_turn_ids[i]}"
+            )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        turn_ids=_increasing_turn_ids,
+        agents=st.lists(agent_ids, min_size=2, max_size=20),
+        tools=st.lists(tool_names, min_size=2, max_size=20),
+        args_list=st.lists(tool_args, min_size=2, max_size=20),
+    )
+    def test_builder_turn_counter_tracks_max(
+        self,
+        turn_ids: list[int],
+        agents: list[str],
+        tools: list[str],
+        args_list: list[dict],
+    ) -> None:
+        """Builder's current_turn_id tracks the maximum turn_id seen.
+
+        **Validates: Requirements 5.3**
+        """
+        builder = TEECContextBuilder()
+
+        for i, turn_id in enumerate(turn_ids):
+            agent_id = agents[i % len(agents)]
+            tool_name = tools[i % len(tools)]
+            tool_arg = args_list[i % len(args_list)]
+
+            builder.build(
+                agent_id=agent_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                tool_args=tool_arg,
+            )
+
+        # After processing all turn_ids, the builder's counter should be the max
+        assert builder.current_turn_id == max(turn_ids)
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        turn_ids=_increasing_turn_ids,
+        agent_id=agent_ids,
+    )
+    def test_conversation_id_is_stable_uuid(
+        self,
+        turn_ids: list[int],
+        agent_id: str,
+    ) -> None:
+        """conversation_id remains the same UUID across all build() calls.
+
+        **Validates: Requirements 5.2**
+        """
+        builder = TEECContextBuilder()
+        initial_conv_id = builder.conversation_id
+
+        for turn_id in turn_ids:
+            ctx = builder.build(agent_id=agent_id, turn_id=turn_id)
+            assert ctx.conversation_id == initial_conv_id, (
+                f"conversation_id changed from {initial_conv_id} to "
+                f"{ctx.conversation_id} at turn {turn_id}"
+            )
+
+        # Builder's property still returns the same value
+        assert builder.conversation_id == initial_conv_id

--- a/packages/ag2-tealtiger/tests/test_property_groupchat.py
+++ b/packages/ag2-tealtiger/tests/test_property_groupchat.py
@@ -1,0 +1,730 @@
+"""Property tests for GovernedGroupChat (Properties 15, 16, 21, 22, 23).
+
+Tests governance-enforced speaker selection in GovernedGroupChat,
+including frozen/budget skip, all-speakers-denied termination,
+REFER decision continuation, REFER action isolation, and
+escalation receipt completeness.
+
+Uses Hypothesis with @settings(max_examples=100, deadline=5000)
+and @pytest.mark.property for all property tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ag2_tealtiger.governed_groupchat import GovernedGroupChat
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import (
+    GovernanceAction,
+    GovernanceMode,
+)
+
+from .conftest import (
+    MockTealEngine,
+    make_mock_agent,
+    make_mock_engine,
+    make_tool_call_message,
+)
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+# Generate 2-5 distinct agent IDs for group chat scenarios
+distinct_agent_ids = st.lists(
+    agent_ids,
+    min_size=2,
+    max_size=5,
+    unique=True,
+)
+
+
+# ── Property 15: GovernedGroupChat Frozen/Budget Skip Without Engine Call ─────
+
+
+@pytest.mark.property
+class TestFrozenBudgetSkipWithoutEngineCall:
+    """Property 15: Frozen/over-budget agents are skipped without TealEngine invocation.
+
+    **Validates: Requirements 3.5, 4.3, 18.6**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=distinct_agent_ids,
+    )
+    def test_frozen_agent_skipped_without_engine_call(
+        self,
+        agent_names: list[str],
+    ) -> None:
+        """Frozen agents are skipped in speaker selection without calling TealEngine.
+
+        **Validates: Requirements 3.5, 4.3**
+        """
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        # Freeze the first agent
+        frozen_agent_id = agent_names[0]
+        guard.freeze(frozen_agent_id)
+
+        # Record engine call count before selection
+        calls_before = engine.call_count
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: frozen agent was skipped without engine call
+        # Engine should NOT be called for the frozen agent
+        # Only non-frozen agents should trigger engine evaluation
+        non_frozen_count = len(agent_names) - 1
+
+        # Since engine returns ALLOW for first non-frozen candidate,
+        # it should be called exactly once (for the first non-frozen candidate)
+        calls_after = engine.call_count
+        engine_calls_during_selection = calls_after - calls_before
+        assert engine_calls_during_selection <= non_frozen_count, (
+            f"Engine called {engine_calls_during_selection} times but only "
+            f"{non_frozen_count} non-frozen candidates exist"
+        )
+
+        # Verify the frozen agent was NOT the one selected
+        if selected is not None:
+            assert selected.name != frozen_agent_id, (
+                "Frozen agent should never be selected as speaker"
+            )
+
+        # Verify audit trail records the skip with AGENT_FROZEN reason
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1, "Should have at least one audit entry"
+        last_round = audit[-1]
+
+        frozen_entries = [
+            c for c in last_round.candidates_evaluated
+            if c["agent_id"] == frozen_agent_id
+        ]
+        assert len(frozen_entries) == 1, "Frozen agent should appear in candidates"
+        assert frozen_entries[0]["reason"] == "AGENT_FROZEN"
+        assert frozen_entries[0]["decision"] == GovernanceAction.DENY.value
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=distinct_agent_ids,
+        budget_limit=st.floats(min_value=0.01, max_value=10.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_over_budget_agent_skipped_without_engine_call(
+        self,
+        agent_names: list[str],
+        budget_limit: float,
+    ) -> None:
+        """Over-budget agents are skipped in speaker selection without calling TealEngine.
+
+        **Validates: Requirements 3.5, 18.6**
+        """
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        # Set budget for first agent and exhaust it
+        over_budget_agent_id = agent_names[0]
+        guard.set_budget(over_budget_agent_id, budget_limit)
+        # Track cost exceeding the limit
+        guard._budget_manager.track_cost(over_budget_agent_id, budget_limit + 0.01)
+
+        # Record engine call count before selection
+        calls_before = engine.call_count
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: over-budget agent was skipped without engine call
+        calls_after = engine.call_count
+        engine_calls_during_selection = calls_after - calls_before
+
+        non_over_budget_count = len(agent_names) - 1
+        assert engine_calls_during_selection <= non_over_budget_count, (
+            f"Engine called {engine_calls_during_selection} times but only "
+            f"{non_over_budget_count} within-budget candidates exist"
+        )
+
+        # Verify the over-budget agent was NOT selected
+        if selected is not None:
+            assert selected.name != over_budget_agent_id, (
+                "Over-budget agent should never be selected as speaker"
+            )
+
+        # Verify audit trail records the skip with BUDGET_EXCEEDED reason
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1
+        last_round = audit[-1]
+
+        budget_entries = [
+            c for c in last_round.candidates_evaluated
+            if c["agent_id"] == over_budget_agent_id
+        ]
+        assert len(budget_entries) == 1, "Over-budget agent should appear in candidates"
+        assert budget_entries[0]["reason"] == "BUDGET_EXCEEDED"
+        assert budget_entries[0]["decision"] == GovernanceAction.DENY.value
+
+
+# ── Property 16: All Speakers Denied Termination ─────────────────────────────
+
+
+@pytest.mark.property
+class TestAllSpeakersDeniedTermination:
+    """Property 16: Conversation terminates with ALL_SPEAKERS_DENIED when all candidates denied.
+
+    **Validates: Requirements 3.3**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=distinct_agent_ids,
+    )
+    def test_all_frozen_agents_terminates_with_all_speakers_denied(
+        self,
+        agent_names: list[str],
+    ) -> None:
+        """When all candidates are frozen, selection terminates with ALL_SPEAKERS_DENIED.
+
+        **Validates: Requirements 3.3**
+        """
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        # Freeze all agents
+        for name in agent_names:
+            guard.freeze(name)
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: no speaker selected
+        assert selected is None, "Should return None when all speakers denied"
+
+        # Verify: audit entry contains ALL_SPEAKERS_DENIED
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1
+        last_round = audit[-1]
+        assert "ALL_SPEAKERS_DENIED" in last_round.reason_codes, (
+            f"Expected ALL_SPEAKERS_DENIED in reason_codes, got {last_round.reason_codes}"
+        )
+        assert last_round.selected_speaker is None
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=distinct_agent_ids,
+    )
+    def test_all_policy_denied_terminates_with_all_speakers_denied(
+        self,
+        agent_names: list[str],
+    ) -> None:
+        """When TealEngine denies all candidates, terminates with ALL_SPEAKERS_DENIED.
+
+        **Validates: Requirements 3.3**
+        """
+        # Engine denies all agents
+        engine = make_mock_engine(
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: no speaker selected
+        assert selected is None, "Should return None when all speakers policy-denied"
+
+        # Verify: audit entry contains ALL_SPEAKERS_DENIED
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1
+        last_round = audit[-1]
+        assert "ALL_SPEAKERS_DENIED" in last_round.reason_codes
+        assert last_round.selected_speaker is None
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=distinct_agent_ids,
+        budget_limit=st.floats(min_value=0.01, max_value=10.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_mixed_denial_reasons_terminates_with_all_speakers_denied(
+        self,
+        agent_names: list[str],
+        budget_limit: float,
+    ) -> None:
+        """When all candidates denied for mixed reasons (frozen + budget + policy), terminates correctly.
+
+        **Validates: Requirements 3.3**
+        """
+        # Engine denies any agent that reaches evaluation
+        engine = make_mock_engine(
+            action=GovernanceAction.DENY,
+            risk_score=70,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        # Freeze first agent, over-budget second (if exists), rest will be policy-denied
+        guard.freeze(agent_names[0])
+        if len(agent_names) > 1:
+            guard.set_budget(agent_names[1], budget_limit)
+            guard._budget_manager.track_cost(agent_names[1], budget_limit + 0.01)
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: no speaker selected
+        assert selected is None, "Should return None when all speakers denied"
+
+        # Verify: audit entry contains ALL_SPEAKERS_DENIED
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1
+        last_round = audit[-1]
+        assert "ALL_SPEAKERS_DENIED" in last_round.reason_codes
+        assert last_round.selected_speaker is None
+
+
+# ── Property 21: REFER Decision Continues GroupChat ───────────────────────────
+
+
+@pytest.mark.property
+class TestReferDecisionContinuesGroupChat:
+    """Property 21: REFER suspends agent but does not terminate group conversation.
+
+    **Validates: Requirements 15.1, 15.3**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=st.lists(agent_ids, min_size=3, max_size=5, unique=True),
+    )
+    def test_refer_suspends_agent_continues_with_others(
+        self,
+        agent_names: list[str],
+    ) -> None:
+        """REFER for one agent does not terminate the group; next eligible agent is selected.
+
+        **Validates: Requirements 15.1, 15.3**
+        """
+        # Engine returns REFER for first agent, ALLOW for others
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        # Override: first agent gets REFER
+        engine.set_decision_for_agent(
+            agent_names[0],
+            action=GovernanceAction.REFER,
+            risk_score=50,
+            reason_codes=["REQUIRES_REVIEW"],
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: conversation did NOT terminate — a speaker was selected
+        assert selected is not None, (
+            "REFER for one agent should not terminate the group conversation"
+        )
+        # The selected speaker should be one of the non-referred agents
+        assert selected.name != agent_names[0], (
+            "The referred agent should not be selected"
+        )
+        assert selected.name in agent_names[1:], (
+            f"Selected speaker '{selected.name}' should be one of the eligible agents"
+        )
+
+        # Verify audit shows REFER for first agent
+        audit = ggc.speaker_selection_audit
+        assert len(audit) >= 1
+        last_round = audit[-1]
+
+        referred_entries = [
+            c for c in last_round.candidates_evaluated
+            if c["agent_id"] == agent_names[0]
+        ]
+        assert len(referred_entries) == 1
+        assert referred_entries[0]["decision"] == GovernanceAction.REFER.value
+
+        # Verify: ALL_SPEAKERS_DENIED is NOT in reason codes
+        assert "ALL_SPEAKERS_DENIED" not in last_round.reason_codes, (
+            "REFER should not cause ALL_SPEAKERS_DENIED when other candidates exist"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_names=st.lists(agent_ids, min_size=3, max_size=5, unique=True),
+        refer_count=st.integers(min_value=1, max_value=2),
+    )
+    def test_multiple_refers_still_continues_if_one_allowed(
+        self,
+        agent_names: list[str],
+        refer_count: int,
+    ) -> None:
+        """Multiple REFER decisions don't terminate if at least one agent is ALLOW.
+
+        **Validates: Requirements 15.1, 15.3**
+        """
+        # Clamp refer_count so at least one agent remains eligible
+        actual_refer_count = min(refer_count, len(agent_names) - 1)
+
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        # Set REFER for the first N agents
+        for i in range(actual_refer_count):
+            engine.set_decision_for_agent(
+                agent_names[i],
+                action=GovernanceAction.REFER,
+                risk_score=50,
+                reason_codes=["REQUIRES_REVIEW"],
+            )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agents = [make_mock_agent(name) for name in agent_names]
+
+        ggc = GovernedGroupChat(
+            agents=agents,
+            guard=guard,
+            speaker_selection_method="auto",
+        )
+
+        selected = ggc.select_speaker(last_speaker=None, selector=None)
+
+        # Verify: a speaker was selected from the non-referred agents
+        assert selected is not None, (
+            "With at least one non-referred agent, conversation should continue"
+        )
+        referred_names = set(agent_names[:actual_refer_count])
+        assert selected.name not in referred_names, (
+            "Selected speaker should not be a referred agent"
+        )
+
+
+# ── Property 22: REFER Agent Unrelated Action Isolation ───────────────────────
+
+
+@pytest.mark.property
+class TestReferAgentUnrelatedActionIsolation:
+    """Property 22: Agent with unresolved REFER for tool X can still use other tools.
+
+    **Validates: Requirements 15.7**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        referred_tool=tool_names,
+        other_tool=tool_names,
+        other_tool_args=tool_args,
+    )
+    def test_refer_for_tool_x_does_not_block_tool_y(
+        self,
+        agent_id: str,
+        referred_tool: str,
+        other_tool: str,
+        other_tool_args: dict[str, Any],
+    ) -> None:
+        """An agent with REFER for tool X can still use other tools Y.
+
+        **Validates: Requirements 15.7**
+        """
+        # Ensure tools are different
+        if referred_tool == other_tool:
+            other_tool = other_tool + "_alt"
+
+        # Engine returns REFER for the referred_tool, ALLOW for others
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        engine.set_decision_for_tool(
+            referred_tool,
+            action=GovernanceAction.REFER,
+            risk_score=50,
+            reason_codes=["REQUIRES_REVIEW"],
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+
+        # Step 1: Trigger REFER for referred_tool
+        refer_messages = [make_tool_call_message(referred_tool, {"key": "value"})]
+        refer_result = guard._reply_hook(
+            recipient=agent,
+            messages=refer_messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify REFER was issued (action suspended)
+        assert refer_result[0] is True, "REFER should suspend the action"
+        assert "pending review" in refer_result[1].lower() or "Action pending" in refer_result[1]
+
+        # Step 2: Now call a different tool — should be ALLOWED
+        other_messages = [make_tool_call_message(other_tool, other_tool_args)]
+        other_result = guard._reply_hook(
+            recipient=agent,
+            messages=other_messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify: the other tool was allowed (not blocked by the pending REFER)
+        assert other_result[0] is False, (
+            f"Tool '{other_tool}' should be allowed despite pending REFER for '{referred_tool}'. "
+            f"Got result: {other_result}"
+        )
+        assert other_result[1] is None, (
+            "ALLOW result should return None reply"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        referred_tool=tool_names,
+    )
+    def test_refer_does_not_freeze_agent_globally(
+        self,
+        agent_id: str,
+        referred_tool: str,
+    ) -> None:
+        """A REFER for one tool does not globally freeze the agent.
+
+        **Validates: Requirements 15.7**
+        """
+        engine = make_mock_engine(action=GovernanceAction.ALLOW)
+        engine.set_decision_for_tool(
+            referred_tool,
+            action=GovernanceAction.REFER,
+            risk_score=50,
+            reason_codes=["REQUIRES_REVIEW"],
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+
+        # Trigger REFER
+        refer_messages = [make_tool_call_message(referred_tool, {})]
+        guard._reply_hook(
+            recipient=agent,
+            messages=refer_messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify agent is NOT frozen
+        assert not guard.is_frozen(agent_id), (
+            "REFER should not freeze the agent globally"
+        )
+
+
+# ── Property 23: Escalation Receipt Completeness ─────────────────────────────
+
+
+@pytest.mark.property
+class TestEscalationReceiptCompleteness:
+    """Property 23: REFER emits escalation receipt with all required fields.
+
+    **Validates: Requirements 15.2, 15.4**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        tool_arguments=tool_args,
+    )
+    def test_refer_produces_complete_escalation_receipt(
+        self,
+        agent_id: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+    ) -> None:
+        """REFER decision produces an audit entry with all required escalation fields.
+
+        Required fields per Requirements 15.2, 15.4:
+        - decision_id
+        - agent_id
+        - tool_name
+        - conversation_id (from TEEC)
+        - turn_id
+        - risk_score
+        - reason_codes
+
+        **Validates: Requirements 15.2, 15.4**
+        """
+        engine = make_mock_engine(
+            action=GovernanceAction.REFER,
+            risk_score=60,
+            reason_codes=["REQUIRES_REVIEW"],
+            reason="Needs human approval",
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+
+        # Trigger REFER
+        messages = [make_tool_call_message(tool_name, tool_arguments)]
+        result = guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Verify: action was suspended
+        assert result[0] is True, "REFER should suspend the action"
+
+        # Verify: audit trail has REFER entry with complete fields
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+            and e.agent_id == agent_id
+        ]
+        assert len(refer_entries) >= 1, "Should have at least one REFER audit entry"
+
+        entry = refer_entries[-1]
+
+        # Verify all required fields are present and valid
+        assert entry.decision_id, "decision_id must be non-empty"
+        assert len(entry.decision_id) > 0
+
+        assert entry.agent_id == agent_id, (
+            f"agent_id should be '{agent_id}', got '{entry.agent_id}'"
+        )
+
+        assert entry.tool_name == tool_name, (
+            f"tool_name should be '{tool_name}', got '{entry.tool_name}'"
+        )
+
+        # TEEC fields
+        assert entry.teec is not None, "TEEC context must be present"
+        assert entry.teec.conversation_id, "conversation_id must be non-empty"
+        assert entry.teec.turn_id > 0, "turn_id must be positive"
+
+        # Risk score
+        assert entry.risk_score >= 0, "risk_score must be non-negative"
+        assert entry.risk_score <= 100, "risk_score must be <= 100"
+
+        # Reason codes
+        assert len(entry.reason_codes) > 0, "reason_codes must be non-empty"
+
+        # Evaluation time
+        assert entry.evaluation_time_ms > 0, "evaluation_time_ms must be positive"
+
+        # Verify decision outcome was cached (for retry idempotency)
+        cached_outcome = guard._decision_outcomes.get(entry.decision_id)
+        assert cached_outcome is not None, (
+            "REFER decision outcome should be cached for retry idempotency"
+        )
+        assert cached_outcome["action"] == GovernanceAction.REFER.value
+        assert cached_outcome["decision_id"] == entry.decision_id
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        agent_id=agent_ids,
+        tool_name=tool_names,
+        risk_score=st.integers(min_value=0, max_value=100),
+    )
+    def test_refer_receipt_includes_risk_and_reason_codes(
+        self,
+        agent_id: str,
+        tool_name: str,
+        risk_score: int,
+    ) -> None:
+        """REFER receipt captures the exact risk_score and reason_codes from engine.
+
+        **Validates: Requirements 15.2, 15.4**
+        """
+        reason_codes_list = ["REQUIRES_REVIEW", "HIGH_RISK"]
+        engine = make_mock_engine(
+            action=GovernanceAction.REFER,
+            risk_score=risk_score,
+            reason_codes=reason_codes_list,
+            reason="Human review needed",
+        )
+
+        guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+        agent = make_mock_agent(agent_id)
+        guard.attach(agent)
+
+        sender = make_mock_agent("user_proxy")
+        messages = [make_tool_call_message(tool_name, {"param": "value"})]
+
+        guard._reply_hook(
+            recipient=agent,
+            messages=messages,
+            sender=sender,
+            config=None,
+        )
+
+        # Find the REFER entry
+        refer_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        assert len(refer_entries) >= 1
+
+        entry = refer_entries[-1]
+
+        # Verify risk_score matches what the engine returned
+        assert entry.risk_score == risk_score, (
+            f"risk_score should be {risk_score}, got {entry.risk_score}"
+        )
+
+        # Verify reason_codes match what the engine returned
+        for code in reason_codes_list:
+            assert code in entry.reason_codes, (
+                f"Expected '{code}' in reason_codes, got {entry.reason_codes}"
+            )

--- a/packages/ag2-tealtiger/tests/test_property_nested_chat_correlation.py
+++ b/packages/ag2-tealtiger/tests/test_property_nested_chat_correlation.py
@@ -1,0 +1,302 @@
+"""Property test: Nested Chat Correlation Preservation (Property 11).
+
+# Feature: ag2-tealtiger-adapter, Property 11: Nested Chat Correlation Preservation
+
+For any nested chat initiated from a parent conversation, the nested scope SHALL
+have a new conversation_id distinct from the parent, preserve parent_conversation_id
+linking back to the parent, and maintain an independent monotonically increasing
+turn_id counter.
+
+**Validates: Requirements 5.6, 9.1, 9.2, 9.4**
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+
+from .strategies import agent_ids, tool_args, tool_names
+
+
+# ── Strategy: sorted list of unique turn_ids (monotonically increasing) ───────
+
+_increasing_turn_ids = st.lists(
+    st.integers(min_value=1, max_value=10000),
+    min_size=2,
+    max_size=15,
+    unique=True,
+).map(sorted)
+
+# Number of parent builds before entering nested chat
+_parent_build_counts = st.integers(min_value=1, max_value=10)
+
+# Nesting depth for arbitrary-depth tests
+_nesting_depths = st.integers(min_value=2, max_value=5)
+
+
+@pytest.mark.property
+class TestNestedChatCorrelationPreservation:
+    """Property 11: Nested Chat Correlation Preservation.
+
+    *For any* nested chat initiated from a parent conversation, the nested scope
+    SHALL have a new conversation_id distinct from the parent, preserve
+    parent_conversation_id linking back to the parent, and maintain an
+    independent monotonically increasing turn_id counter.
+
+    **Validates: Requirements 5.6, 9.1, 9.2, 9.4**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        parent_agent=agent_ids,
+        parent_turn_ids=_increasing_turn_ids,
+        nested_agent=agent_ids,
+        nested_turn_ids=_increasing_turn_ids,
+    )
+    def test_nested_chat_gets_new_conversation_id(
+        self,
+        parent_agent: str,
+        parent_turn_ids: list[int],
+        nested_agent: str,
+        nested_turn_ids: list[int],
+    ) -> None:
+        """Nested chat has a new conversation_id distinct from parent.
+
+        **Validates: Requirements 5.6**
+        """
+        parent = TEECContextBuilder()
+
+        # Build some parent contexts
+        for turn_id in parent_turn_ids:
+            parent.build(agent_id=parent_agent, turn_id=turn_id)
+
+        # Enter nested chat
+        nested = parent.enter_nested_chat()
+
+        # Nested conversation_id must differ from parent
+        assert nested.conversation_id != parent.conversation_id, (
+            f"Nested conversation_id {nested.conversation_id} should differ "
+            f"from parent {parent.conversation_id}"
+        )
+
+        # Nested conversation_id must be a valid UUID v4
+        parsed = uuid.UUID(nested.conversation_id, version=4)
+        assert str(parsed) == nested.conversation_id
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        parent_agent=agent_ids,
+        parent_turn_ids=_increasing_turn_ids,
+        nested_agent=agent_ids,
+        nested_turn_ids=_increasing_turn_ids,
+    )
+    def test_nested_preserves_parent_conversation_id(
+        self,
+        parent_agent: str,
+        parent_turn_ids: list[int],
+        nested_agent: str,
+        nested_turn_ids: list[int],
+    ) -> None:
+        """Contexts built with nested builder have parent_conversation_id == parent.conversation_id.
+
+        **Validates: Requirements 9.1**
+        """
+        parent = TEECContextBuilder()
+
+        # Build parent contexts
+        for turn_id in parent_turn_ids:
+            parent.build(agent_id=parent_agent, turn_id=turn_id)
+
+        parent_conv_id = parent.conversation_id
+
+        # Enter nested chat
+        nested = parent.enter_nested_chat()
+
+        # All contexts built with nested builder must link back to parent
+        for turn_id in nested_turn_ids:
+            ctx = nested.build(agent_id=nested_agent, turn_id=turn_id)
+            assert ctx.parent_conversation_id == parent_conv_id, (
+                f"Nested context parent_conversation_id {ctx.parent_conversation_id} "
+                f"should equal parent conversation_id {parent_conv_id}"
+            )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        parent_agent=agent_ids,
+        parent_turn_ids=_increasing_turn_ids,
+        nested_agent=agent_ids,
+        nested_turn_ids=_increasing_turn_ids,
+    )
+    def test_nested_has_independent_turn_counter(
+        self,
+        parent_agent: str,
+        parent_turn_ids: list[int],
+        nested_agent: str,
+        nested_turn_ids: list[int],
+    ) -> None:
+        """Nested builder has independent turn_id counter starting at 0.
+
+        The nested turn_id counter is independent of the parent counter,
+        and the parent counter is unaffected by nested builds.
+
+        **Validates: Requirements 9.2**
+        """
+        parent = TEECContextBuilder()
+
+        # Build parent contexts to advance parent counter
+        for turn_id in parent_turn_ids:
+            parent.build(agent_id=parent_agent, turn_id=turn_id)
+
+        parent_counter_before = parent.current_turn_id
+
+        # Enter nested chat — should start at 0
+        nested = parent.enter_nested_chat()
+        assert nested.current_turn_id == 0, (
+            f"Nested turn counter should start at 0, got {nested.current_turn_id}"
+        )
+
+        # Build nested contexts with increasing turn_ids
+        for turn_id in nested_turn_ids:
+            nested.build(agent_id=nested_agent, turn_id=turn_id)
+
+        # Nested counter tracks its own max
+        assert nested.current_turn_id == max(nested_turn_ids)
+
+        # Parent counter is unaffected by nested builds
+        assert parent.current_turn_id == parent_counter_before, (
+            f"Parent counter changed from {parent_counter_before} to "
+            f"{parent.current_turn_id} after nested builds"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        parent_agent=agent_ids,
+        nested_agent=agent_ids,
+        nested_turn_ids=_increasing_turn_ids,
+    )
+    def test_nested_turn_ids_are_monotonically_increasing(
+        self,
+        parent_agent: str,
+        nested_agent: str,
+        nested_turn_ids: list[int],
+    ) -> None:
+        """Nested builder maintains monotonically increasing turn_id within its scope.
+
+        **Validates: Requirements 9.2**
+        """
+        parent = TEECContextBuilder()
+        parent.build(agent_id=parent_agent, turn_id=1)
+
+        nested = parent.enter_nested_chat()
+        recorded_turn_ids = []
+
+        for turn_id in nested_turn_ids:
+            ctx = nested.build(agent_id=nested_agent, turn_id=turn_id)
+            recorded_turn_ids.append(ctx.turn_id)
+
+        # Verify monotonically increasing
+        for i in range(1, len(recorded_turn_ids)):
+            assert recorded_turn_ids[i] > recorded_turn_ids[i - 1], (
+                f"Nested turn_id not monotonically increasing at index {i}: "
+                f"{recorded_turn_ids[i - 1]} >= {recorded_turn_ids[i]}"
+            )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        depth=_nesting_depths,
+        agent=agent_ids,
+    )
+    def test_arbitrary_nesting_depth_preserves_ancestor_chain(
+        self,
+        depth: int,
+        agent: str,
+    ) -> None:
+        """Arbitrarily deep nesting preserves the full ancestor chain.
+
+        Each nested level links to its immediate parent, allowing
+        reconstruction of the full causal chain from any depth.
+
+        **Validates: Requirements 9.4**
+        """
+        builders: list[TEECContextBuilder] = []
+
+        # Create the root builder
+        root = TEECContextBuilder()
+        root.build(agent_id=agent, turn_id=1)
+        builders.append(root)
+
+        # Create nested builders up to the specified depth
+        for i in range(depth):
+            parent_builder = builders[-1]
+            child = parent_builder.enter_nested_chat()
+            child.build(agent_id=agent, turn_id=1)
+            builders.append(child)
+
+        # Verify ancestor chain: each child links to its immediate parent
+        for i in range(1, len(builders)):
+            child = builders[i]
+            parent = builders[i - 1]
+            ctx = child.build(agent_id=agent, turn_id=2)
+            assert ctx.parent_conversation_id == parent.conversation_id, (
+                f"At depth {i}, parent_conversation_id {ctx.parent_conversation_id} "
+                f"should equal immediate parent's conversation_id {parent.conversation_id}"
+            )
+
+        # All builders have distinct conversation_ids
+        conv_ids = [b.conversation_id for b in builders]
+        assert len(set(conv_ids)) == len(conv_ids), (
+            f"All nested levels should have distinct conversation_ids, "
+            f"but got duplicates: {conv_ids}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(
+        parent_agent=agent_ids,
+        parent_turn_ids=_increasing_turn_ids,
+        nested_agent=agent_ids,
+        nested_tool_args=tool_args,
+    )
+    def test_nested_contexts_share_same_nested_conversation_id(
+        self,
+        parent_agent: str,
+        parent_turn_ids: list[int],
+        nested_agent: str,
+        nested_tool_args: dict,
+    ) -> None:
+        """All contexts from a nested builder share the nested conversation_id.
+
+        This is the nested-scope analog of Property 10 (Conversation ID Stability).
+
+        **Validates: Requirements 5.6, 9.2**
+        """
+        parent = TEECContextBuilder()
+        for turn_id in parent_turn_ids:
+            parent.build(agent_id=parent_agent, turn_id=turn_id)
+
+        nested = parent.enter_nested_chat()
+        nested_conv_id = nested.conversation_id
+
+        # Build several contexts in the nested scope
+        contexts = []
+        for turn_id in range(1, 6):
+            ctx = nested.build(
+                agent_id=nested_agent,
+                turn_id=turn_id,
+                tool_args=nested_tool_args if turn_id % 2 == 0 else None,
+            )
+            contexts.append(ctx)
+
+        # All nested contexts share the same conversation_id
+        for ctx in contexts:
+            assert ctx.conversation_id == nested_conv_id, (
+                f"Nested context conversation_id {ctx.conversation_id} should "
+                f"equal {nested_conv_id}"
+            )
+
+        # The nested conversation_id differs from parent
+        assert nested_conv_id != parent.conversation_id

--- a/packages/ag2-tealtiger/tests/test_property_params_hash.py
+++ b/packages/ag2-tealtiger/tests/test_property_params_hash.py
@@ -1,0 +1,108 @@
+"""Property-based test: Params Hash Determinism (Property 6).
+
+# Feature: ag2-tealtiger-adapter, Property 6: Params Hash Determinism
+
+Verifies that compute_params_hash (SHA-256 of JCS-canonicalized JSON) is
+deterministic — the same arguments always produce the same hash, and different
+arguments produce different hashes (with cryptographic probability).
+
+**Validates: Requirements 5.5**
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from hypothesis import given, settings, assume
+
+from ag2_tealtiger.idempotency import compute_params_hash
+from tests.strategies import tool_args
+
+
+@pytest.mark.property
+class TestParamsHashDeterminism:
+    """Property 6: Params Hash Determinism.
+
+    *For any* tool call arguments, computing params_hash (SHA-256 of
+    JCS-canonicalized JSON) SHALL be deterministic — the same arguments
+    SHALL always produce the same hash, and different arguments SHALL
+    produce different hashes (with cryptographic probability).
+
+    **Validates: Requirements 5.5**
+    """
+
+    @settings(max_examples=100, deadline=5000)
+    @given(args=tool_args)
+    def test_same_args_produce_same_hash(self, args: dict) -> None:
+        """Same tool args always produce identical hash (determinism).
+
+        For any tool call arguments, calling compute_params_hash multiple
+        times with the same logical input must always return the same result.
+        """
+        hash_1 = compute_params_hash(args)
+        hash_2 = compute_params_hash(args)
+        assert hash_1 == hash_2, (
+            f"Same args produced different hashes: {hash_1!r} != {hash_2!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(args=tool_args)
+    def test_deep_copy_produces_same_hash(self, args: dict) -> None:
+        """A deep copy of tool args produces the same hash as the original.
+
+        This verifies that the hash depends only on the logical content
+        of the arguments, not on object identity or memory layout.
+        """
+        original_hash = compute_params_hash(args)
+        copied_args = copy.deepcopy(args)
+        copied_hash = compute_params_hash(copied_args)
+        assert original_hash == copied_hash, (
+            f"Deep copy produced different hash: {original_hash!r} != {copied_hash!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(args=tool_args)
+    def test_key_order_does_not_affect_hash(self, args: dict) -> None:
+        """Reordering top-level keys produces the same hash.
+
+        JCS canonicalization sorts keys, so any permutation of the same
+        key-value pairs must yield an identical hash.
+        """
+        assume(len(args) >= 2)
+        # Reverse the key order to create a differently-ordered dict
+        reversed_args = dict(reversed(list(args.items())))
+        assert compute_params_hash(args) == compute_params_hash(reversed_args), (
+            f"Key reordering changed the hash for args with keys: {list(args.keys())}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(args_a=tool_args, args_b=tool_args)
+    def test_different_args_produce_different_hashes(
+        self, args_a: dict, args_b: dict
+    ) -> None:
+        """Different tool args produce different hashes (collision resistance).
+
+        With cryptographic probability, two distinct inputs to SHA-256
+        should never produce the same digest.
+        """
+        assume(args_a != args_b)
+        hash_a = compute_params_hash(args_a)
+        hash_b = compute_params_hash(args_b)
+        assert hash_a != hash_b, (
+            f"Different args produced same hash {hash_a!r}: "
+            f"args_a={args_a!r}, args_b={args_b!r}"
+        )
+
+    @settings(max_examples=100, deadline=5000)
+    @given(args=tool_args)
+    def test_hash_is_valid_sha256_hex(self, args: dict) -> None:
+        """The hash is always a valid 64-character lowercase hex string (SHA-256).
+
+        This ensures the output format is consistent and well-formed.
+        """
+        result = compute_params_hash(args)
+        assert len(result) == 64, f"Expected 64 chars, got {len(result)}"
+        assert all(c in "0123456789abcdef" for c in result), (
+            f"Hash contains non-hex characters: {result!r}"
+        )

--- a/packages/ag2-tealtiger/tests/test_resolve_refer.py
+++ b/packages/ag2-tealtiger/tests/test_resolve_refer.py
@@ -1,0 +1,544 @@
+"""Tests for resolve_refer and retry idempotency in TealTigerGuard.
+
+Validates:
+- resolve_refer(decision_id, resolution, approval_id) resumes or denies suspended actions
+- Retry with same decision_id returns prior outcome (idempotency)
+- Retry with different params produces new decision_id (params_hash change)
+- Same agent/tool/args in different turns produce distinct decision_ids
+
+Requirements: 11.1, 11.3, 11.4, 11.5, 15.5, 15.6
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ag2_tealtiger.guard import TealTigerGuard
+from ag2_tealtiger.types import GovernanceAction, GovernanceMode
+
+
+# ── Test Helpers ──────────────────────────────────────────────────────────────
+
+
+class _MockAgent:
+    """Minimal mock AG2 agent for resolve_refer tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._reply_funcs: list[dict[str, Any]] = []
+
+    def register_reply(
+        self, trigger: Any, reply_func: Any, position: int = 0, **kwargs: Any
+    ) -> None:
+        self._reply_funcs.insert(
+            position, {"trigger": trigger, "reply_func": reply_func}
+        )
+
+
+def _tool_msg(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a mock tool call message in AG2 format."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": f"call_{tool_name}_001",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": arguments or {},
+                },
+            }
+        ],
+    }
+
+
+def _engine(
+    action: GovernanceAction = GovernanceAction.ALLOW,
+    risk_score: int = 0,
+    reason_codes: list[str] | None = None,
+    reason: str = "Mock decision",
+) -> Any:
+    """Create a mock TealEngine returning a fixed decision."""
+
+    class _Eng:
+        def __init__(self) -> None:
+            self.evaluate_calls: list[dict[str, Any]] = []
+
+        def evaluate(
+            self,
+            tool_name: str | None = None,
+            args: dict[str, Any] | None = None,
+            context: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            self.evaluate_calls.append(
+                {"tool_name": tool_name, "args": args, "context": context}
+            )
+            return {
+                "action": action.value,
+                "risk_score": risk_score,
+                "reason_codes": reason_codes or [],
+                "reason": reason,
+            }
+
+    return _Eng()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def refer_guard() -> TealTigerGuard:
+    """Create a guard with REFER engine in ENFORCE mode."""
+    eng = _engine(
+        action=GovernanceAction.REFER,
+        risk_score=50,
+        reason_codes=["REQUIRES_REVIEW"],
+        reason="Action requires human review",
+    )
+    return TealTigerGuard(engine=eng, mode=GovernanceMode.ENFORCE)
+
+
+@pytest.fixture
+def allow_guard() -> TealTigerGuard:
+    """Create a guard with ALLOW engine in ENFORCE mode."""
+    eng = _engine(
+        action=GovernanceAction.ALLOW,
+        risk_score=0,
+        reason_codes=["POLICY_PASS"],
+        reason="Allowed",
+    )
+    return TealTigerGuard(engine=eng, mode=GovernanceMode.ENFORCE)
+
+
+# ── resolve_refer tests ───────────────────────────────────────────────────────
+
+
+class TestResolveRefer:
+    """Tests for resolve_refer method."""
+
+    def test_resolve_allow_creates_audit_entry(self, refer_guard: TealTigerGuard) -> None:
+        """WHEN resolution == ALLOW, record audit entry with ALLOW and REFER_RESOLVED."""
+        agent = _MockAgent("coder")
+        refer_guard.attach(agent)
+
+        # Trigger a REFER decision
+        msg = _tool_msg("run_code", {"code": "print('hi')"})
+        result = refer_guard._reply_hook(agent, [msg], agent, None)
+        assert result[0] is True  # Action suspended
+
+        # Extract decision_id from audit trail
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        assert len(refer_entries) == 1
+        decision_id = refer_entries[0].decision_id
+
+        # Resolve with ALLOW
+        outcome = refer_guard.resolve_refer(decision_id, "ALLOW", "approval-001")
+
+        assert outcome["decision_id"] == decision_id
+        assert outcome["action"] == GovernanceAction.ALLOW.value
+        assert outcome["approval_id"] == "approval-001"
+        assert "REFER_RESOLVED" in outcome["reason_codes"]
+        assert outcome["already_resolved"] is False
+
+        # Verify audit entry was recorded
+        resolution_entries = [
+            e for e in refer_guard.audit_trail
+            if "REFER_RESOLVED" in e.reason_codes
+        ]
+        assert len(resolution_entries) == 1
+        assert resolution_entries[0].action == GovernanceAction.ALLOW.value
+        assert resolution_entries[0].teec.approval_id == "approval-001"
+
+    def test_resolve_deny_expires_receipt(self, refer_guard: TealTigerGuard) -> None:
+        """WHEN resolution == DENY, expire receipt with REFER_DENIED."""
+        agent = _MockAgent("coder")
+        refer_guard.attach(agent)
+
+        # Trigger a REFER decision
+        msg = _tool_msg("run_code", {"code": "print('hi')"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        # Get the decision_id
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        # Resolve with DENY
+        outcome = refer_guard.resolve_refer(decision_id, "DENY", "approval-002")
+
+        assert outcome["decision_id"] == decision_id
+        assert outcome["action"] == GovernanceAction.DENY.value
+        assert outcome["approval_id"] == "approval-002"
+        assert "REFER_DENIED" in outcome["reason_codes"]
+        assert outcome["already_resolved"] is False
+
+        # Verify receipt is expired
+        receipt = refer_guard._decision_manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.is_expired is True
+        assert receipt.execution_outcome == "REFER_DENIED"
+
+        # Verify audit entry was recorded
+        deny_entries = [
+            e for e in refer_guard.audit_trail
+            if "REFER_DENIED" in e.reason_codes
+        ]
+        assert len(deny_entries) == 1
+        assert deny_entries[0].action == GovernanceAction.DENY.value
+
+    def test_resolve_invalid_resolution_raises(self, refer_guard: TealTigerGuard) -> None:
+        """WHEN resolution is invalid, raise ValueError."""
+        agent = _MockAgent("coder")
+        refer_guard.attach(agent)
+
+        msg = _tool_msg("run_code", {"code": "x"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        with pytest.raises(ValueError, match="Invalid resolution"):
+            refer_guard.resolve_refer(decision_id, "MODIFY", "approval-003")
+
+    def test_resolve_unknown_decision_id_raises(self, refer_guard: TealTigerGuard) -> None:
+        """WHEN decision_id is not found, raise KeyError."""
+        with pytest.raises(KeyError, match="Decision receipt not found"):
+            refer_guard.resolve_refer("nonexistent-id", "ALLOW", "approval-004")
+
+    def test_resolve_allow_stores_approval_on_receipt(self, refer_guard: TealTigerGuard) -> None:
+        """WHEN resolution == ALLOW, the receipt should have the approval_id set."""
+        agent = _MockAgent("executor")
+        refer_guard.attach(agent)
+
+        msg = _tool_msg("delete_file", {"path": "/tmp/x"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        refer_guard.resolve_refer(decision_id, "ALLOW", "reviewer-42")
+
+        receipt = refer_guard._decision_manager.get_receipt(decision_id)
+        assert receipt is not None
+        assert receipt.approval_id == "reviewer-42"
+        assert receipt.execution_outcome == "approved"
+
+
+# ── Retry Idempotency tests ──────────────────────────────────────────────────
+
+
+class TestRetryIdempotency:
+    """Tests for retry idempotency guarantees."""
+
+    def test_retry_same_decision_id_returns_prior_outcome(
+        self, refer_guard: TealTigerGuard
+    ) -> None:
+        """WHEN same decision_id is retried after resolution, return prior outcome.
+
+        Requirements: 11.1, 11.5
+        """
+        agent = _MockAgent("coder")
+        refer_guard.attach(agent)
+
+        msg = _tool_msg("run_code", {"code": "x"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        # First resolution
+        outcome_1 = refer_guard.resolve_refer(decision_id, "ALLOW", "approval-A")
+        assert outcome_1["already_resolved"] is False
+
+        # Retry with same decision_id — should return prior outcome
+        outcome_2 = refer_guard.resolve_refer(decision_id, "ALLOW", "approval-A")
+        assert outcome_2["already_resolved"] is True
+        assert outcome_2["decision_id"] == decision_id
+        assert outcome_2["action"] == GovernanceAction.ALLOW.value
+        assert outcome_2["approval_id"] == "approval-A"
+
+    def test_retry_same_decision_id_no_duplicate_audit_entries(
+        self, refer_guard: TealTigerGuard
+    ) -> None:
+        """Retry with same decision_id should NOT create duplicate audit entries.
+
+        Requirements: 11.1, 11.5
+        """
+        agent = _MockAgent("coder")
+        refer_guard.attach(agent)
+
+        msg = _tool_msg("run_code", {"code": "y"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        trail_len_before = len(refer_guard.audit_trail)
+
+        # First resolution
+        refer_guard.resolve_refer(decision_id, "DENY", "approval-B")
+        trail_len_after_first = len(refer_guard.audit_trail)
+        assert trail_len_after_first == trail_len_before + 1  # One new entry
+
+        # Retry — should NOT add another audit entry
+        refer_guard.resolve_refer(decision_id, "DENY", "approval-B")
+        trail_len_after_retry = len(refer_guard.audit_trail)
+        assert trail_len_after_retry == trail_len_after_first  # No new entry
+
+    def test_get_prior_outcome_returns_cached_decision(
+        self, allow_guard: TealTigerGuard
+    ) -> None:
+        """get_prior_outcome returns the cached decision for a known decision_id.
+
+        Requirements: 11.1, 11.5
+        """
+        agent = _MockAgent("coder")
+        allow_guard.attach(agent)
+
+        msg = _tool_msg("search", {"query": "hello"})
+        allow_guard._reply_hook(agent, [msg], agent, None)
+
+        # The ALLOW decision should be cached
+        allow_entries = [
+            e for e in allow_guard.audit_trail
+            if e.action == GovernanceAction.ALLOW.value
+        ]
+        assert len(allow_entries) >= 1
+        decision_id = allow_entries[0].decision_id
+
+        prior = allow_guard.get_prior_outcome(decision_id)
+        assert prior is not None
+        assert prior["decision_id"] == decision_id
+        assert prior["action"] == GovernanceAction.ALLOW.value
+
+    def test_get_prior_outcome_returns_none_for_unknown(
+        self, allow_guard: TealTigerGuard
+    ) -> None:
+        """get_prior_outcome returns None for an unknown decision_id."""
+        assert allow_guard.get_prior_outcome("nonexistent-id") is None
+
+
+# ── Different params → different decision_id tests ────────────────────────────
+
+
+class TestDifferentParamsDifferentDecisionId:
+    """Tests that different params produce different decision_ids.
+
+    Requirements: 11.3
+    """
+
+    def test_different_args_produce_different_decision_ids(
+        self, allow_guard: TealTigerGuard
+    ) -> None:
+        """WHEN tool call has different parameters, generate new decision_id.
+
+        Because params_hash changes → TEEC builder generates a new decision_id anyway.
+        """
+        agent = _MockAgent("coder")
+        allow_guard.attach(agent)
+
+        # First call
+        msg_1 = _tool_msg("search", {"query": "hello"})
+        allow_guard._reply_hook(agent, [msg_1], agent, None)
+
+        # Second call with different args
+        msg_2 = _tool_msg("search", {"query": "world"})
+        allow_guard._reply_hook(agent, [msg_2], agent, None)
+
+        allow_entries = [
+            e for e in allow_guard.audit_trail
+            if e.action == GovernanceAction.ALLOW.value
+        ]
+        assert len(allow_entries) >= 2
+
+        # Decision IDs must be different
+        decision_id_1 = allow_entries[0].decision_id
+        decision_id_2 = allow_entries[1].decision_id
+        assert decision_id_1 != decision_id_2
+
+        # Params hashes must also be different
+        assert allow_entries[0].teec.params_hash != allow_entries[1].teec.params_hash
+
+
+# ── Same agent/tool/args in different turns → distinct decision_ids ───────────
+
+
+class TestDistinctDecisionIdsAcrossTurns:
+    """Tests that same agent/tool/args in different turns produce distinct decision_ids.
+
+    Requirements: 11.4
+    """
+
+    def test_same_call_different_turns_distinct_decision_ids(
+        self, allow_guard: TealTigerGuard
+    ) -> None:
+        """Same agent calls same tool with identical args in two turns → distinct decision_ids.
+
+        Even though params_hash is the same, each turn gets a unique decision_id
+        because TEECContextBuilder.build() generates a fresh UUID v4 each time.
+        """
+        agent = _MockAgent("executor")
+        allow_guard.attach(agent)
+
+        msg = _tool_msg("run_code", {"code": "print(1)"})
+
+        # Turn 1
+        allow_guard._reply_hook(agent, [msg], agent, None)
+
+        # Turn 2 (same message/args)
+        allow_guard._reply_hook(agent, [msg], agent, None)
+
+        allow_entries = [
+            e for e in allow_guard.audit_trail
+            if e.action == GovernanceAction.ALLOW.value
+        ]
+        assert len(allow_entries) >= 2
+
+        decision_id_1 = allow_entries[0].decision_id
+        decision_id_2 = allow_entries[1].decision_id
+
+        # Decision IDs must be distinct even with same args
+        assert decision_id_1 != decision_id_2
+
+        # Params hashes should be the same (same args)
+        assert allow_entries[0].teec.params_hash == allow_entries[1].teec.params_hash
+
+    def test_multiple_turns_all_unique_decision_ids(
+        self, allow_guard: TealTigerGuard
+    ) -> None:
+        """Multiple turns with identical tool calls all produce unique decision_ids."""
+        agent = _MockAgent("worker")
+        allow_guard.attach(agent)
+
+        msg = _tool_msg("fetch_data", {"url": "http://example.com"})
+
+        for _ in range(5):
+            allow_guard._reply_hook(agent, [msg], agent, None)
+
+        allow_entries = [
+            e for e in allow_guard.audit_trail
+            if e.action == GovernanceAction.ALLOW.value
+        ]
+        decision_ids = [e.decision_id for e in allow_entries]
+
+        # All decision IDs must be unique
+        assert len(decision_ids) == len(set(decision_ids))
+
+    def test_deny_decisions_also_get_distinct_ids_across_turns(self) -> None:
+        """DENY decisions in different turns also produce distinct decision_ids."""
+        eng = _engine(
+            action=GovernanceAction.DENY,
+            risk_score=80,
+            reason_codes=["POLICY_VIOLATION"],
+        )
+        guard = TealTigerGuard(engine=eng, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("risky_agent")
+        guard.attach(agent)
+
+        msg = _tool_msg("dangerous_tool", {"target": "prod"})
+
+        # Two separate turns
+        guard._reply_hook(agent, [msg], agent, None)
+        guard._reply_hook(agent, [msg], agent, None)
+
+        deny_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.DENY.value
+        ]
+        assert len(deny_entries) >= 2
+
+        decision_id_1 = deny_entries[0].decision_id
+        decision_id_2 = deny_entries[1].decision_id
+        assert decision_id_1 != decision_id_2
+
+
+# ── Decision outcome caching tests ───────────────────────────────────────────
+
+
+class TestDecisionOutcomeCaching:
+    """Tests that decision outcomes are cached for all decision types."""
+
+    def test_allow_decision_cached(self, allow_guard: TealTigerGuard) -> None:
+        """ALLOW decisions are cached for later retrieval."""
+        agent = _MockAgent("coder")
+        allow_guard.attach(agent)
+
+        msg = _tool_msg("search", {"q": "test"})
+        allow_guard._reply_hook(agent, [msg], agent, None)
+
+        allow_entries = [
+            e for e in allow_guard.audit_trail
+            if e.action == GovernanceAction.ALLOW.value
+        ]
+        decision_id = allow_entries[0].decision_id
+
+        cached = allow_guard.get_prior_outcome(decision_id)
+        assert cached is not None
+        assert cached["action"] == "ALLOW"
+
+    def test_deny_decision_cached(self) -> None:
+        """DENY decisions are cached for later retrieval."""
+        eng = _engine(
+            action=GovernanceAction.DENY,
+            risk_score=90,
+            reason_codes=["BLOCKED"],
+        )
+        guard = TealTigerGuard(engine=eng, mode=GovernanceMode.ENFORCE)
+        agent = _MockAgent("agent")
+        guard.attach(agent)
+
+        msg = _tool_msg("rm_rf", {"path": "/"})
+        guard._reply_hook(agent, [msg], agent, None)
+
+        deny_entries = [
+            e for e in guard.audit_trail
+            if e.action == GovernanceAction.DENY.value
+        ]
+        decision_id = deny_entries[0].decision_id
+
+        cached = guard.get_prior_outcome(decision_id)
+        assert cached is not None
+        assert cached["action"] == "DENY"
+        assert cached["risk_score"] == 90
+
+    def test_refer_decision_cached(self, refer_guard: TealTigerGuard) -> None:
+        """REFER decisions are cached for later retrieval."""
+        agent = _MockAgent("agent")
+        refer_guard.attach(agent)
+
+        msg = _tool_msg("send_email", {"to": "admin@corp.com"})
+        refer_guard._reply_hook(agent, [msg], agent, None)
+
+        refer_entries = [
+            e for e in refer_guard.audit_trail
+            if e.action == GovernanceAction.REFER.value
+        ]
+        decision_id = refer_entries[0].decision_id
+
+        cached = refer_guard.get_prior_outcome(decision_id)
+        assert cached is not None
+        assert cached["action"] == "REFER"
+        assert cached["risk_score"] == 50

--- a/packages/ag2-tealtiger/tests/test_teec_builder.py
+++ b/packages/ag2-tealtiger/tests/test_teec_builder.py
@@ -1,0 +1,247 @@
+"""Unit tests for TEECContextBuilder.
+
+Tests cover:
+- UUID v4 conversation_id generation
+- Monotonically increasing turn_id counter
+- build() method field population (all TEECContext fields)
+- params_hash computation from tool_args
+- idempotency_key derivation
+- decision_id uniqueness per build() call
+- enter_nested_chat() — fresh conversation_id, preserved parent, independent counter
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ag2_tealtiger.idempotency import compute_params_hash, derive_idempotency_key
+from ag2_tealtiger.teec_builder import TEECContextBuilder
+from ag2_tealtiger.types import TEECContext
+
+
+class TestTEECContextBuilderInit:
+    """Tests for TEECContextBuilder.__init__."""
+
+    def test_auto_generates_uuid4_conversation_id(self) -> None:
+        builder = TEECContextBuilder()
+        # Should be a valid UUID v4
+        parsed = uuid.UUID(builder.conversation_id, version=4)
+        assert str(parsed) == builder.conversation_id
+
+    def test_accepts_explicit_conversation_id(self) -> None:
+        custom_id = "custom-conv-123"
+        builder = TEECContextBuilder(conversation_id=custom_id)
+        assert builder.conversation_id == custom_id
+
+    def test_initial_turn_id_is_zero(self) -> None:
+        builder = TEECContextBuilder()
+        assert builder.current_turn_id == 0
+
+
+class TestTEECContextBuilderBuild:
+    """Tests for TEECContextBuilder.build() method."""
+
+    def test_returns_teec_context(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert isinstance(ctx, TEECContext)
+
+    def test_populates_namespace(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.namespace == "teec.ag2"
+
+    def test_populates_conversation_id(self) -> None:
+        builder = TEECContextBuilder(conversation_id="conv-abc")
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.conversation_id == "conv-abc"
+
+    def test_populates_turn_id(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=5)
+        assert ctx.turn_id == 5
+
+    def test_populates_agent_role(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="reviewer", turn_id=1)
+        assert ctx.agent_role == "reviewer"
+
+    def test_populates_group_chat_id(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1, group_chat_id="gc-001")
+        assert ctx.group_chat_id == "gc-001"
+
+    def test_group_chat_id_defaults_to_none(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.group_chat_id is None
+
+    def test_generates_unique_decision_id_per_call(self) -> None:
+        builder = TEECContextBuilder()
+        ctx1 = builder.build(agent_id="coder", turn_id=1)
+        ctx2 = builder.build(agent_id="coder", turn_id=2)
+        assert ctx1.decision_id != ctx2.decision_id
+        # Both should be valid UUIDs
+        uuid.UUID(ctx1.decision_id, version=4)
+        uuid.UUID(ctx2.decision_id, version=4)
+
+    def test_computes_params_hash_from_tool_args(self) -> None:
+        builder = TEECContextBuilder()
+        tool_args = {"code": "print('hello')", "language": "python"}
+        ctx = builder.build(agent_id="coder", turn_id=1, tool_args=tool_args)
+        expected_hash = compute_params_hash(tool_args)
+        assert ctx.params_hash == expected_hash
+
+    def test_params_hash_none_when_no_tool_args(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.params_hash is None
+
+    def test_derives_idempotency_key_when_tool_args_present(self) -> None:
+        builder = TEECContextBuilder()
+        tool_args = {"file": "main.py"}
+        ctx = builder.build(agent_id="coder", turn_id=1, tool_args=tool_args)
+        expected_key = derive_idempotency_key(ctx.decision_id, ctx.params_hash)
+        assert ctx.idempotency_key == expected_key
+
+    def test_idempotency_key_none_when_no_tool_args(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.idempotency_key is None
+
+    def test_populates_parent_conversation_id(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(
+            agent_id="coder", turn_id=1, parent_conversation_id="parent-123"
+        )
+        assert ctx.parent_conversation_id == "parent-123"
+
+    def test_parent_conversation_id_defaults_to_none(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.parent_conversation_id is None
+
+    def test_default_decision_source(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.decision_source == "default_mode"
+
+    def test_default_execution_outcome_is_none(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.execution_outcome is None
+
+    def test_default_approval_id_is_none(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.approval_id is None
+
+    def test_default_policy_digest_is_none(self) -> None:
+        builder = TEECContextBuilder()
+        ctx = builder.build(agent_id="coder", turn_id=1)
+        assert ctx.policy_digest is None
+
+
+class TestTEECContextBuilderTurnId:
+    """Tests for monotonically increasing turn_id counter."""
+
+    def test_turn_counter_updates_to_provided_value(self) -> None:
+        builder = TEECContextBuilder()
+        builder.build(agent_id="coder", turn_id=3)
+        assert builder.current_turn_id == 3
+
+    def test_turn_counter_increases_monotonically(self) -> None:
+        builder = TEECContextBuilder()
+        builder.build(agent_id="coder", turn_id=1)
+        assert builder.current_turn_id == 1
+        builder.build(agent_id="coder", turn_id=5)
+        assert builder.current_turn_id == 5
+        builder.build(agent_id="coder", turn_id=10)
+        assert builder.current_turn_id == 10
+
+    def test_turn_counter_does_not_decrease(self) -> None:
+        builder = TEECContextBuilder()
+        builder.build(agent_id="coder", turn_id=5)
+        assert builder.current_turn_id == 5
+        # Providing a lower turn_id should not decrease the counter
+        builder.build(agent_id="coder", turn_id=3)
+        assert builder.current_turn_id == 5
+
+    def test_turn_counter_stays_same_for_equal_value(self) -> None:
+        builder = TEECContextBuilder()
+        builder.build(agent_id="coder", turn_id=4)
+        builder.build(agent_id="coder", turn_id=4)
+        assert builder.current_turn_id == 4
+
+
+class TestTEECContextBuilderNestedChat:
+    """Tests for enter_nested_chat() method."""
+
+    def test_nested_builder_has_fresh_conversation_id(self) -> None:
+        parent = TEECContextBuilder(conversation_id="parent-conv")
+        nested = parent.enter_nested_chat()
+        assert nested.conversation_id != "parent-conv"
+        # Nested should be a valid UUID v4
+        uuid.UUID(nested.conversation_id, version=4)
+
+    def test_nested_builder_preserves_parent_conversation_id(self) -> None:
+        parent = TEECContextBuilder(conversation_id="parent-conv")
+        nested = parent.enter_nested_chat()
+        ctx = nested.build(agent_id="reviewer", turn_id=1)
+        assert ctx.parent_conversation_id == "parent-conv"
+
+    def test_nested_builder_has_independent_turn_counter(self) -> None:
+        parent = TEECContextBuilder()
+        parent.build(agent_id="coder", turn_id=10)
+        assert parent.current_turn_id == 10
+
+        nested = parent.enter_nested_chat()
+        assert nested.current_turn_id == 0
+        nested.build(agent_id="reviewer", turn_id=1)
+        assert nested.current_turn_id == 1
+        # Parent counter unaffected
+        assert parent.current_turn_id == 10
+
+    def test_nested_of_nested_preserves_immediate_parent(self) -> None:
+        grandparent = TEECContextBuilder(conversation_id="gp-conv")
+        parent = grandparent.enter_nested_chat()
+        child = parent.enter_nested_chat()
+
+        child_ctx = child.build(agent_id="executor", turn_id=1)
+        # Child's parent should be the parent's conversation_id, not grandparent's
+        assert child_ctx.parent_conversation_id == parent.conversation_id
+        assert child_ctx.parent_conversation_id != "gp-conv"
+
+    def test_explicit_parent_conversation_id_overrides_stored(self) -> None:
+        parent = TEECContextBuilder(conversation_id="parent-conv")
+        nested = parent.enter_nested_chat()
+        ctx = nested.build(
+            agent_id="reviewer",
+            turn_id=1,
+            parent_conversation_id="override-id",
+        )
+        assert ctx.parent_conversation_id == "override-id"
+
+    def test_parent_builder_unaffected_by_nested_builds(self) -> None:
+        parent = TEECContextBuilder(conversation_id="parent-conv")
+        parent.build(agent_id="coder", turn_id=1)
+
+        nested = parent.enter_nested_chat()
+        nested.build(agent_id="reviewer", turn_id=5)
+
+        # Parent state unchanged
+        assert parent.conversation_id == "parent-conv"
+        assert parent.current_turn_id == 1
+
+    def test_multiple_nested_chats_are_independent(self) -> None:
+        parent = TEECContextBuilder(conversation_id="parent-conv")
+        nested1 = parent.enter_nested_chat()
+        nested2 = parent.enter_nested_chat()
+
+        # Different conversation IDs
+        assert nested1.conversation_id != nested2.conversation_id
+        # Both link back to the same parent
+        ctx1 = nested1.build(agent_id="a", turn_id=1)
+        ctx2 = nested2.build(agent_id="b", turn_id=1)
+        assert ctx1.parent_conversation_id == "parent-conv"
+        assert ctx2.parent_conversation_id == "parent-conv"

--- a/packages/ag2-tealtiger/tests/test_types.py
+++ b/packages/ag2-tealtiger/tests/test_types.py
@@ -1,0 +1,437 @@
+"""Unit tests for ag2_tealtiger.types module."""
+
+from datetime import datetime, timezone
+
+from ag2_tealtiger.types import (
+    ActionKind,
+    AuditEntry,
+    BudgetState,
+    DecisionReceipt,
+    DecisionSource,
+    DenialMessage,
+    EscalationReceipt,
+    GovernanceAction,
+    GovernanceMode,
+    RevalidationCondition,
+    SpeakerSelectionAuditEntry,
+    TEECContext,
+)
+
+
+class TestGovernanceAction:
+    """Tests for GovernanceAction enum."""
+
+    def test_values(self):
+        assert GovernanceAction.ALLOW == "ALLOW"
+        assert GovernanceAction.DENY == "DENY"
+        assert GovernanceAction.MODIFY == "MODIFY"
+        assert GovernanceAction.REFER == "REFER"
+
+    def test_is_str_enum(self):
+        assert isinstance(GovernanceAction.ALLOW, str)
+        assert GovernanceAction.DENY.upper() == "DENY"
+
+    def test_all_members(self):
+        assert len(GovernanceAction) == 4
+
+
+class TestGovernanceMode:
+    """Tests for GovernanceMode enum."""
+
+    def test_values(self):
+        assert GovernanceMode.ENFORCE == "ENFORCE"
+        assert GovernanceMode.MONITOR == "MONITOR"
+        assert GovernanceMode.OBSERVE == "OBSERVE"
+
+    def test_is_str_enum(self):
+        assert isinstance(GovernanceMode.ENFORCE, str)
+
+    def test_all_members(self):
+        assert len(GovernanceMode) == 3
+
+
+class TestActionKind:
+    """Tests for ActionKind enum."""
+
+    def test_values(self):
+        assert ActionKind.MESSAGE == "message"
+        assert ActionKind.TOOL_CALL == "tool_call"
+        assert ActionKind.BUDGET_CHANGE == "budget_change"
+        assert ActionKind.STOP == "stop"
+        assert ActionKind.FREEZE == "freeze"
+
+    def test_is_str_enum(self):
+        assert isinstance(ActionKind.MESSAGE, str)
+
+    def test_all_members(self):
+        assert len(ActionKind) == 5
+
+
+class TestDecisionSource:
+    """Tests for DecisionSource enum."""
+
+    def test_values(self):
+        assert DecisionSource.POLICY_ENGINE == "policy_engine"
+        assert DecisionSource.HUMAN_REVIEWER == "human_reviewer"
+        assert DecisionSource.DELEGATED_AUTHORITY == "delegated_authority"
+        assert DecisionSource.DEFAULT_MODE == "default_mode"
+        assert DecisionSource.SYSTEM_TIMEOUT == "system_timeout"
+
+    def test_is_str_enum(self):
+        assert isinstance(DecisionSource.POLICY_ENGINE, str)
+
+    def test_all_members(self):
+        assert len(DecisionSource) == 5
+
+
+class TestTEECContext:
+    """Tests for TEECContext dataclass."""
+
+    def test_defaults(self):
+        ctx = TEECContext()
+        assert ctx.namespace == "teec.ag2"
+        assert ctx.conversation_id == ""
+        assert ctx.turn_id == 0
+        assert ctx.agent_role is None
+        assert ctx.group_chat_id is None
+        assert ctx.params_hash is None
+        assert ctx.parent_conversation_id is None
+        assert ctx.decision_id == ""
+        assert ctx.idempotency_key is None
+        assert ctx.policy_digest is None
+        assert ctx.decision_source == "default_mode"
+        assert ctx.execution_outcome is None
+        assert ctx.approval_id is None
+
+    def test_custom_values(self):
+        ctx = TEECContext(
+            conversation_id="conv-123",
+            turn_id=5,
+            agent_role="coder",
+            group_chat_id="gc-456",
+            params_hash="abc123",
+            decision_id="dec-789",
+        )
+        assert ctx.conversation_id == "conv-123"
+        assert ctx.turn_id == 5
+        assert ctx.agent_role == "coder"
+        assert ctx.group_chat_id == "gc-456"
+        assert ctx.params_hash == "abc123"
+        assert ctx.decision_id == "dec-789"
+
+
+class TestAuditEntry:
+    """Tests for AuditEntry dataclass."""
+
+    def test_required_fields(self):
+        teec = TEECContext(conversation_id="conv-1", decision_id="dec-1")
+        entry = AuditEntry(
+            correlation_id="corr-1",
+            decision_id="dec-1",
+            timestamp_ms=1000.0,
+            action="ALLOW",
+            action_kind="tool_call",
+            mode="ENFORCE",
+            agent_id="agent-1",
+            reason="Policy allows",
+            reason_codes=["POLICY_ALLOW"],
+            risk_score=0,
+            evaluation_time_ms=1.5,
+            teec=teec,
+        )
+        assert entry.correlation_id == "corr-1"
+        assert entry.decision_id == "dec-1"
+        assert entry.timestamp_ms == 1000.0
+        assert entry.action == "ALLOW"
+        assert entry.action_kind == "tool_call"
+        assert entry.mode == "ENFORCE"
+        assert entry.agent_id == "agent-1"
+        assert entry.reason == "Policy allows"
+        assert entry.reason_codes == ["POLICY_ALLOW"]
+        assert entry.risk_score == 0
+        assert entry.evaluation_time_ms == 1.5
+        assert entry.teec is teec
+
+    def test_optional_fields_defaults(self):
+        teec = TEECContext()
+        entry = AuditEntry(
+            correlation_id="corr-1",
+            decision_id="dec-1",
+            timestamp_ms=1000.0,
+            action="ALLOW",
+            action_kind="tool_call",
+            mode="OBSERVE",
+            agent_id="agent-1",
+            reason="Observe mode",
+            reason_codes=["OBSERVE_PASSTHROUGH"],
+            risk_score=0,
+            evaluation_time_ms=0.5,
+            teec=teec,
+        )
+        assert entry.tool_name is None
+        assert entry.tool_args_summary is None
+        assert entry.pii_detected == []
+        assert entry.cost_tracked == 0.0
+        assert entry.cumulative_cost == 0.0
+        assert entry.trace_id is None
+        assert entry.metadata == {}
+
+    def test_optional_fields_set(self):
+        teec = TEECContext()
+        entry = AuditEntry(
+            correlation_id="corr-1",
+            decision_id="dec-1",
+            timestamp_ms=1000.0,
+            action="DENY",
+            action_kind="tool_call",
+            mode="ENFORCE",
+            agent_id="agent-1",
+            reason="PII detected",
+            reason_codes=["PII_DETECTED"],
+            risk_score=85,
+            evaluation_time_ms=2.1,
+            teec=teec,
+            tool_name="send_email",
+            tool_args_summary={"to": "***"},
+            pii_detected=[{"type": "email", "confidence": 0.99}],
+            cost_tracked=0.003,
+            cumulative_cost=0.015,
+            trace_id="trace-abc",
+            metadata={"policy_version": "v2"},
+        )
+        assert entry.tool_name == "send_email"
+        assert entry.tool_args_summary == {"to": "***"}
+        assert entry.pii_detected == [{"type": "email", "confidence": 0.99}]
+        assert entry.cost_tracked == 0.003
+        assert entry.cumulative_cost == 0.015
+        assert entry.trace_id == "trace-abc"
+        assert entry.metadata == {"policy_version": "v2"}
+
+
+class TestDecisionReceipt:
+    """Tests for DecisionReceipt dataclass."""
+
+    def test_basic_receipt(self):
+        now = datetime.now(tz=timezone.utc)
+        receipt = DecisionReceipt(
+            decision_id="dec-1",
+            action=GovernanceAction.ALLOW,
+            issued_at=now,
+            expires_at=None,
+        )
+        assert receipt.decision_id == "dec-1"
+        assert receipt.action == GovernanceAction.ALLOW
+        assert receipt.issued_at == now
+        assert receipt.expires_at is None
+        assert receipt.revalidate_if == []
+        assert receipt.execution_outcome is None
+        assert receipt.approval_id is None
+        assert receipt.is_expired is False
+
+    def test_receipt_with_revalidation(self):
+        now = datetime.now(tz=timezone.utc)
+        condition = RevalidationCondition(
+            condition_type="cost_exceeded",
+            threshold=10.0,
+            description="Re-evaluate if cost exceeds $10",
+        )
+        receipt = DecisionReceipt(
+            decision_id="dec-2",
+            action=GovernanceAction.ALLOW,
+            issued_at=now,
+            expires_at=now,
+            revalidate_if=[condition],
+        )
+        assert len(receipt.revalidate_if) == 1
+        assert receipt.revalidate_if[0].condition_type == "cost_exceeded"
+
+
+class TestRevalidationCondition:
+    """Tests for RevalidationCondition dataclass."""
+
+    def test_creation(self):
+        cond = RevalidationCondition(
+            condition_type="time_elapsed",
+            threshold=3600,
+            description="Re-evaluate after 1 hour",
+        )
+        assert cond.condition_type == "time_elapsed"
+        assert cond.threshold == 3600
+        assert cond.description == "Re-evaluate after 1 hour"
+
+
+class TestEscalationReceipt:
+    """Tests for EscalationReceipt dataclass."""
+
+    def test_creation(self):
+        now = datetime.now(tz=timezone.utc)
+        receipt = EscalationReceipt(
+            decision_id="dec-refer-1",
+            agent_id="agent-risky",
+            tool_name="delete_database",
+            tool_arguments={"db": "production"},
+            conversation_id="conv-1",
+            turn_id=3,
+            group_chat_id="gc-1",
+            risk_score=95,
+            reason_codes=["HIGH_RISK_TOOL", "PRODUCTION_TARGET"],
+            human_readable_summary="Agent attempted to delete production database",
+            policy_context={"policy": "no_prod_delete"},
+            issued_at=now,
+            expires_at=None,
+        )
+        assert receipt.decision_id == "dec-refer-1"
+        assert receipt.agent_id == "agent-risky"
+        assert receipt.tool_name == "delete_database"
+        assert receipt.tool_arguments == {"db": "production"}
+        assert receipt.conversation_id == "conv-1"
+        assert receipt.turn_id == 3
+        assert receipt.group_chat_id == "gc-1"
+        assert receipt.risk_score == 95
+        assert receipt.reason_codes == ["HIGH_RISK_TOOL", "PRODUCTION_TARGET"]
+        assert receipt.human_readable_summary == "Agent attempted to delete production database"
+        assert receipt.policy_context == {"policy": "no_prod_delete"}
+        assert receipt.issued_at == now
+        assert receipt.expires_at is None
+
+
+class TestBudgetState:
+    """Tests for BudgetState dataclass."""
+
+    def test_defaults(self):
+        state = BudgetState(agent_id="agent-1", budget_limit=100.0)
+        assert state.agent_id == "agent-1"
+        assert state.budget_limit == 100.0
+        assert state.current_spend == 0.0
+        assert state.remaining_budget is None
+        assert state.warning_emitted is False
+
+    def test_no_limit(self):
+        state = BudgetState(agent_id="agent-2", budget_limit=None)
+        assert state.budget_limit is None
+
+    def test_with_spend(self):
+        state = BudgetState(
+            agent_id="agent-3",
+            budget_limit=50.0,
+            current_spend=30.0,
+            remaining_budget=20.0,
+            warning_emitted=True,
+        )
+        assert state.current_spend == 30.0
+        assert state.remaining_budget == 20.0
+        assert state.warning_emitted is True
+
+
+class TestSpeakerSelectionAuditEntry:
+    """Tests for SpeakerSelectionAuditEntry dataclass."""
+
+    def test_creation(self):
+        entry = SpeakerSelectionAuditEntry(
+            round_id="round-1",
+            timestamp_ms=5000.0,
+            candidates_evaluated=[
+                {"agent_id": "a1", "decision": "ALLOW", "reason": "policy_allow"},
+                {"agent_id": "a2", "decision": "DENY", "reason": "AGENT_FROZEN"},
+            ],
+            selected_speaker="a1",
+            reason_codes=["POLICY_ALLOW"],
+            group_chat_id="gc-1",
+        )
+        assert entry.round_id == "round-1"
+        assert entry.timestamp_ms == 5000.0
+        assert len(entry.candidates_evaluated) == 2
+        assert entry.selected_speaker == "a1"
+        assert entry.reason_codes == ["POLICY_ALLOW"]
+        assert entry.group_chat_id == "gc-1"
+
+    def test_no_speaker_selected(self):
+        entry = SpeakerSelectionAuditEntry(
+            round_id="round-2",
+            timestamp_ms=6000.0,
+            candidates_evaluated=[
+                {"agent_id": "a1", "decision": "DENY", "reason": "AGENT_FROZEN"},
+            ],
+            selected_speaker=None,
+            reason_codes=["ALL_SPEAKERS_DENIED"],
+            group_chat_id="gc-1",
+        )
+        assert entry.selected_speaker is None
+        assert "ALL_SPEAKERS_DENIED" in entry.reason_codes
+
+
+class TestDenialMessage:
+    """Tests for DenialMessage dataclass and to_reply_string method."""
+
+    def test_creation(self):
+        msg = DenialMessage(
+            tool_name="send_email",
+            action="DENY",
+            reason="PII in arguments",
+            risk_score=80,
+            reason_codes=["PII_DETECTED", "SENSITIVE_DATA"],
+            correlation_id="corr-123",
+            decision_id="dec-456",
+        )
+        assert msg.tool_name == "send_email"
+        assert msg.action == "DENY"
+        assert msg.reason == "PII in arguments"
+        assert msg.risk_score == 80
+        assert msg.reason_codes == ["PII_DETECTED", "SENSITIVE_DATA"]
+        assert msg.correlation_id == "corr-123"
+        assert msg.decision_id == "dec-456"
+
+    def test_to_reply_string_format(self):
+        msg = DenialMessage(
+            tool_name="delete_file",
+            action="DENY",
+            reason="High risk operation",
+            risk_score=95,
+            reason_codes=["HIGH_RISK", "PRODUCTION"],
+            correlation_id="corr-abc",
+            decision_id="dec-xyz",
+        )
+        result = msg.to_reply_string()
+        assert result.startswith("[GOVERNANCE DENIAL]")
+        assert "Tool: delete_file" in result
+        assert "Action: DENY" in result
+        assert "Risk: 95" in result
+        assert "Reason: High risk operation" in result
+        assert "Codes: HIGH_RISK,PRODUCTION" in result
+        assert "Decision: dec-xyz" in result
+
+    def test_to_reply_string_single_code(self):
+        msg = DenialMessage(
+            tool_name="read_db",
+            action="DENY",
+            reason="Unauthorized",
+            risk_score=50,
+            reason_codes=["UNAUTHORIZED"],
+            correlation_id="corr-1",
+            decision_id="dec-1",
+        )
+        result = msg.to_reply_string()
+        assert "Codes: UNAUTHORIZED" in result
+
+    def test_to_reply_string_parseable(self):
+        """Verify the denial message is parseable by splitting on pipe delimiter."""
+        msg = DenialMessage(
+            tool_name="execute_sql",
+            action="DENY",
+            reason="SQL injection risk",
+            risk_score=90,
+            reason_codes=["SQL_INJECTION", "UNTRUSTED_INPUT"],
+            correlation_id="corr-parse",
+            decision_id="dec-parse",
+        )
+        result = msg.to_reply_string()
+        parts = result.split(" | ")
+        assert len(parts) == 6
+        # Each part should be parseable to extract its value
+        assert parts[0].startswith("[GOVERNANCE DENIAL] Tool: ")
+        assert "execute_sql" in parts[0]
+        assert parts[1].startswith("Action: ")
+        assert parts[2].startswith("Risk: ")
+        assert parts[3].startswith("Reason: ")
+        assert parts[4].startswith("Codes: ")
+        assert parts[5].startswith("Decision: ")


### PR DESCRIPTION
Implements deterministic governance for AG2 (AutoGen fork) via register_reply interceptor mechanism. Features:

- TealTigerGuard: register_reply interceptor with observe/monitor/enforce modes
- TealTigerAuditAgent: ConversableAgent subclass with built-in governance
- GovernedGroupChat: governance-enforced speaker selection
- Per-agent freeze/unfreeze kill switch (mode-independent)
- Per-agent budget enforcement with 80% warning threshold
- Decision receipt lifecycle (expiry + revalidation conditions)
- REFER decision state with escalation receipts
- Inter-agent message governance
- TEEC namespace (teec.ag2) with full correlation
- PII detection in tool call arguments
- JSONL audit trail export
- Retry idempotency via decision_id caching
- 28 property-based tests (Hypothesis)
- 22 integration tests
- 3 example scripts (zero-config, policy enforcement, governed groupchat)

Zero LLM in the governance path. All evaluation is deterministic, targeting sub-5ms latency with in-process evaluation.

Also includes:
- v1.4 adapter parity requirements (TEEC v2.1 upgrade)
- Haystack adoption strategy and GitHub issues template

Refs: ag2ai/ag2#2942

## Summary

- Brief summary of change:

## Linked Issue

- Related issue(s): 

## Testing

- [ ] Tests run:
- [ ] Test output:

## Change Management Check

Please confirm these checklist items before requesting review:

- [ ] Scope is clearly described and out-of-scope items are listed.
- [ ] Required tests were run and results are included in this PR body.
- [ ] PR is linked to an issue or clearly justified as triage/housekeeping.
- [ ] Security impact has been considered where applicable.
- [ ] Reviewer requirements (including maintainer review for sensitive changes) are met.
- [ ] Change management process reviewed: [docs/security/change-management.md](docs/security/change-management.md)

## PR Body Notes

- [ ] If this is a fast-follow/hotfix, explain urgency and blast radius.
- [ ] If behavior changed for users, update relevant docs/changelog references.
