### PR TITLE
feat: Add MLflow Integration for Governance Tracking

### DIFF
--- a/packages/mlflow-tealtiger/examples/governed_mlflow_agent.py
+++ b/packages/mlflow-tealtiger/examples/governed_mlflow_agent.py
@@ -1,0 +1,56 @@
+import os
+import mlflow
+from tealtiger.integrations.mlflow import MLflowGovernanceLogger
+
+# Example using a mock TealOpenAI since we are focusing on MLflow
+class MockTealOpenAI:
+    def __init__(self, api_key, guardrails, on_decision):
+        self.on_decision = on_decision
+        self.guardrails = guardrails
+        
+    def run_agent_step(self, prompt: str):
+        # Simulate an allowed tool call
+        self.on_decision({
+            "action": "ALLOW",
+            "risk_score": 0.1,
+            "latency_ms": 45,
+            "reason": "Safe"
+        })
+        
+        # Simulate a denied tool call due to PII
+        if "secret" in prompt.lower():
+            self.on_decision({
+                "action": "DENY",
+                "risk_score": 0.95,
+                "latency_ms": 60,
+                "reason": "PII Detected in arguments",
+                "pii_detected": True
+            })
+
+def main():
+    print("--- Running MLflow Governed Agent ---")
+    
+    # Set up MLflow tracking (local by default)
+    mlflow.set_experiment("TealTiger_Governance_Demo")
+    
+    logger = MLflowGovernanceLogger(mode="enforce")
+    
+    with mlflow.start_run():
+        print("MLflow run started.")
+        client = MockTealOpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY", "dummy"),
+            guardrails={"pii_detection": True},
+            on_decision=logger.log,  # Each decision → MLflow artifact
+        )
+        
+        # Run agent workflow
+        print("Running agent...")
+        client.run_agent_step("Analyze public data")
+        client.run_agent_step("Query user secret_id=123")
+        
+        # Export summary as SARIF artifact
+        logger.finalize()
+        print("MLflow run finalized. Check mlflow ui for artifacts and metrics.")
+
+if __name__ == "__main__":
+    main()

--- a/packages/mlflow-tealtiger/pyproject.toml
+++ b/packages/mlflow-tealtiger/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mlflow-tealtiger"
+version = "0.1.0"
+description = "Deterministic governance middleware for MLflow — log decisions, metrics, and SARIF artifacts for compliance."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "TealTiger Team", email = "reachout@tealtiger.ai"},
+]
+keywords = [
+    "mlflow",
+    "governance",
+    "security",
+    "ai-agents",
+    "guardrails",
+    "policy",
+    "tealtiger",
+    "sarif",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "mlflow>=2.10.0",
+    "tealtiger>=1.4.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.5.0",
+    "ruff>=0.4.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tealtiger"]

--- a/packages/mlflow-tealtiger/src/tealtiger/integrations/mlflow.py
+++ b/packages/mlflow-tealtiger/src/tealtiger/integrations/mlflow.py
@@ -1,0 +1,108 @@
+import json
+import os
+import time
+import mlflow
+from typing import Dict, Any, List
+
+class MLflowGovernanceLogger:
+    """
+    MLflow logger for TealTiger governance decisions.
+    Logs metrics (risk_score, latency) per decision, and exports
+    a SARIF/JSON artifact with the full audit trail when finalized.
+    """
+    def __init__(self, mode: str = "enforce"):
+        self.mode = mode
+        self.decisions = []
+        self.total_denials = 0
+        self.max_risk_score = 0.0
+        
+        # Log initial tags
+        if mlflow.active_run():
+            mlflow.set_tag("governance_mode", self.mode)
+
+    def log(self, decision: Dict[str, Any]) -> None:
+        """
+        Callback to log an individual decision from TealTigerGuard.
+        """
+        # Store for artifact export
+        decision_record = {
+            "timestamp": time.time(),
+            "decision": decision
+        }
+        self.decisions.append(decision_record)
+        
+        # Calculate metrics
+        action = decision.get("action", "ALLOW")
+        if action == "DENY":
+            self.total_denials += 1
+            
+        risk_score = float(decision.get("risk_score", 0.0))
+        if risk_score > self.max_risk_score:
+            self.max_risk_score = risk_score
+            
+        latency = float(decision.get("latency_ms", 0.0))
+        
+        step = len(self.decisions)
+        
+        if mlflow.active_run():
+            # Log metrics
+            mlflow.log_metric("governance_risk_score", risk_score, step=step)
+            if latency > 0:
+                mlflow.log_metric("governance_latency_ms", latency, step=step)
+
+    def _generate_sarif(self) -> Dict[str, Any]:
+        """
+        Generates a basic SARIF format representation of the denied decisions.
+        """
+        results = []
+        for d in self.decisions:
+            dec = d["decision"]
+            if dec.get("action") == "DENY":
+                results.append({
+                    "ruleId": dec.get("reason", "policy_violation"),
+                    "level": "error",
+                    "message": {
+                        "text": f"Governance blocked action: {dec.get('reason')}"
+                    }
+                })
+                
+        return {
+            "version": "2.1.0",
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "TealTiger",
+                            "informationUri": "https://tealtiger.ai",
+                            "rules": []
+                        }
+                    },
+                    "results": results
+                }
+            ]
+        }
+
+    def finalize(self) -> None:
+        """
+        Exports summary metrics and the SARIF artifact to MLflow.
+        """
+        if not mlflow.active_run():
+            return
+            
+        mlflow.set_tag("total_denials", self.total_denials)
+        mlflow.set_tag("max_risk_score", self.max_risk_score)
+        
+        # Save raw JSON audit log
+        audit_file = "tealtiger_audit.json"
+        with open(audit_file, "w") as f:
+            json.dump(self.decisions, f, indent=2)
+        mlflow.log_artifact(audit_file)
+        os.remove(audit_file)
+        
+        # Save SARIF artifact
+        sarif_file = "tealtiger_audit.sarif"
+        with open(sarif_file, "w") as f:
+            json.dump(self._generate_sarif(), f, indent=2)
+        mlflow.log_artifact(sarif_file)
+        os.remove(sarif_file)

