### PR TITLE
feat(haystack): add governed-by badge to haystack package and adoption guide

### DIFF
--- a/docs/community/badge-adoption.md
+++ b/docs/community/badge-adoption.md
@@ -1,0 +1,81 @@
+# "Governed by TealTiger" Badge
+
+Show users and collaborators that your Haystack pipeline enforces deterministic
+governance with TealTiger: cost caps, PII redaction, prompt-injection defence, and
+structured audit evidence.
+
+## Quick copy-paste
+
+### Shields.io badge (recommended)
+
+```markdown
+[![Governed by TealTiger](https://img.shields.io/badge/Governed%20by-TealTiger-0f766e?style=flat)](https://github.com/agentguard-ai/tealtiger)
+```
+
+Renders as:
+
+[![Governed by TealTiger](https://img.shields.io/badge/Governed%20by-TealTiger-0f766e?style=flat)](https://github.com/agentguard-ai/tealtiger)
+
+### SVG badge (self-hosted, no external dependency)
+
+Copy [`assets/badges/governed-by-tealtiger.svg`](../../assets/badges/governed-by-tealtiger.svg)
+into your repository and reference it directly:
+
+```markdown
+[![Governed by TealTiger](path/to/governed-by-tealtiger.svg)](https://github.com/agentguard-ai/tealtiger)
+```
+
+A dark-background variant is available at
+[`assets/badges/governed-by-tealtiger-dark.svg`](../../assets/badges/governed-by-tealtiger-dark.svg).
+
+## Where to place it
+
+Add the badge to your `README.md` alongside your existing CI and quality badges,
+before the first section heading:
+
+```markdown
+[![Governed by TealTiger](https://img.shields.io/badge/Governed%20by-TealTiger-0f766e?style=flat)](https://github.com/agentguard-ai/tealtiger)
+```
+
+## Outreach template
+
+Use this message when asking Haystack open-source maintainers to adopt the badge.
+Adjust the project name and governance component references as appropriate.
+
+---
+
+**Subject:** Adding a "Governed by TealTiger" badge to {project-name}
+
+Hi {maintainer-name},
+
+I noticed that {project-name} uses Haystack pipelines involving LLM generators.
+We recently integrated [TealTiger](https://github.com/agentguard-ai/tealtiger)
+to add deterministic governance — cost caps, PII redaction, and prompt-injection
+defence — without touching the pipeline's output logic.
+
+If you are interested in adding similar governance to {project-name}, the
+`tealtiger-haystack` package is a drop-in Haystack component:
+
+```python
+pip install tealtiger-haystack
+```
+
+We would also appreciate it if you would add the "Governed by TealTiger" badge
+to signal to contributors that the pipeline's security posture is explicit and
+auditable:
+
+```markdown
+[![Governed by TealTiger](https://img.shields.io/badge/Governed%20by-TealTiger-0f766e?style=flat)](https://github.com/agentguard-ai/tealtiger)
+```
+
+Happy to answer any questions or open a draft PR if that is easier.
+
+{your-name}
+
+---
+
+## Badge design
+
+The badge uses TealTiger's brand colour (`#0f766e`) and is sized to align with
+standard shields.io badges at 28 px height. The SVG variant includes a subtle
+gradient overlay for compatibility with both light and dark GitHub themes.

--- a/packages/haystack-tealtiger/README.md
+++ b/packages/haystack-tealtiger/README.md
@@ -8,6 +8,7 @@ Deterministic governance component for [Haystack](https://haystack.deepset.ai/) 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/tealtiger-haystack)](https://pypi.org/project/tealtiger-haystack/)
 [![Coverage](https://codecov.io/gh/agentguard-ai/tealtiger/branch/main/graph/badge.svg?flag=haystack-tealtiger)](https://app.codecov.io/gh/agentguard-ai/tealtiger?flags%5B0%5D=haystack-tealtiger)
+[![Governed by TealTiger](https://img.shields.io/badge/Governed%20by-TealTiger-0f766e?style=flat)](https://github.com/agentguard-ai/tealtiger)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Adds the `Governed by TealTiger` shields.io badge to `packages/haystack-tealtiger/README.md` alongside existing PyPI, license, and coverage badges
- Creates `docs/community/badge-adoption.md` with copy-paste snippets for both the shields.io URL and the self-hosted SVG variant, placement guidance, and an outreach template for asking Haystack open-source maintainers to adopt the badge

## Files

| File | Change |
|---|---|
| `packages/haystack-tealtiger/README.md` | Added shields.io badge line |
| `docs/community/badge-adoption.md` | New — badge snippets + outreach template |

## Test plan

- [ ] Badge renders correctly in the haystack-tealtiger README on GitHub
- [ ] Shields.io URL resolves and displays teal colour (`#0f766e`)
- [ ] Links correctly to the TealTiger repository

Closes #286