### PR TITLE
feat(ci): add Haystack pipeline security scan GitHub Action

### DIFF
--- a/integrations/cicd/github-action-haystack/README.md
+++ b/integrations/cicd/github-action-haystack/README.md
@@ -1,0 +1,99 @@
+# TealTiger Haystack Pipeline Security Scan — GitHub Action
+
+AST-scans Haystack pipeline Python files in pull requests for un-guarded LLM generators
+and unbounded agent loops that can cause runaway API costs.
+Findings are posted as a PR comment with specific fix suggestions.
+
+## Quickstart
+
+```yaml
+- uses: actions/checkout@v4
+- uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
+```
+
+The action scans all Python files in the repository, detects Haystack pipelines
+that lack TealTiger governance, and posts a comment on the PR if any warnings are found.
+
+## What it detects
+
+| Check | What it finds | Default |
+|---|---|---|
+| `unguarded-generator` | `OpenAIGenerator`, `AnthropicChatGenerator`, or any Haystack LLM generator used without a TealTiger guard (`TealGovernance`, `BudgetManager`, `PIIDetectionGuardrail`, ...) | enabled |
+| `agent-loop` | `while True:` loops that call `pipeline.run()` without a budget guard or circuit breaker — a common source of runaway API spend | enabled |
+
+### Example PR comment
+
+> **Potential unguarded LLM generator** at line 42: `OpenAIGenerator` is used
+> without a TealTiger governance component. This pipeline has no cost cap, PII protection,
+> or prompt-injection defence.
+>
+> **Fix:** Wrap `OpenAIGenerator` with a `TealGovernance` component, or add `BudgetManager`
+> + `PIIDetectionGuardrail` before the generator.
+> See recipe: [examples/haystack-governance/main.py](../../../examples/haystack-governance/main.py)
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `path` | `.` | File or directory to scan |
+| `checks` | `all` | Comma-separated checks to run (`unguarded-generator`, `agent-loop`), or `all` |
+| `fail-on-warning` | `false` | Exit code 1 when warnings are found |
+| `post-comment` | `true` | Post findings as a PR comment (requires `pull-requests: write` permission) |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `warnings` | Number of warnings found (`0` means clean) |
+| `report` | JSON array of all findings (file, line, check, message, fix) |
+
+## Full example workflow
+
+```yaml
+name: TealTiger Haystack Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['**.py']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  haystack-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
+        id: scan
+        with:
+          path: '.'
+          checks: 'all'
+          fail-on-warning: 'false'
+
+      - run: echo "Warnings found ${{ steps.scan.outputs.warnings }}"
+```
+
+## Disabling a specific check
+
+```yaml
+- uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
+  with:
+    checks: 'unguarded-generator'   # skip agent-loop
+```
+
+## Running locally
+
+```bash
+python integrations/cicd/github-action-haystack/scan.py --path ./src
+```
+
+## Running tests
+
+```bash
+cd integrations/cicd/github-action-haystack
+python -m pytest tests/ -v
+```

--- a/integrations/cicd/github-action-haystack/README.md
+++ b/integrations/cicd/github-action-haystack/README.md
@@ -7,7 +7,7 @@ Findings are posted as a PR comment with specific fix suggestions.
 ## Quickstart
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 - uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
 ```
 
@@ -65,7 +65,7 @@ jobs:
   haystack-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
         id: scan
@@ -88,7 +88,14 @@ jobs:
 ## Running locally
 
 ```bash
+# Human-readable (default)
 python integrations/cicd/github-action-haystack/scan.py --path ./src
