### PR TITLE
Add compact JSON audit export

### DIFF
--- a/packages/ag2-tealtiger/README.md
+++ b/packages/ag2-tealtiger/README.md
@@ -44,6 +44,24 @@ guard.attach(agent)
 # DENY blocks the call with a structured denial message
 ```
 
+### Audit Export
+
+```python
+decisions = guard.to_json()
+# [
+#   {
+#     "decision_id": "d-4a8b2c1f",
+#     "timestamp": "2026-06-16T14:30:00Z",
+#     "agent_id": "research-agent",
+#     "action": "deny",
+#     "tool_name": "web_scrape",
+#     "reason_codes": ["TOOL_NOT_ALLOWED"],
+#     "risk_score": 80,
+#     "evaluation_time_ms": 2.1,
+#   }
+# ]
+```
+
 ### Governed GroupChat
 
 ```python

--- a/packages/ag2-tealtiger/src/ag2_tealtiger/guard.py
+++ b/packages/ag2-tealtiger/src/ag2_tealtiger/guard.py
@@ -239,6 +239,33 @@ class TealTigerGuard:
 
         return entries_written
 
+    def to_json(self) -> list[dict[str, Any]]:
+        """Return audit decisions as dashboard-friendly JSON objects.
+
+        This is a compact representation for SIEM, dashboard, or data pipeline
+        ingestion. For the full AuditEntry payload, use export_audit_trail().
+
+        Returns:
+            A list of decision dictionaries containing the stable fields most
+            consumers need for governance reporting.
+        """
+        return [
+            {
+                "decision_id": entry.decision_id,
+                "timestamp": datetime.fromtimestamp(
+                    entry.timestamp_ms / 1000,
+                    tz=timezone.utc,
+                ).isoformat().replace("+00:00", "Z"),
+                "agent_id": entry.agent_id,
+                "action": entry.action.lower(),
+                "tool_name": entry.tool_name,
+                "reason_codes": list(entry.reason_codes),
+                "risk_score": entry.risk_score,
+                "evaluation_time_ms": entry.evaluation_time_ms,
+            }
+            for entry in self._audit_trail
+        ]
+
     # ── Per-Agent Kill Switch ─────────────────────────────────────────────────
 
     def freeze(self, agent_id: str) -> None:

--- a/packages/ag2-tealtiger/tests/test_audit_export.py
+++ b/packages/ag2-tealtiger/tests/test_audit_export.py
@@ -16,13 +16,12 @@ import pytest
 
 from ag2_tealtiger.guard import TealTigerGuard
 from ag2_tealtiger.types import (
+    ActionKind,
     AuditEntry,
     GovernanceAction,
     GovernanceMode,
-    ActionKind,
     TEECContext,
 )
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -38,19 +37,19 @@ def _make_audit_entry(
     import uuid
 
     decision_id = str(uuid.uuid4())
-    defaults = dict(
-        correlation_id=str(uuid.uuid4()),
-        decision_id=decision_id,
-        timestamp_ms=time.time() * 1000,
-        action=action,
-        action_kind=ActionKind.TOOL_CALL.value,
-        mode=GovernanceMode.OBSERVE.value,
-        agent_id=agent_id,
-        reason="Test entry",
-        reason_codes=["OBSERVE_PASSTHROUGH"],
-        risk_score=0,
-        evaluation_time_ms=evaluation_time_ms,
-        teec=TEECContext(
+    defaults = {
+        "correlation_id": str(uuid.uuid4()),
+        "decision_id": decision_id,
+        "timestamp_ms": time.time() * 1000,
+        "action": action,
+        "action_kind": ActionKind.TOOL_CALL.value,
+        "mode": GovernanceMode.OBSERVE.value,
+        "agent_id": agent_id,
+        "reason": "Test entry",
+        "reason_codes": ["OBSERVE_PASSTHROUGH"],
+        "risk_score": 0,
+        "evaluation_time_ms": evaluation_time_ms,
+        "teec": TEECContext(
             namespace="teec.ag2",
             conversation_id=str(uuid.uuid4()),
             turn_id=1,
@@ -58,8 +57,8 @@ def _make_audit_entry(
             decision_id=decision_id,
             decision_source="default_mode",
         ),
-        tool_name=tool_name,
-    )
+        "tool_name": tool_name,
+    }
     defaults.update(overrides)
     return AuditEntry(**defaults)
 
@@ -403,3 +402,42 @@ class TestExportAuditTrailIntegration:
 
         assert count == n
         assert count == len(guard.audit_trail)
+
+
+class TestAuditTrailJsonExport:
+    """Test compact JSON export for dashboard ingestion."""
+
+    def test_to_json_returns_expected_schema(self) -> None:
+        """to_json returns one compact decision object per audit entry."""
+        guard = TealTigerGuard()
+        entry = _make_audit_entry(
+            agent_id="research-agent",
+            tool_name="web_scrape",
+            action=GovernanceAction.DENY.value,
+            reason_codes=["TOOL_NOT_ALLOWED"],
+            risk_score=80,
+            evaluation_time_ms=2.1,
+            timestamp_ms=0,
+        )
+        guard._audit_trail.append(entry)
+
+        payload = guard.to_json()
+
+        assert payload == [
+            {
+                "decision_id": entry.decision_id,
+                "timestamp": "1970-01-01T00:00:00Z",
+                "agent_id": "research-agent",
+                "action": "deny",
+                "tool_name": "web_scrape",
+                "reason_codes": ["TOOL_NOT_ALLOWED"],
+                "risk_score": 80,
+                "evaluation_time_ms": 2.1,
+            }
+        ]
+
+    def test_to_json_empty_trail(self) -> None:
+        """Empty audit trails export as an empty JSON array."""
+        guard = TealTigerGuard()
+
+        assert guard.to_json() == []


### PR DESCRIPTION
## Summary\n- add TealTigerGuard.to_json() for compact dashboard/SIEM-friendly audit decision export\n- cover the JSON export schema and empty-trail behavior in audit export tests\n- document the new audit export helper in the AG2 adapter README\n\n## Notes\nThe issue references TealAudit paths that do not appear to exist in the current repository layout. This PR implements the requested compact JSON export on the existing AG2 audit trail implementation, alongside the existing JSONL file export.\n\n## Tests\n- uv run --directory packages/ag2-tealtiger --extra dev pytest tests/test_audit_export.py\n- uv run --directory packages/ag2-tealtiger --extra dev ruff check tests/test_audit_export.py\n- git diff --check\n\nCloses #310