--- a/packages/mlflow-tealtiger/tests/test_mlflow.py
+++ b/packages/mlflow-tealtiger/tests/test_mlflow.py
@@ -1,0 +1,82 @@
+import os
+import json
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+from tealtiger.integrations.mlflow import MLflowGovernanceLogger
+
+@pytest.fixture
+def mock_mlflow():
+    with patch("tealtiger.integrations.mlflow.mlflow") as mock:
+        yield mock
+
+def test_logger_init(mock_mlflow):
+    mock_mlflow.active_run.return_value = True
+    logger = MLflowGovernanceLogger(mode="audit")
+    assert logger.mode == "audit"
+    mock_mlflow.set_tag.assert_called_with("governance_mode", "audit")
+
+def test_logger_log_allow(mock_mlflow):
+    mock_mlflow.active_run.return_value = True
+    logger = MLflowGovernanceLogger()
+    
+    decision = {
+        "action": "ALLOW",
+        "risk_score": 0.2,
+        "latency_ms": 150
+    }
+    logger.log(decision)
+    
+    assert len(logger.decisions) == 1
+    assert logger.total_denials == 0
+    assert logger.max_risk_score == 0.2
+    
+    mock_mlflow.log_metric.assert_any_call("governance_risk_score", 0.2, step=1)
+    mock_mlflow.log_metric.assert_any_call("governance_latency_ms", 150.0, step=1)
+
+def test_logger_log_deny(mock_mlflow):
+    mock_mlflow.active_run.return_value = True
+    logger = MLflowGovernanceLogger()
+    
+    decision = {
+        "action": "DENY",
+        "risk_score": 0.9,
+        "latency_ms": 100,
+        "reason": "PII detected"
+    }
+    logger.log(decision)
+    
+    assert logger.total_denials == 1
+    assert logger.max_risk_score == 0.9
+
+def test_generate_sarif(mock_mlflow):
+    logger = MLflowGovernanceLogger()
+    logger.decisions = [
+        {"decision": {"action": "ALLOW", "risk_score": 0.1}},
+        {"decision": {"action": "DENY", "reason": "PII Detected", "risk_score": 0.9}}
+    ]
+    
+    sarif = logger._generate_sarif()
+    assert sarif["version"] == "2.1.0"
+    results = sarif["runs"][0]["results"]
+    assert len(results) == 1
+    assert results[0]["ruleId"] == "PII Detected"
+    assert results[0]["level"] == "error"
+
+@patch("tealtiger.integrations.mlflow.os.remove")
+def test_finalize(mock_remove, mock_mlflow):
+    mock_mlflow.active_run.return_value = True
+    logger = MLflowGovernanceLogger()
+    logger.total_denials = 1
+    logger.max_risk_score = 0.9
+    
+    # We can mock builtins.open to avoid actually writing files
+    with patch("builtins.open", mock_open()) as mocked_file:
+        logger.finalize()
+        
+    mock_mlflow.set_tag.assert_any_call("total_denials", 1)
+    mock_mlflow.set_tag.assert_any_call("max_risk_score", 0.9)
+    
+    mock_mlflow.log_artifact.assert_any_call("tealtiger_audit.json")
+    mock_mlflow.log_artifact.assert_any_call("tealtiger_audit.sarif")
+    
+    assert mock_remove.call_count == 2


### PR DESCRIPTION
### Description
This PR implements the requested MLflow integration for enterprise compliance tracking (Issue #330).

**Deliverables Included:**
- `tealtiger.integrations.mlflow` module configured via namespace package structure.
- `MLflowGovernanceLogger` class designed to be passed as a callback to governed clients (like `TealOpenAI`).
- Automatically logs individual governance decisions as metrics (`governance_risk_score`, `governance_latency_ms`) step-by-step.
- Sets high-level run tags at the end of the session (`total_denials`, `max_risk_score`, `governance_mode`).
- Exports a complete summary of denied actions using the industry-standard **SARIF 2.1.0** format and attaches it as an MLflow run artifact.
- Working example provided in `packages/mlflow-tealtiger/examples/governed_mlflow_agent.py`.

Closes #330