+
+# Machine-parseable JSON
+python integrations/cicd/github-action-haystack/scan.py --path ./src --output-format json
+
+# SARIF for GitHub code scanning upload
+python integrations/cicd/github-action-haystack/scan.py --path ./src --output-format sarif
 ```
 
 ## Running tests

--- a/integrations/cicd/github-action-haystack/action.yml
+++ b/integrations/cicd/github-action-haystack/action.yml
@@ -1,0 +1,61 @@
+name: 'TealTiger Haystack Pipeline Security Scan'
+description: >
+  AST-scans Haystack pipeline Python files in PRs for un-guarded LLM
+  generators and unbounded agent loops that can incur runaway API costs.
+  Posts actionable warnings as PR comments.
+author: 'TealTiger Team'
+
+branding:
+  icon: 'shield'
+  color: 'teal'
+
+inputs:
+  path:
+    description: 'File or directory to scan for Haystack pipeline files'
+    required: false
+    default: '.'
+  checks:
+    description: >
+      Comma-separated list of checks to run, or "all".
+      Available: unguarded-generator, agent-loop
+    required: false
+    default: 'all'
+  fail-on-warning:
+    description: 'Exit with code 1 when any warnings are found'
+    required: false
+    default: 'false'
+  post-comment:
+    description: 'Post findings as a PR comment (only fires on pull_request events)'
+    required: false
+    default: 'true'
+
+outputs:
+  warnings:
+    description: 'Number of warnings found'
+    value: ${{ steps.scan.outputs.warnings }}
+  report:
+    description: 'JSON array of all findings (file, line, check, message, fix)'
+    value: ${{ steps.scan.outputs.report }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.10'
+
+    - name: Run Haystack pipeline security scan
+      id: scan
+      shell: bash
+      run: |
+        python "${{ github.action_path }}/scan.py" \
+          --path "${{ inputs.path }}" \
+          --checks "${{ inputs.checks }}" \
+          --fail-on-warning "${{ inputs.fail-on-warning }}" \
+          --post-comment "${{ inputs.post-comment }}" \
+          --github-token "${{ github.token }}"
+      env:
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/integrations/cicd/github-action-haystack/examples/haystack-pipeline-scan.yml
+++ b/integrations/cicd/github-action-haystack/examples/haystack-pipeline-scan.yml
@@ -1,0 +1,41 @@
+# TealTiger Haystack Pipeline Security Scan — Example Workflow
+#
+# Scans every Python file in the repository for Haystack pipelines that lack
+# TealTiger governance guards. Runs on every pull request.
+#
+# Usage:
+#   Copy this file to .github/workflows/haystack-security-scan.yml in your repo.
+#   No additional configuration is required for a standard Haystack project.
+
+name: TealTiger Haystack Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.py'
+
+permissions:
+  contents: read
+  pull-requests: write  # required for posting PR comments
+
+jobs:
+  haystack-scan:
+    name: Haystack Pipeline Security Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run TealTiger Haystack Scan
+        id: scan
+        uses: agentguard-ai/tealtiger/integrations/cicd/github-action-haystack@main
+        with:
+          path: '.'
+          checks: 'all'
+          fail-on-warning: 'false'
+          post-comment: 'true'
+
+      - name: Print warning count
+        run: echo "Warnings found ${{ steps.scan.outputs.warnings }}"

--- a/integrations/cicd/github-action-haystack/scan.py
+++ b/integrations/cicd/github-action-haystack/scan.py
@@ -187,6 +187,12 @@ def _check_agent_loop(
     """
     Warn when pipeline.run() is called inside an unbounded while-True loop
     without a TealTiger budget guard or circuit breaker in the same module.
+
+    Design note: a bare `break` statement inside the loop does not suppress this
+    warning because the check verifies governance intent, not control flow. A
+    loop that exits via an arbitrary condition still has no cost cap if it runs
+    for many iterations before hitting that condition. Only an explicit TealTiger
+    budget guard in module scope suppresses the warning.
     """
     has_budget_guard = bool(names & _BUDGET_GUARDS)
     findings: list[Finding] = []
@@ -333,6 +339,55 @@ def _parse_checks(raw: str) -> set[str]:
     return selected & all_checks
 
 
+def _format_sarif(findings: list[Finding]) -> str:
+    results = []
+    for f in findings:
+        results.append(
+            {
+                "ruleId": f.check,
+                "message": {"text": f.message},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": f.file},
+                            "region": {"startLine": f.line},
+                        }
+                    }
+                ],
+            }
+        )
+    sarif = {
+        "version": "2.1.0",
+        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "tealtiger-haystack-scan",
+                        "version": "1.0.0",
+                        "rules": [
+                            {
+                                "id": "unguarded-generator",
+                                "shortDescription": {
+                                    "text": "Haystack LLM generator used without TealTiger governance"
+                                },
+                            },
+                            {
+                                "id": "agent-loop",
+                                "shortDescription": {
+                                    "text": "Unbounded agent loop without budget guard"
+                                },
+                            },
+                        ],
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(sarif, indent=2)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="TealTiger Haystack Pipeline Security Scanner"
@@ -352,6 +407,12 @@ def main() -> None:
         "--post-comment",
         default="true",
         help="Post findings as a PR comment (requires GITHUB_TOKEN)",
+    )
+    parser.add_argument(
+        "--output-format",
+        default="text",
+        choices=["text", "json", "sarif"],
+        help="Output format for local runs: text (default), json, or sarif",
     )
     parser.add_argument("--github-token", default="", help="GitHub token for PR comments")
     args = parser.parse_args()
@@ -378,17 +439,37 @@ def main() -> None:
             fh.write(f"warnings={len(findings)}\n")
             fh.write(f"report={report_json}\n")
 
-    # Console summary
-    if not findings:
-        print("No unguarded Haystack pipeline components detected.")
+    # Console output — format selected by --output-format
+    if args.output_format == "json":
+        print(
+            json.dumps(
+                [
+                    {
+                        "file": f.file,
+                        "line": f.line,
+                        "check": f.check,
+                        "message": f.message,
+                        "fix": f.fix,
+                    }
+                    for f in findings
+                ],
+                indent=2,
+            )
+        )
+    elif args.output_format == "sarif":
+        print(_format_sarif(findings))
     else:
-        print(f"{len(findings)} warning(s) found:\n")
-        for f in findings:
-            print(f"  [{f.check}] {f.file}:{f.line}")
-            print(f"    {f.message}")
-            print(f"    Fix: {f.fix}\n")
+        if not findings:
+            print("No unguarded Haystack pipeline components detected.")
+        else:
+            print(f"{len(findings)} warning(s) found:\n")
+            for f in findings:
+                print(f"  [{f.check}] {f.file}:{f.line}")
+                print(f"    {f.message}")
+                print(f"    Fix: {f.fix}\n")
 
-    # Post PR comment if running in a pull_request event with findings
+    # Post PR comment if running in a pull_request event with findings.
+    # argparse converts --post-comment to args.post_comment (hyphens become underscores).
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")
     if (
         findings

--- a/integrations/cicd/github-action-haystack/scan.py
+++ b/integrations/cicd/github-action-haystack/scan.py
@@ -1,0 +1,406 @@
+"""
+TealTiger Haystack Pipeline Security Scanner
+
+AST-analyses Python files for Haystack pipelines that lack TealTiger governance.
+Detects:
+  - unguarded-generator: LLM generators used without TealTiger cost/PII/injection guards
+  - agent-loop: pipeline.run() called inside an unbounded loop without a budget guard
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Haystack LLM generator class names (v2 official + common third-party integrations)
+_HAYSTACK_GENERATORS = frozenset(
+    {
+        "OpenAIGenerator",
+        "OpenAIChatGenerator",
+        "AnthropicChatGenerator",
+        "GoogleAIGeminiChatGenerator",
+        "GoogleAIGeminiGenerator",
+        "GroqChatGenerator",
+        "TogetherAIChatGenerator",
+        "HuggingFaceLocalGenerator",
+        "HuggingFaceAPIChatGenerator",
+        "AmazonBedrockChatGenerator",
+        "MistralChatGenerator",
+        "CohereGenerator",
+        "CohereChatGenerator",
+        "DeepSeekChatGenerator",
+    }
+)
+
+# TealTiger components/classes that make a pipeline "governed"
+_TEALTIGER_GUARDS = frozenset(
+    {
+        "TealGovernance",
+        "TealTigerGuardComponent",
+        "TealTigerGovernanceComponent",
+        "TealTigerCircuitBreaker",
+        "TealTigerBudgetGuard",
+        "BudgetManager",
+        "PIIDetectionGuardrail",
+        "TealEngine",
+    }
+)
+
+# Budget/circuit-breaker classes sufficient to protect an agent loop
+_BUDGET_GUARDS = frozenset(
+    {
+        "BudgetManager",
+        "TealTigerCircuitBreaker",
+        "TealTigerBudgetGuard",
+        "TealTigerGovernanceComponent",
+    }
+)
+
+_RECIPE_URL = (
+    "https://github.com/agentguard-ai/tealtiger/blob/main"
+    "/examples/haystack-governance/main.py"
+)
+
+
+@dataclass
+class Finding:
+    file: str
+    line: int
+    check: str
+    message: str
+    fix: str
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _imported_and_referenced_names(tree: ast.Module) -> set[str]:
+    """Return all names imported or referenced anywhere in the module."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[-1])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def _is_haystack_file(tree: ast.Module) -> bool:
+    """Return True only if the file imports from haystack."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and "haystack" in node.module:
+            return True
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if "haystack" in alias.name:
+                    return True
+    return False
+
+
+def _call_name(node: ast.Call) -> Optional[str]:
+    """Return the simple class/function name from a Call node, if determinable."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check: unguarded-generator
+# ---------------------------------------------------------------------------
+
+
+def _check_unguarded_generator(
+    path: str, tree: ast.Module, names: set[str]
+) -> list[Finding]:
+    """
+    Warn when a Haystack LLM generator is instantiated in a file that contains
+    no TealTiger governance component.
+    """
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if name and name in _HAYSTACK_GENERATORS:
+                found.append((name, node.lineno))
+
+    if not found:
+        return []
+    if names & _TEALTIGER_GUARDS:
+        return []
+
+    return [
+        Finding(
+            file=path,
+            line=lineno,
+            check="unguarded-generator",
+            message=(
+                f"Potential unguarded LLM generator at line {lineno}: "
+                f"`{gen_name}` is used without a TealTiger governance component. "
+                f"This pipeline has no cost cap, PII protection, or prompt-injection defence."
+            ),
+            fix=(
+                f"Wrap `{gen_name}` with a `TealGovernance` component, or add "
+                f"`BudgetManager` + `PIIDetectionGuardrail` before the generator. "
+                f"See recipe: {_RECIPE_URL}"
+            ),
+        )
+        for gen_name, lineno in found
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Check: agent-loop
+# ---------------------------------------------------------------------------
+
+
+def _loop_contains_pipeline_run(loop_node: ast.stmt) -> bool:
+    """Return True if any statement inside the loop calls <something>.run()."""
+    for child in ast.walk(loop_node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Attribute) and func.attr == "run":
+                return True
+    return False
+
+
+def _check_agent_loop(
+    path: str, tree: ast.Module, names: set[str]
+) -> list[Finding]:
+    """
+    Warn when pipeline.run() is called inside an unbounded while-True loop
+    without a TealTiger budget guard or circuit breaker in the same module.
+    """
+    has_budget_guard = bool(names & _BUDGET_GUARDS)
+    findings: list[Finding] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.While):
+            continue
+        # Only flag `while True:` (literal constant True)
+        if not (isinstance(node.test, ast.Constant) and node.test.value is True):
+            continue
+        if not _loop_contains_pipeline_run(node):
+            continue
+        if has_budget_guard:
+            continue
+        findings.append(
+            Finding(
+                file=path,
+                line=node.lineno,
+                check="agent-loop",
+                message=(
+                    f"Potential runaway cost loop at line {node.lineno}: "
+                    f"an unbounded `while True:` loop calls `pipeline.run()` with no "
+                    f"TealTiger budget guard or circuit breaker. "
+                    f"This can incur unlimited API spend."
+                ),
+                fix=(
+                    "Add `BudgetManager(limit=0.50)` and check it before each iteration, "
+                    "or wrap the agent with `TealTigerCircuitBreaker(max_cost_usd=0.50)`. "
+                    f"See recipe: {_RECIPE_URL}"
+                ),
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# File / directory scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_file(path: str, checks: set[str]) -> list[Finding]:
+    try:
+        source = Path(path).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=path)
+    except (OSError, SyntaxError):
+        return []
+
+    if not _is_haystack_file(tree):
+        return []
+
+    names = _imported_and_referenced_names(tree)
+    findings: list[Finding] = []
+
+    if "unguarded-generator" in checks:
+        findings.extend(_check_unguarded_generator(path, tree, names))
+    if "agent-loop" in checks:
+        findings.extend(_check_agent_loop(path, tree, names))
+
+    return findings
+
+
+def scan_path(root: str, checks: set[str]) -> list[Finding]:
+    p = Path(root)
+    if p.is_file():
+        return scan_file(str(p), checks)
+    return [
+        finding
+        for py_file in sorted(p.rglob("*.py"))
+        for finding in scan_file(str(py_file), checks)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GitHub PR comment
+# ---------------------------------------------------------------------------
+
+
+def _build_pr_comment(findings: list[Finding]) -> str:
+    lines = [
+        "## TealTiger Haystack Security Scan",
+        "",
+        f"Found **{len(findings)} warning(s)** in Haystack pipeline files.",
+        "",
+    ]
+    for f in findings:
+        lines += [
+            f"### `{f.file}` — line {f.line}",
+            "",
+            f.message,
+            "",
+            f"**Fix:** {f.fix}",
+            "",
+            "---",
+            "",
+        ]
+    lines.append(
+        "_Powered by [TealTiger](https://github.com/agentguard-ai/tealtiger). "
+        "Disable a check with `checks: agent-loop` to skip `unguarded-generator`._"
+    )
+    return "\n".join(lines)
+
+
+def _post_pr_comment(body: str, token: str) -> None:
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    if not repo or not pr_number:
+        print("::warning::Skipping PR comment — GITHUB_REPOSITORY or PR_NUMBER not set.")
+        return
+
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    payload = json.dumps({"body": body}).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status not in (200, 201):
+                print(f"::warning::PR comment returned HTTP {resp.status}")
+    except Exception as exc:
+        print(f"::warning::Could not post PR comment: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_checks(raw: str) -> set[str]:
+    all_checks = {"unguarded-generator", "agent-loop"}
+    if raw.strip().lower() == "all":
+        return all_checks
+    selected = {c.strip() for c in raw.split(",") if c.strip()}
+    unknown = selected - all_checks
+    for u in unknown:
+        print(f"::warning::Unknown check '{u}' will be ignored.")
+    return selected & all_checks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="TealTiger Haystack Pipeline Security Scanner"
+    )
+    parser.add_argument("--path", default=".", help="File or directory to scan")
+    parser.add_argument(
+        "--checks",
+        default="all",
+        help="Comma-separated checks (unguarded-generator,agent-loop) or 'all'",
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        default="false",
+        help="Exit 1 if any warnings are found",
+    )
+    parser.add_argument(
+        "--post-comment",
+        default="true",
+        help="Post findings as a PR comment (requires GITHUB_TOKEN)",
+    )
+    parser.add_argument("--github-token", default="", help="GitHub token for PR comments")
+    args = parser.parse_args()
+
+    checks = _parse_checks(args.checks)
+    findings = scan_path(args.path, checks)
+
+    # Write GitHub Actions outputs
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        report_json = json.dumps(
+            [
+                {
+                    "file": f.file,
+                    "line": f.line,
+                    "check": f.check,
+                    "message": f.message,
+                    "fix": f.fix,
+                }
+                for f in findings
+            ]
+        )
+        with open(github_output, "a") as fh:
+            fh.write(f"warnings={len(findings)}\n")
+            fh.write(f"report={report_json}\n")
+
+    # Console summary
+    if not findings:
+        print("No unguarded Haystack pipeline components detected.")
+    else:
+        print(f"{len(findings)} warning(s) found:\n")
+        for f in findings:
+            print(f"  [{f.check}] {f.file}:{f.line}")
+            print(f"    {f.message}")
+            print(f"    Fix: {f.fix}\n")
+
+    # Post PR comment if running in a pull_request event with findings
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if (
+        findings
+        and args.post_comment.lower() == "true"
+        and event_name == "pull_request"
+        and args.github_token
+    ):
+        _post_pr_comment(_build_pr_comment(findings), args.github_token)
+
+    if args.fail_on_warning.lower() == "true" and findings:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/cicd/github-action-haystack/tests/test_scan.py
+++ b/integrations/cicd/github-action-haystack/tests/test_scan.py
@@ -1,0 +1,298 @@
+"""Unit tests for the TealTiger Haystack Pipeline Security Scanner."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+import sys
+from pathlib import Path
+
+# Allow running tests without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scan import (  # noqa: E402
+    Finding,
+    _check_agent_loop,
+    _check_unguarded_generator,
+    _imported_and_referenced_names,
+    _is_haystack_file,
+    scan_file,
+)
+
+
+def _parse(source: str) -> tuple[ast.Module, set[str]]:
+    source = textwrap.dedent(source)
+    tree = ast.parse(source)
+    return tree, _imported_and_referenced_names(tree)
+
+
+# ---------------------------------------------------------------------------
+# _is_haystack_file
+# ---------------------------------------------------------------------------
+
+
+def test_detects_haystack_import():
+    tree, _ = _parse(
+        """
+        from haystack import Pipeline, component
+        from haystack.components.generators.openai import OpenAIGenerator
+        """
+    )
+    assert _is_haystack_file(tree)
+
+
+def test_ignores_non_haystack_file():
+    tree, _ = _parse(
+        """
+        import os
+        from pathlib import Path
+        """
+    )
+    assert not _is_haystack_file(tree)
+
+
+# ---------------------------------------------------------------------------
+# unguarded-generator check
+# ---------------------------------------------------------------------------
+
+
+def test_flags_unguarded_openai_generator():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline, component
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        pipe.run({"llm": {"prompt": "Hello"}})
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    assert len(findings) == 1
+    assert findings[0].check == "unguarded-generator"
+    assert "OpenAIGenerator" in findings[0].message
+
+
+def test_no_false_positive_when_tealtiger_guard_present():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline, component
+        from haystack.components.generators.openai import OpenAIGenerator
+        from tealtiger import BudgetManager, PIIDetectionGuardrail
+
+        budget = BudgetManager(limit=0.50)
+        pii = PIIDetectionGuardrail({})
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    assert findings == []
+
+
+def test_no_false_positive_with_teal_governance():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline, component
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        class TealGovernance:
+            pass
+
+        pipe = Pipeline()
+        pipe.add_component("guard", TealGovernance())
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    assert findings == []
+
+
+def test_no_false_positive_when_no_generator():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+
+        pipe = Pipeline()
+        pipe.add_component("retriever", InMemoryBM25Retriever(document_store=None))
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    assert findings == []
+
+
+def test_flags_multiple_generators():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+        from haystack_integrations.components.generators.anthropic import AnthropicChatGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm1", OpenAIGenerator(model="gpt-4o"))
+        pipe.add_component("llm2", AnthropicChatGenerator(model="claude-opus-4-8"))
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    assert len(findings) == 2
+
+
+def test_no_false_positive_plain_rag_pipeline():
+    """A standard RAG pipeline (retriever + generator) without governance should warn."""
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+        from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+        from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+        store = InMemoryDocumentStore()
+        pipe = Pipeline()
+        pipe.add_component("retriever", InMemoryBM25Retriever(document_store=store))
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        pipe.connect("retriever.documents", "llm.documents")
+        result = pipe.run({"retriever": {"query": "What is AI?"}})
+        """
+    )
+    findings = _check_unguarded_generator("<test>", tree, names)
+    # Standard RAG pipelines ARE warned — they lack governance
+    assert len(findings) == 1
+    assert findings[0].check == "unguarded-generator"
+
+
+# ---------------------------------------------------------------------------
+# agent-loop check
+# ---------------------------------------------------------------------------
+
+
+def test_flags_while_true_with_pipeline_run_no_guard():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+
+        while True:
+            result = pipe.run({"llm": {"prompt": "Next step"}})
+        """
+    )
+    findings = _check_agent_loop("<test>", tree, names)
+    assert len(findings) == 1
+    assert findings[0].check == "agent-loop"
+
+
+def test_no_false_positive_single_pipeline_run():
+    """A single pipe.run() outside any loop must not trigger agent-loop."""
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        result = pipe.run({"llm": {"prompt": "Hello"}})
+        """
+    )
+    findings = _check_agent_loop("<test>", tree, names)
+    assert findings == []
+
+
+def test_no_false_positive_while_true_with_budget_guard():
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+        from tealtiger import BudgetManager
+
+        budget = BudgetManager(limit=0.50)
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+
+        while True:
+            ok = budget.check()
+            if not ok:
+                break
+            result = pipe.run({"llm": {"prompt": "Next step"}})
+        """
+    )
+    findings = _check_agent_loop("<test>", tree, names)
+    assert findings == []
+
+
+def test_no_false_positive_bounded_for_loop():
+    """A for-loop (not while True) must not trigger agent-loop."""
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+
+        for query in ["a", "b", "c"]:
+            result = pipe.run({"llm": {"prompt": query}})
+        """
+    )
+    findings = _check_agent_loop("<test>", tree, names)
+    assert findings == []
+
+
+def test_no_false_positive_while_condition():
+    """while some_condition: (not True) must not trigger agent-loop."""
+    tree, names = _parse(
+        """
+        from haystack import Pipeline
+        from haystack.components.generators.openai import OpenAIGenerator
+
+        pipe = Pipeline()
+        pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+        done = False
+        while not done:
+            result = pipe.run({"llm": {"prompt": "Step"}})
+            done = True
+        """
+    )
+    findings = _check_agent_loop("<test>", tree, names)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# scan_file integration
+# ---------------------------------------------------------------------------
+
+
+def test_scan_file_non_haystack_returns_empty(tmp_path: Path):
+    f = tmp_path / "utils.py"
+    f.write_text("import os\n\ndef helper():\n    return 42\n")
+    assert scan_file(str(f), {"unguarded-generator", "agent-loop"}) == []
+
+
+def test_scan_file_syntax_error_returns_empty(tmp_path: Path):
+    f = tmp_path / "broken.py"
+    f.write_text("def broken(\n")
+    assert scan_file(str(f), {"unguarded-generator", "agent-loop"}) == []
+
+
+def test_scan_file_respects_disabled_checks(tmp_path: Path):
+    f = tmp_path / "pipeline.py"
+    f.write_text(
+        textwrap.dedent(
+            """
+            from haystack import Pipeline
+            from haystack.components.generators.openai import OpenAIGenerator
+
+            pipe = Pipeline()
+            pipe.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+            while True:
+                pipe.run({"llm": {"prompt": "x"}})
+            """
+        )
+    )
+    # Only run agent-loop check, not unguarded-generator
+    findings = scan_file(str(f), {"agent-loop"})
+    checks_seen = {fw.check for fw in findings}
+    assert "unguarded-generator" not in checks_seen
+    assert "agent-loop" in checks_seen


### PR DESCRIPTION
## Summary

- Adds `integrations/cicd/github-action-haystack/` — a composite GitHub Action that AST-scans Haystack pipeline Python files in pull requests for governance gaps
- Detects `OpenAIGenerator` / any Haystack LLM generator used without a TealTiger cost, PII, or injection guard (`unguarded-generator` check)
- Detects unbounded `while True:` loops calling `pipeline.run()` without a `BudgetManager` or circuit breaker (`agent-loop` check)
- Posts a PR comment identifying the file and line with a concrete fix suggestion
- 16 unit tests covering true positives, false-positive guards, per-check filtering, syntax errors, and non-Haystack files

## Files

| File | Purpose |
|---|---|
| `action.yml` | Composite action definition (inputs, outputs, steps) |
| `scan.py` | AST scanner — Python 3.9+ compatible, zero third-party dependencies |
| `examples/haystack-pipeline-scan.yml` | Ready-to-copy workflow YAML |
| `tests/test_scan.py` | 16 unit tests |
| `README.md` | Usage guide with input/output tables and full workflow example |

## Test plan

- [ ] `python3 -m pytest integrations/cicd/github-action-haystack/tests/ -v` — 16 passed
- [ ] Scanner returns no findings on `examples/haystack-governance/main.py` (governed pipeline)
- [ ] Scanner flags a bare `OpenAIGenerator` with no TealTiger guard
- [ ] Scanner flags a `while True: pipeline.run()` with no budget guard
- [ ] Workflow example in `examples/` runs to completion on a test repository

Closes #287