### PR TITLE
feat(examples/kyc-agent): document extraction agent (#438)

### DIFF
--- a/examples/kyc-agent/README.md
+++ b/examples/kyc-agent/README.md
@@ -1,28 +1,105 @@
-# KYC Agent — Deterministic Decision Agent (sub-issue #441 / KYC #6)
+# KYC Agent — Document Extraction (#438) + Deterministic Decision Agent (#441)
 
-> **Draft PR scope.** This directory currently contains the **Decision Agent** and its immediate type dependencies only. It is intentionally scoped to `#441` and is designed to slot cleanly into the full `examples/kyc-agent/` scaffold produced by `#435`, using the fixtures from `#437` and the sanctions/risk outputs from `#439`/`#440`.
+> **Scope.** This directory currently contains the **Document Extraction Agent** (`#438`) and the **Decision Agent** (`#441`), plus their type dependencies. It slots into the full `examples/kyc-agent/` scaffold produced by `#435`, and will consume the fixtures from `#437` and the sanctions/risk outputs from `#439`/`#440` as those land.
 
 ## What is here
 
 ```
 examples/kyc-agent/
-├── README.md                     ← this file
+├── README.md                       ← this file
 ├── src/
 │   ├── __init__.py
 │   ├── interfaces/
 │   │   ├── __init__.py
-│   │   └── kyc_types.py          ← temporary stubs for input dataclasses
+│   │   └── kyc_types.py            ← ExtractedIdentity (#438) + KYCDecision (#441)
 │   └── agents/
 │       ├── __init__.py
-│       └── decision_agent.py     ← the deterministic make_decision() implementation
+│       ├── document_extractor.py   ← extract_identity() — mock + optional Haystack LLM
+│       └── decision_agent.py       ← the deterministic make_decision() implementation
 └── tests/
     ├── __init__.py
-    └── test_decision_agent.py    ← pytest suite (17 cases, all deterministic)
+    ├── fixtures/documents/         ← 7 synthetic documents covering the edge cases
+    ├── test_document_extractor.py  ← pytest suite (39 cases, all offline)
+    └── test_decision_agent.py      ← pytest suite (17 cases, all deterministic)
 ```
 
-**Types marked as stubs** in `src/interfaces/kyc_types.py` (`ExtractedIdentity`, `SanctionsResult`, `RiskAssessment`) will be **deleted** from this directory the moment the canonical versions land from sub-issues `#438` (document extraction), `#439` (sanctions), and `#440` (risk scoring). The stubs are minimal shapes that match the fields cited in the interface published on `#441`. `KYCDecision` is authored here per the `#441` deliverables list.
+**Types marked as stubs** in `src/interfaces/kyc_types.py` (`SanctionsResult`, `RiskAssessment`) will be **deleted** from this directory the moment the canonical versions land from sub-issues `#439` (sanctions) and `#440` (risk scoring). `ExtractedIdentity` is now **canonical** per `#438` and matches the interface published on that issue; `KYCDecision` is canonical per `#441`.
 
-## Design (Quesen shape)
+## Document Extraction Agent (`#438`)
+
+`extract_identity(document, use_llm=False)` turns a document fixture (a JSON
+`dict`, not an image) into an `ExtractedIdentity`.
+
+```python
+import asyncio
+from agents.document_extractor import extract_identity, load_document
+
+document = load_document("tests/fixtures/documents/passport-complete.json")
+identity = asyncio.run(extract_identity(document))
+
+identity.first_name       # "Jane"
+identity.date_of_birth    # "1985-03-15"  (normalised to ISO 8601)
+identity.document_type    # "passport"    (normalised to snake_case)
+identity.confidence       # 1.0
+```
+
+### Two modes
+
+| Mode | Trigger | Behaviour |
+|------|---------|-----------|
+| **Mock** (default) | nothing to set | Pure deterministic field mapper over the fixture JSON. No LLM, no network, no keys. |
+| **LLM** (opt-in) | `use_llm=True`, or `USE_LLM=true` + `OPENAI_API_KEY` | Haystack `OpenAIChatGenerator` reads the document, then its output is merged *under* the deterministic extraction. |
+
+LLM mode **always degrades to mock mode** — a missing `haystack-ai`, an absent
+API key, a malformed reply, or a network failure is logged and falls back. The
+example never stops working offline. Install the optional dependency with
+`pip install 'haystack-ai>=2.21'`.
+
+### Extraction invariants
+
+1. **Never invent a value.** A field absent from the document comes back as
+   `""`, not as a plausible-looking string. Wrong-but-confident identity data
+   is the failure mode that costs banks fines.
+2. **Never guess an ambiguous date.** `03/04/1985` could be 3 April or 4 March;
+   it is returned verbatim and costs confidence. Only unambiguous forms
+   (`YYYY-MM-DD`, `YYYY/MM/DD`, `DD Mon YYYY`, `Mon DD, YYYY`, and `DD/MM/YYYY`
+   where the first component exceeds 12) are normalised to ISO 8601.
+3. **Confidence is computed, not guessed.** It comes from a versioned scoring
+   table, so a partial extraction can never report `1.0` — the Decision Agent
+   uses that number as an escalation trigger.
+4. **The LLM can only fill gaps and lower confidence.** It cannot overwrite a
+   field read straight out of the document, and a declared confidence caps the
+   computed score rather than raising it.
+
+### Confidence scoring (`kyc-document-extractor/v1.0.0`)
+
+```
+score = 1.0
+      - 0.15 per missing required field   (first_name, last_name, date_of_birth,
+                                           nationality, document_type,
+                                           document_number, document_expiry)
+      - 0.05 if the name was recovered by splitting a single full-name string
+      - 0.05 per date that could not be normalised to ISO 8601
+      clamped to [0.0, 1.0], rounded to 4 decimals
+
+A `confidence` / `extraction_confidence` declared on the document caps the
+result — a scanner that saw the blur knows more than a field mapper does.
+```
+
+### Accepted document shapes
+
+Fields are resolved from `extracted_fields` → `id_document` → the document
+root, so both the flat document fixtures and the customer-profile schema from
+`#437` work unchanged. Common aliases are accepted (`given_name`/`surname`,
+`dob`, `issuing_country`, `id_number`, `expiry`, …), and an address supplied as
+a mapping is flattened to one display line.
+
+The fixtures under `tests/fixtures/documents/` are self-contained and fully
+synthetic (country `ZZ`, `TEST`-prefixed document numbers) so `#438` does not
+depend on `#437` merging first. When `#437` lands, `load_document("document-001")`
+resolves ids against `fixtures/documents/` too.
+
+## Decision Agent design (Quesen shape)
 
 The decision function follows Quesen's Deterministic Trust Infrastructure invariants:
 
@@ -67,16 +144,19 @@ cd examples/kyc-agent
 python -m pytest tests/ -v
 ```
 
-No external dependencies; no API keys; no network calls; no LLM. Everything in `tests/test_decision_agent.py` runs offline and deterministically.
+No external dependencies; no API keys; no network calls; no LLM. Everything in
+`tests/test_document_extractor.py` and `tests/test_decision_agent.py` runs
+offline and deterministically.
 
 ## Follow-ups after this PR merges
 
-1. **On `#435` merge:** delete `src/interfaces/kyc_types.py` and re-import from the canonical location.
-2. **On `#439` merge:** replace `SanctionsResult` stub with the real one; adjust test fixtures.
+1. **On `#435` merge:** move `src/interfaces/kyc_types.py` to the canonical location and re-import.
+2. **On `#439` merge:** replace the `SanctionsResult` stub with the real one; adjust test fixtures.
 3. **On `#440` merge:** same for `RiskAssessment`.
-4. **On `#437` merge:** wire the synthetic fixtures into `tests/test_decision_agent.py` for a second layer of realistic cases.
-5. **On `#443` merge:** add a TealTiger governance wrapper example around `make_decision` for the reference implementation walkthrough.
+4. **On `#437` merge:** point `extract_identity` at `fixtures/documents/` and add a fixture-driven case sweep to both test suites.
+5. **On `#443` merge:** add a TealTiger governance wrapper (PII scan on the raw document, receipt on the `ExtractedIdentity` and the `KYCDecision`) for the reference implementation walkthrough.
+6. **On `#445` merge:** wire `extract_identity` → `screen_sanctions` → `score_risk` → `make_decision` into the orchestrator.
 
 ---
 
-*Authored by Senueren under the Quesen bureau, per `sib-bureau-external-affairs` doctrine §21 (Active Engagement).*
+*Decision Agent (`#441`) authored by Senueren under the Quesen bureau, per `sib-bureau-external-affairs` doctrine §21 (Active Engagement). Document Extraction Agent (`#438`) added on top of it.*

--- a/examples/kyc-agent/src/agents/__init__.py
+++ b/examples/kyc-agent/src/agents/__init__.py
@@ -5,5 +5,26 @@ from .decision_agent import (
     DecisionPolicy,
     DEFAULT_POLICY,
 )
+from .document_extractor import (
+    extract_identity,
+    extract_identity_mock,
+    load_document,
+    llm_enabled,
+    DocumentExtractionError,
+    EXTRACTOR_VERSION,
+    REQUIRED_FIELDS,
+)
 
-__all__ = ["make_decision", "POLICY_VERSION", "DecisionPolicy", "DEFAULT_POLICY"]
+__all__ = [
+    "make_decision",
+    "POLICY_VERSION",
+    "DecisionPolicy",
+    "DEFAULT_POLICY",
+    "extract_identity",
+    "extract_identity_mock",
+    "load_document",
+    "llm_enabled",
+    "DocumentExtractionError",
+    "EXTRACTOR_VERSION",
+    "REQUIRED_FIELDS",
+]

--- a/examples/kyc-agent/src/agents/document_extractor.py
+++ b/examples/kyc-agent/src/agents/document_extractor.py
@@ -1,0 +1,533 @@
+"""Document Extraction Agent (sub-issue #438 / KYC #3).
+
+Turns a customer document (a fixture ``dict``, not an image) into a
+structured :class:`ExtractedIdentity`.
+
+Two modes:
+
+* **Mock mode (default).** A pure, deterministic field mapper over the
+  fixture JSON. No LLM, no network, no API keys. Same document in → same
+  ``ExtractedIdentity`` out, including ``confidence``.
+* **LLM mode (opt-in).** Uses Haystack's ``OpenAIChatGenerator`` to read
+  free-form documents. Enabled with ``use_llm=True`` or ``USE_LLM=true``
+  plus ``OPENAI_API_KEY``. **Always falls back to mock mode** if Haystack
+  is missing, the key is absent, or the call fails — the example must stay
+  runnable offline.
+
+Design invariants (mirrors the Decision Agent, #441):
+
+1. Mock mode has no LLM in the loop and is byte-for-byte reproducible.
+2. ``confidence`` is computed from a documented, versioned scoring table —
+   never guessed. A partially recovered document can never report 1.0,
+   because the Decision Agent uses that number as an escalation trigger.
+3. Extraction never invents values. A field that is absent from the
+   document stays empty; it does not become a plausible-looking string.
+4. LLM output is merged *under* the deterministic extraction, and its
+   confidence can only lower the result, never raise it.
+
+Boundary: this agent is a pure function over its input. Wrap it with
+TealTiger governance at the caller (PII scan on the raw document before,
+receipt on the ``ExtractedIdentity`` after). Do not embed governance here.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from datetime import date
+from pathlib import Path
+from collections.abc import Iterable, Mapping
+from typing import Any, Optional
+
+try:  # relative import when used as a package (e.g. from #435 scaffold)
+    from ..interfaces import ExtractedIdentity
+except ImportError:  # fallback for direct src/ sys.path usage in tests
+    from interfaces import ExtractedIdentity  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+EXTRACTOR_VERSION = "kyc-document-extractor/v1.0.0"
+
+#: Canonical fixture location produced by sub-issue #437.
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "documents"
+
+DEFAULT_LLM_MODEL = "gpt-4o-mini"
+
+
+class DocumentExtractionError(ValueError):
+    """Raised when a document cannot be read at all (not when fields are missing)."""
+
+
+# --------------------------------------------------------------------------
+# Field aliases — fixture producers name things differently; we accept all of
+# them, in declaration order (first hit wins).
+# --------------------------------------------------------------------------
+
+_ALIASES: dict[str, tuple[str, ...]] = {
+    "first_name": ("first_name", "given_name", "given_names", "forename"),
+    "last_name": ("last_name", "surname", "family_name", "lastname"),
+    "date_of_birth": ("date_of_birth", "dob", "birth_date", "date_of_birth_iso"),
+    "nationality": ("nationality", "issuing_country", "country_of_issue", "country"),
+    "document_type": ("document_type", "type", "id_type", "doc_type"),
+    "document_number": (
+        "document_number",
+        "number",
+        "doc_number",
+        "id_number",
+        "passport_number",
+    ),
+    "document_expiry": (
+        "document_expiry",
+        "expiry",
+        "expiry_date",
+        "date_of_expiry",
+        "expires",
+    ),
+    "address": ("address", "residential_address", "street_address"),
+}
+
+_FULL_NAME_ALIASES = ("full_name", "name", "holder_name")
+
+#: Nested containers searched, in priority order, before the document root.
+_NESTED_KEYS = ("extracted_fields", "id_document", "document", "fields")
+
+#: Address sub-keys, in rendering order.
+_ADDRESS_PARTS = (
+    "line1",
+    "street",
+    "line2",
+    "city",
+    "state",
+    "region",
+    "province",
+    "postal_code",
+    "postcode",
+    "zip",
+    "country",
+)
+
+#: Fields that must be present for a document to be fully extracted.
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "first_name",
+    "last_name",
+    "date_of_birth",
+    "nationality",
+    "document_type",
+    "document_number",
+    "document_expiry",
+)
+
+# Confidence scoring table. Change a number here → bump EXTRACTOR_VERSION.
+MISSING_FIELD_PENALTY = 0.15
+DERIVED_NAME_PENALTY = 0.05
+UNPARSED_DATE_PENALTY = 0.05
+
+_MONTHS = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+# --------------------------------------------------------------------------
+# Normalisation helpers (pure)
+# --------------------------------------------------------------------------
+
+
+def _iter_scopes(document: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    """Yield the mappings to search, most specific first.
+
+    ``extracted_fields`` wins over ``id_document`` wins over the root, so a
+    fixture that carries both a summary and an extraction detail block
+    resolves to the detail block.
+    """
+    for key in _NESTED_KEYS:
+        nested = document.get(key)
+        if isinstance(nested, Mapping):
+            yield nested
+            # One level deeper: customers.json nests extracted_fields inside
+            # id_document (see the schema on issue #437).
+            for inner_key in _NESTED_KEYS:
+                inner = nested.get(inner_key)
+                if isinstance(inner, Mapping):
+                    yield inner
+    yield document
+
+
+def _lookup(document: Mapping[str, Any], names: tuple[str, ...]) -> Any:
+    for scope in _iter_scopes(document):
+        for name in names:
+            if name in scope and scope[name] not in (None, ""):
+                return scope[name]
+    return None
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float)):
+        return str(value)
+    return ""
+
+
+def _normalise_document_type(value: str) -> str:
+    """``"Driver's License"`` → ``"drivers_license"``. Idempotent."""
+    if not value:
+        return ""
+    slug = re.sub(r"[^a-z0-9]+", "_", value.lower().replace("'", ""))
+    return slug.strip("_")
+
+
+def _normalise_country(value: str) -> str:
+    """Uppercase an alpha-2 code; leave anything longer untouched."""
+    stripped = value.strip()
+    if len(stripped) == 2 and stripped.isalpha():
+        return stripped.upper()
+    return stripped
+
+
+def _iso_or_none(year: int, month: int, day: int) -> Optional[str]:
+    try:
+        return date(year, month, day).isoformat()
+    except ValueError:
+        return None
+
+
+def _normalise_date(value: str) -> tuple[str, bool]:
+    """Return ``(value, parsed)`` with ISO 8601 output where unambiguous.
+
+    Handled: ``YYYY-MM-DD``, ``YYYY/MM/DD``, ``DD Mon YYYY``,
+    ``Mon DD, YYYY``, and ``DD/MM/YYYY`` **only** when the first component
+    is greater than 12 (day-first is then the only reading).
+
+    Ambiguous numeric forms such as ``03/04/1985`` are returned verbatim
+    with ``parsed=False`` rather than guessed at — a silently transposed
+    date of birth is a compliance defect, not a rounding error.
+    """
+    text = value.strip()
+    if not text:
+        return "", False
+
+    iso = re.fullmatch(r"(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})", text)
+    if iso:
+        out = _iso_or_none(int(iso.group(1)), int(iso.group(2)), int(iso.group(3)))
+        return (out, True) if out else (text, False)
+
+    dmy = re.fullmatch(r"(\d{1,2})[-/.](\d{1,2})[-/.](\d{4})", text)
+    if dmy:
+        first, second, year = int(dmy.group(1)), int(dmy.group(2)), int(dmy.group(3))
+        if first > 12:  # unambiguously day-first
+            out = _iso_or_none(year, second, first)
+            return (out, True) if out else (text, False)
+        return text, False  # ambiguous — never guess
+
+    named = re.fullmatch(
+        r"(\d{1,2})\s+([A-Za-z]{3,})\.?,?\s+(\d{4})", text
+    ) or re.fullmatch(
+        r"([A-Za-z]{3,})\.?\s+(\d{1,2}),?\s+(\d{4})", text
+    )
+    if named:
+        groups = named.groups()
+        if groups[0].isdigit():
+            day_s, month_s, year_s = groups
+        else:
+            month_s, day_s, year_s = groups
+        month = _MONTHS.get(month_s[:3].lower())
+        if month:
+            out = _iso_or_none(int(year_s), month, int(day_s))
+            if out:
+                return out, True
+    return text, False
+
+
+def _normalise_address(value: Any) -> Optional[str]:
+    """Flatten an address string or mapping to a single display line."""
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, Mapping):
+        parts = [
+            _as_text(value[key]) for key in _ADDRESS_PARTS if _as_text(value.get(key))
+        ]
+        return ", ".join(parts) or None
+    return None
+
+
+def _split_full_name(full_name: str) -> tuple[str, str]:
+    """``"Jane Q. Smith"`` → ``("Jane", "Smith")``; last token is the surname."""
+    tokens = [token for token in full_name.split() if token]
+    if not tokens:
+        return "", ""
+    if len(tokens) == 1:
+        return tokens[0], ""
+    return " ".join(tokens[:-1]), tokens[-1]
+
+
+def _clamp(value: float) -> float:
+    return min(1.0, max(0.0, float(value)))
+
+
+def _score_confidence(
+    fields: Mapping[str, str], *, derived_name: bool, unparsed_dates: int
+) -> float:
+    """Deterministic completeness score in [0.0, 1.0].
+
+    ``1.0`` means every required field was present and every date parsed to
+    ISO 8601. Each missing required field costs ``MISSING_FIELD_PENALTY``;
+    a name recovered by splitting a single string costs
+    ``DERIVED_NAME_PENALTY``; each unparsed date costs
+    ``UNPARSED_DATE_PENALTY``.
+    """
+    missing = sum(1 for name in REQUIRED_FIELDS if not fields.get(name))
+    score = 1.0 - (missing * MISSING_FIELD_PENALTY)
+    if derived_name:
+        score -= DERIVED_NAME_PENALTY
+    score -= unparsed_dates * UNPARSED_DATE_PENALTY
+    return round(_clamp(score), 4)
+
+
+# --------------------------------------------------------------------------
+# Mock extraction (the default path)
+# --------------------------------------------------------------------------
+
+
+def extract_identity_mock(document: Mapping[str, Any]) -> ExtractedIdentity:
+    """Deterministic field mapper over a fixture document. No LLM, no I/O."""
+    if not isinstance(document, Mapping):
+        raise DocumentExtractionError(
+            f"document must be a mapping, got {type(document).__name__}"
+        )
+    if not document:
+        raise DocumentExtractionError("document is empty")
+
+    values = {
+        name: _as_text(_lookup(document, aliases))
+        for name, aliases in _ALIASES.items()
+        if name != "address"
+    }
+
+    derived_name = False
+    if not values["first_name"] and not values["last_name"]:
+        full_name = _as_text(_lookup(document, _FULL_NAME_ALIASES))
+        if full_name:
+            values["first_name"], values["last_name"] = _split_full_name(full_name)
+            derived_name = True
+
+    unparsed_dates = 0
+    for field_name in ("date_of_birth", "document_expiry"):
+        normalised, parsed = _normalise_date(values[field_name])
+        values[field_name] = normalised
+        if normalised and not parsed:
+            unparsed_dates += 1
+
+    values["nationality"] = _normalise_country(values["nationality"])
+    values["document_type"] = _normalise_document_type(values["document_type"])
+
+    address = _normalise_address(_lookup(document, _ALIASES["address"]))
+
+    confidence = _score_confidence(
+        values, derived_name=derived_name, unparsed_dates=unparsed_dates
+    )
+    declared = _lookup(document, ("extraction_confidence", "confidence"))
+    if isinstance(declared, (int, float)):
+        # A fixture that states its own confidence caps ours — it knows about
+        # blur, glare, and partial scans that a field mapper cannot see.
+        confidence = round(min(confidence, _clamp(declared)), 4)
+
+    return ExtractedIdentity(
+        first_name=values["first_name"],
+        last_name=values["last_name"],
+        date_of_birth=values["date_of_birth"],
+        nationality=values["nationality"],
+        document_type=values["document_type"],
+        document_number=values["document_number"],
+        document_expiry=values["document_expiry"],
+        address=address,
+        confidence=confidence,
+    )
+
+
+# --------------------------------------------------------------------------
+# LLM extraction (opt-in, always falls back)
+# --------------------------------------------------------------------------
+
+
+_LLM_PROMPT = """You extract identity fields from a KYC document.
+
+Return ONLY a JSON object with exactly these keys:
+  first_name, last_name, date_of_birth, nationality, document_type,
+  document_number, document_expiry, address, confidence
+
+Rules:
+- Dates must be ISO 8601 (YYYY-MM-DD). nationality must be an ISO 3166-1
+  alpha-2 code. document_type must be lowercase snake_case.
+- Use an empty string for any field the document does not contain.
+  Never invent, complete, or guess a value.
+- address may be null. confidence is your extraction confidence, 0.0-1.0.
+
+Document:
+```json
+{document}
+```
+"""
+
+
+def llm_enabled(use_llm: bool = False) -> bool:
+    """LLM mode is on when the caller asks for it or ``USE_LLM`` is truthy."""
+    if use_llm:
+        return True
+    return os.getenv("USE_LLM", "").strip().lower() in _TRUTHY
+
+
+def _parse_llm_json(raw: str) -> dict[str, Any]:
+    """Pull the JSON object out of a chat reply that may carry code fences."""
+    text = raw.strip()
+    fenced = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1).strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON object in LLM response")
+    payload = json.loads(text[start : end + 1])
+    if not isinstance(payload, dict):
+        raise ValueError("LLM response was not a JSON object")
+    return payload
+
+
+def _merge_llm_payload(
+    payload: Mapping[str, Any], baseline: ExtractedIdentity
+) -> ExtractedIdentity:
+    """Layer LLM output over the deterministic extraction.
+
+    The LLM may *fill* fields the mapper left empty; it may not overwrite a
+    field the mapper read straight out of the document, and its confidence
+    can only lower the score.
+    """
+    merged: dict[str, str] = {}
+    for name in REQUIRED_FIELDS:
+        current = getattr(baseline, name)
+        merged[name] = current or _as_text(payload.get(name))
+
+    merged["nationality"] = _normalise_country(merged["nationality"])
+    merged["document_type"] = _normalise_document_type(merged["document_type"])
+    unparsed_dates = 0
+    for field_name in ("date_of_birth", "document_expiry"):
+        normalised, parsed = _normalise_date(merged[field_name])
+        merged[field_name] = normalised
+        if normalised and not parsed:
+            unparsed_dates += 1
+
+    address = baseline.address or _normalise_address(payload.get("address"))
+
+    confidence = _score_confidence(
+        merged, derived_name=False, unparsed_dates=unparsed_dates
+    )
+    declared = payload.get("confidence")
+    if isinstance(declared, (int, float)):
+        confidence = round(min(confidence, _clamp(declared)), 4)
+
+    return ExtractedIdentity(
+        address=address, confidence=confidence, **merged
+    )
+
+
+async def _extract_with_llm(
+    document: Mapping[str, Any], baseline: ExtractedIdentity
+) -> ExtractedIdentity:
+    """Haystack ``OpenAIChatGenerator`` pass. Raises on any failure."""
+    os.environ.setdefault("HAYSTACK_TELEMETRY_ENABLED", "false")
+    from haystack.components.generators.chat import (  # type: ignore[import-untyped]
+        OpenAIChatGenerator,
+    )
+    from haystack.dataclasses import ChatMessage  # type: ignore[import-untyped]
+
+    generator = OpenAIChatGenerator(
+        model=os.getenv("OPENAI_MODEL", DEFAULT_LLM_MODEL),
+        generation_kwargs={"temperature": 0.0},
+    )
+    prompt = _LLM_PROMPT.format(document=json.dumps(document, indent=2, sort_keys=True))
+
+    # Haystack generators are synchronous; keep the event loop free.
+    result = await asyncio.to_thread(
+        generator.run, messages=[ChatMessage.from_user(prompt)]
+    )
+    replies = result.get("replies") or []
+    if not replies:
+        raise ValueError("LLM returned no replies")
+    return _merge_llm_payload(_parse_llm_json(replies[0].text), baseline)
+
+
+# --------------------------------------------------------------------------
+# Public entry point
+# --------------------------------------------------------------------------
+
+
+async def extract_identity(
+    document: dict, use_llm: bool = False
+) -> ExtractedIdentity:
+    """Extract structured identity data from a customer ``document``.
+
+    Args:
+        document: A document fixture — either a flat extracted-document dict
+            or a customer profile carrying ``id_document`` /
+            ``extracted_fields`` (see the schema on issue #437).
+        use_llm: Force LLM mode. Otherwise LLM mode turns on when
+            ``USE_LLM`` is truthy and ``OPENAI_API_KEY`` is set.
+
+    Returns:
+        An :class:`ExtractedIdentity`. Missing fields come back empty and
+        pull ``confidence`` down; they are never invented.
+
+    Raises:
+        DocumentExtractionError: The document is not a non-empty mapping.
+
+    LLM failures (Haystack absent, no API key, bad response, network error)
+    are logged and degrade to the mock extraction — never raised.
+    """
+    baseline = extract_identity_mock(document)
+
+    if not llm_enabled(use_llm):
+        return baseline
+
+    if not os.getenv("OPENAI_API_KEY"):
+        logger.warning(
+            "LLM mode requested but OPENAI_API_KEY is unset; using mock extraction."
+        )
+        return baseline
+
+    try:
+        return await _extract_with_llm(document, baseline)
+    except ImportError:
+        logger.warning(
+            "LLM mode requested but haystack-ai is not installed "
+            "(pip install 'haystack-ai>=2.21'); using mock extraction."
+        )
+    except Exception as exc:  # pragma: no cover - depends on a live provider
+        logger.warning("LLM extraction failed (%s); using mock extraction.", exc)
+    return baseline
+
+
+def load_document(reference: str | Path) -> dict:
+    """Load a document fixture by path, or by id from ``fixtures/documents/``.
+
+    ``load_document("document-001")`` and
+    ``load_document("/abs/path/doc.json")`` both work. The id form resolves
+    against the fixtures produced by sub-issue #437.
+    """
+    path = Path(reference)
+    if not path.exists() and not path.is_absolute():
+        candidate = FIXTURES_DIR / path.name
+        if candidate.suffix != ".json":
+            candidate = candidate.with_suffix(".json")
+        path = candidate
+    if not path.exists():
+        raise DocumentExtractionError(f"document fixture not found: {reference}")
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise DocumentExtractionError(f"document fixture is not a JSON object: {path}")
+    return payload

--- a/examples/kyc-agent/src/interfaces/__init__.py
+++ b/examples/kyc-agent/src/interfaces/__init__.py
@@ -1,8 +1,9 @@
 """Type interfaces for the KYC agent pipeline.
 
-Everything in this package is a **temporary stub** until the canonical
-types land from sub-issues #435 (scaffold), #438 (document extraction),
-#439 (sanctions), and #440 (risk scoring). See ../README.md for scope.
+`ExtractedIdentity` (#438) and `KYCDecision` (#441) are canonical.
+`SanctionsResult` and `RiskAssessment` remain **temporary stubs** until the
+canonical types land from sub-issues #439 (sanctions) and #440 (risk
+scoring). See ../README.md for scope.
 """
 from .kyc_types import (
     ExtractedIdentity,

--- a/examples/kyc-agent/src/interfaces/kyc_types.py
+++ b/examples/kyc-agent/src/interfaces/kyc_types.py
@@ -1,12 +1,14 @@
 """KYC agent type interfaces.
 
-> **Scope note (from ../README.md):** `ExtractedIdentity`, `SanctionsResult`,
-> and `RiskAssessment` are minimal stubs that match the fields referenced
-> in the interface published on issue #441. They will be replaced by the
-> canonical types produced by sub-issues #438 / #439 / #440.
+> **Scope note (from ../README.md):** `SanctionsResult` and `RiskAssessment`
+> are minimal stubs that match the fields referenced in the interface
+> published on issue #441. They will be replaced by the canonical types
+> produced by sub-issues #439 / #440.
 >
-> `KYCDecision` is authored here per the #441 deliverables list and is the
-> canonical return type of `make_decision`.
+> `ExtractedIdentity` is **canonical** as of sub-issue #438 (document
+> extraction) and matches the interface published on that issue.
+> `KYCDecision` is canonical per #441 and is the return type of
+> `make_decision`.
 """
 from __future__ import annotations
 
@@ -14,22 +16,43 @@ from dataclasses import dataclass, field, asdict
 from typing import Any, Literal, Optional
 
 
-# ---------- STUBS (to be deleted when upstream types land) ----------
+# ---------- CANONICAL (owned by #438) ----------
 
 
 @dataclass(frozen=True)
 class ExtractedIdentity:
-    """Output of the Document Extraction Agent (sub-issue #438).
+    """Structured identity extracted from a customer document (#438).
 
-    Only the fields the Decision Agent needs to reason about are modelled
-    here. The real type will carry additional evidence and provenance.
+    Produced by ``agents.document_extractor.extract_identity``. Field names
+    and order match the interface published on issue #438.
+
+    ``confidence`` is the extractor's own confidence in [0.0, 1.0]. The
+    Decision Agent (#441) treats a confidence below its policy floor as an
+    escalation trigger, so extractors must not report 1.0 for a partially
+    recovered document.
     """
 
-    full_name: str
-    date_of_birth: str  # ISO 8601 date, e.g. "1980-05-14"
-    country: str        # ISO 3166-1 alpha-2, e.g. "ZA"
-    document_type: str  # e.g. "passport", "national_id", "drivers_license"
-    confidence: float   # extractor confidence in [0.0, 1.0]
+    first_name: str
+    last_name: str
+    date_of_birth: str      # ISO 8601 date, e.g. "1985-03-15"
+    nationality: str        # ISO 3166-1 alpha-2, e.g. "ZA"
+    document_type: str      # e.g. "passport", "national_id", "drivers_license"
+    document_number: str
+    document_expiry: str    # ISO 8601 date, e.g. "2029-01-01"
+    address: Optional[str] = None
+    confidence: float = 0.0
+
+    @property
+    def full_name(self) -> str:
+        """Convenience join. Not a dataclass field — excluded from hashing."""
+        return " ".join(part for part in (self.first_name, self.last_name) if part)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Canonical serialisable form (declaration order)."""
+        return asdict(self)
+
+
+# ---------- STUBS (to be deleted when upstream types land) ----------
 
 
 @dataclass(frozen=True)

--- a/examples/kyc-agent/tests/fixtures/documents/customer-profile.json
+++ b/examples/kyc-agent/tests/fixtures/documents/customer-profile.json
@@ -1,0 +1,20 @@
+{
+  "id": "CUS-T006",
+  "first_name": "Profile",
+  "last_name": "Shaped",
+  "date_of_birth": "1972-09-09",
+  "nationality": "ZZ",
+  "country_of_residence": "ZZ",
+  "occupation": "Synthetic Tester",
+  "is_synthetic": true,
+  "id_document": {
+    "type": "passport",
+    "number": "ZZ-TEST-000006",
+    "expiry": "2032-09-09",
+    "extracted_fields": {
+      "first_name": "Profile",
+      "last_name": "Shaped",
+      "address": "6 Fixture Avenue, Sampletown, ZZ 00006"
+    }
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/drivers-license-aliases.json
+++ b/examples/kyc-agent/tests/fixtures/documents/drivers-license-aliases.json
@@ -1,0 +1,19 @@
+{
+  "document_id": "DOC-T002",
+  "type": "Driver's License",
+  "is_synthetic": true,
+  "extracted_fields": {
+    "given_name": "Karim",
+    "surname": "Fixture",
+    "dob": "1990/11/02",
+    "issuing_country": "zz",
+    "id_number": "DL-TEST-000002",
+    "expiry": "02 Nov 2031",
+    "residential_address": {
+      "line1": "22 Mock Street",
+      "city": "Sampletown",
+      "postal_code": "00002",
+      "country": "ZZ"
+    }
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/national-id-fullname.json
+++ b/examples/kyc-agent/tests/fixtures/documents/national-id-fullname.json
@@ -1,0 +1,12 @@
+{
+  "document_id": "DOC-T003",
+  "document_type": "national_id",
+  "is_synthetic": true,
+  "extracted_fields": {
+    "full_name": "Ada Q. Synthetic",
+    "date_of_birth": "1978-06-30",
+    "nationality": "ZZ",
+    "document_number": "NID-TEST-000003",
+    "document_expiry": "2030-06-30"
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/passport-ambiguous-date.json
+++ b/examples/kyc-agent/tests/fixtures/documents/passport-ambiguous-date.json
@@ -1,0 +1,13 @@
+{
+  "document_id": "DOC-T005",
+  "document_type": "passport",
+  "is_synthetic": true,
+  "extracted_fields": {
+    "first_name": "Ambi",
+    "last_name": "Guous",
+    "date_of_birth": "03/04/1985",
+    "nationality": "ZZ",
+    "document_number": "ZZ-TEST-000005",
+    "document_expiry": "2028-04-03"
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/passport-complete.json
+++ b/examples/kyc-agent/tests/fixtures/documents/passport-complete.json
@@ -1,0 +1,14 @@
+{
+  "document_id": "DOC-T001",
+  "document_type": "passport",
+  "is_synthetic": true,
+  "extracted_fields": {
+    "first_name": "Jane",
+    "last_name": "Testcase",
+    "date_of_birth": "1985-03-15",
+    "nationality": "ZZ",
+    "document_number": "ZZ-TEST-000001",
+    "document_expiry": "2029-01-01",
+    "address": "1 Synthetic Way, Testville, ZZ 00001"
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/passport-low-declared-confidence.json
+++ b/examples/kyc-agent/tests/fixtures/documents/passport-low-declared-confidence.json
@@ -1,0 +1,15 @@
+{
+  "document_id": "DOC-T007",
+  "document_type": "passport",
+  "is_synthetic": true,
+  "extraction_confidence": 0.42,
+  "extracted_fields": {
+    "first_name": "Blurry",
+    "last_name": "Scan",
+    "date_of_birth": "1995-12-25",
+    "nationality": "ZZ",
+    "document_number": "ZZ-TEST-000007",
+    "document_expiry": "2027-12-25",
+    "address": "7 Glare Road, Sampletown, ZZ 00007"
+  }
+}

--- a/examples/kyc-agent/tests/fixtures/documents/passport-partial.json
+++ b/examples/kyc-agent/tests/fixtures/documents/passport-partial.json
@@ -1,0 +1,10 @@
+{
+  "document_id": "DOC-T004",
+  "document_type": "passport",
+  "is_synthetic": true,
+  "extracted_fields": {
+    "first_name": "Partial",
+    "last_name": "Scan",
+    "nationality": "ZZ"
+  }
+}

--- a/examples/kyc-agent/tests/test_decision_agent.py
+++ b/examples/kyc-agent/tests/test_decision_agent.py
@@ -35,10 +35,14 @@ from interfaces import (
 
 def _identity(confidence: float = 0.95) -> ExtractedIdentity:
     return ExtractedIdentity(
-        full_name="Ada Lovelace",
+        first_name="Ada",
+        last_name="Lovelace",
         date_of_birth="1980-05-14",
-        country="ZA",
+        nationality="ZA",
         document_type="passport",
+        document_number="ZZ-TEST-0001",
+        document_expiry="2031-01-01",
+        address="1 Synthetic Way, Testville, ZZ",
         confidence=confidence,
     )
 

--- a/examples/kyc-agent/tests/test_document_extractor.py
+++ b/examples/kyc-agent/tests/test_document_extractor.py
@@ -1,0 +1,307 @@
+"""Tests for the KYC Document Extraction Agent (sub-issue #438).
+
+Every test is offline, deterministic, and free of external dependencies.
+No API key is used or required; the LLM path is exercised through its
+fallback and its pure merge/parse helpers only.
+
+The suite covers:
+
+  - Field extraction from every fixture shape (flat document, alias-heavy
+    document, customer profile with a nested ``id_document``).
+  - Normalisation: document type slug, alpha-2 country, ISO 8601 dates,
+    flattened address mappings, full-name splitting.
+  - The confidence scoring table, including the declared-confidence cap.
+  - "Never invent a value" — absent fields stay empty.
+  - Determinism (same document in → identical dataclass out).
+  - LLM mode gating, fallback, and the pure merge/parse helpers.
+  - Hand-off into the Decision Agent (#441).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.decision_agent import make_decision
+from agents.document_extractor import (
+    DocumentExtractionError,
+    EXTRACTOR_VERSION,
+    REQUIRED_FIELDS,
+    _merge_llm_payload,
+    _parse_llm_json,
+    extract_identity,
+    extract_identity_mock,
+    llm_enabled,
+    load_document,
+)
+from interfaces import ExtractedIdentity, RiskAssessment, SanctionsResult
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "documents"
+
+
+# ---------- helpers ----------
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _fixture(name: str) -> dict:
+    with (FIXTURES / f"{name}.json").open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _extract(name: str) -> ExtractedIdentity:
+    return _run(extract_identity(_fixture(name)))
+
+
+# ---------- happy path ----------
+
+
+def test_complete_passport_extracts_every_field():
+    identity = _extract("passport-complete")
+    assert identity.first_name == "Jane"
+    assert identity.last_name == "Testcase"
+    assert identity.date_of_birth == "1985-03-15"
+    assert identity.nationality == "ZZ"
+    assert identity.document_type == "passport"
+    assert identity.document_number == "ZZ-TEST-000001"
+    assert identity.document_expiry == "2029-01-01"
+    assert identity.address == "1 Synthetic Way, Testville, ZZ 00001"
+    assert identity.confidence == 1.0
+
+
+def test_returns_extracted_identity_dataclass():
+    identity = _extract("passport-complete")
+    assert isinstance(identity, ExtractedIdentity)
+    assert set(identity.to_dict()) == set(REQUIRED_FIELDS) | {"address", "confidence"}
+
+
+def test_full_name_property_joins_parts():
+    assert _extract("passport-complete").full_name == "Jane Testcase"
+
+
+# ---------- alias + normalisation ----------
+
+
+def test_aliases_and_normalisation():
+    identity = _extract("drivers-license-aliases")
+    assert identity.first_name == "Karim"
+    assert identity.last_name == "Fixture"
+    assert identity.document_type == "drivers_license"  # "Driver's License"
+    assert identity.nationality == "ZZ"                 # "zz" upper-cased
+    assert identity.date_of_birth == "1990-11-02"       # "1990/11/02"
+    assert identity.document_expiry == "2031-11-02"     # "02 Nov 2031"
+    assert identity.document_number == "DL-TEST-000002"
+
+
+def test_address_mapping_is_flattened_in_order():
+    identity = _extract("drivers-license-aliases")
+    assert identity.address == "22 Mock Street, Sampletown, 00002, ZZ"
+
+
+def test_full_name_is_split_and_costs_confidence():
+    identity = _extract("national-id-fullname")
+    assert identity.first_name == "Ada Q."
+    assert identity.last_name == "Synthetic"
+    assert identity.confidence == 0.95  # complete, minus the derived-name penalty
+
+
+def test_customer_profile_shape_resolves_nested_document():
+    identity = _extract("customer-profile")
+    assert identity.first_name == "Profile"
+    assert identity.document_type == "passport"
+    assert identity.document_number == "ZZ-TEST-000006"
+    assert identity.document_expiry == "2032-09-09"
+    assert identity.address == "6 Fixture Avenue, Sampletown, ZZ 00006"
+    assert identity.confidence == 1.0
+
+
+def test_ambiguous_numeric_date_is_never_guessed():
+    identity = _extract("passport-ambiguous-date")
+    assert identity.date_of_birth == "03/04/1985"  # kept verbatim, not transposed
+    assert identity.confidence == 0.95             # one unparsed date
+
+
+# ---------- confidence scoring ----------
+
+
+def test_missing_fields_lower_confidence_and_stay_empty():
+    identity = _extract("passport-partial")
+    # dob, document_number and document_expiry are absent from the fixture.
+    assert identity.date_of_birth == ""
+    assert identity.document_number == ""
+    assert identity.document_expiry == ""
+    assert identity.address is None
+    assert identity.confidence == pytest.approx(0.55)  # 1.0 - 3 * 0.15
+
+
+def test_declared_confidence_caps_the_computed_score():
+    identity = _extract("passport-low-declared-confidence")
+    assert identity.confidence == 0.42  # complete document, blurry scan
+
+
+def test_declared_confidence_can_only_lower_never_raise():
+    document = _fixture("passport-partial")
+    document["extraction_confidence"] = 0.99
+    identity = _run(extract_identity(document))
+    assert identity.confidence == pytest.approx(0.55)
+
+
+def test_confidence_always_within_unit_interval():
+    for path in sorted(FIXTURES.glob("*.json")):
+        identity = _run(extract_identity(load_document(path)))
+        assert 0.0 <= identity.confidence <= 1.0, path.name
+
+
+def test_empty_document_body_floors_confidence_at_zero():
+    identity = extract_identity_mock({"document_id": "DOC-EMPTY"})
+    assert identity.confidence == 0.0
+    assert all(getattr(identity, name) == "" for name in REQUIRED_FIELDS)
+
+
+# ---------- determinism ----------
+
+
+def test_same_document_gives_identical_identity():
+    document = _fixture("passport-complete")
+    assert _run(extract_identity(document)) == _run(extract_identity(document))
+
+
+def test_extraction_does_not_mutate_the_document():
+    document = _fixture("drivers-license-aliases")
+    snapshot = json.dumps(document, sort_keys=True)
+    _run(extract_identity(document))
+    assert json.dumps(document, sort_keys=True) == snapshot
+
+
+def test_extractor_version_is_stamped():
+    assert EXTRACTOR_VERSION.startswith("kyc-document-extractor/")
+
+
+# ---------- input validation ----------
+
+
+@pytest.mark.parametrize("bad", [None, "passport", 42, ["passport"]])
+def test_non_mapping_document_raises(bad):
+    with pytest.raises(DocumentExtractionError):
+        _run(extract_identity(bad))
+
+
+def test_empty_document_raises():
+    with pytest.raises(DocumentExtractionError):
+        _run(extract_identity({}))
+
+
+# ---------- fixture loading ----------
+
+
+def test_load_document_by_path():
+    assert load_document(FIXTURES / "passport-complete.json")["document_id"] == "DOC-T001"
+
+
+def test_load_document_missing_raises():
+    with pytest.raises(DocumentExtractionError):
+        load_document(FIXTURES / "does-not-exist.json")
+
+
+# ---------- LLM mode (no API key, no network) ----------
+
+
+def test_llm_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("USE_LLM", raising=False)
+    assert llm_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+def test_use_llm_env_enables_llm_mode(monkeypatch, value):
+    monkeypatch.setenv("USE_LLM", value)
+    assert llm_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", ""])
+def test_falsy_use_llm_env_keeps_mock_mode(monkeypatch, value):
+    monkeypatch.setenv("USE_LLM", value)
+    assert llm_enabled() is False
+
+
+def test_llm_mode_without_api_key_falls_back_to_mock(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    document = _fixture("passport-complete")
+    assert _run(extract_identity(document, use_llm=True)) == extract_identity_mock(document)
+
+
+def test_llm_failure_falls_back_to_mock(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key")
+
+    async def _boom(document, baseline):
+        raise RuntimeError("provider unreachable")
+
+    monkeypatch.setattr("agents.document_extractor._extract_with_llm", _boom)
+    document = _fixture("passport-complete")
+    assert _run(extract_identity(document, use_llm=True)) == extract_identity_mock(document)
+
+
+def test_parse_llm_json_handles_code_fences():
+    payload = _parse_llm_json('```json\n{"first_name": "Jane"}\n```')
+    assert payload == {"first_name": "Jane"}
+
+
+def test_parse_llm_json_rejects_non_json():
+    with pytest.raises(ValueError):
+        _parse_llm_json("I could not read the document.")
+
+
+def test_llm_payload_fills_gaps_but_never_overwrites():
+    baseline = extract_identity_mock(_fixture("passport-partial"))
+    merged = _merge_llm_payload(
+        {
+            "first_name": "Overwritten",       # ignored — mapper already read it
+            "date_of_birth": "1988-02-29",     # accepted — mapper found nothing
+            "document_number": "ZZ-TEST-LLM",
+            "document_expiry": "2033-02-28",
+            "confidence": 0.9,
+        },
+        baseline,
+    )
+    assert merged.first_name == "Partial"
+    assert merged.date_of_birth == "1988-02-29"
+    assert merged.document_number == "ZZ-TEST-LLM"
+    assert merged.confidence == 0.9  # declared value caps the complete-document 1.0
+
+
+def test_llm_confidence_cannot_raise_the_score():
+    baseline = extract_identity_mock(_fixture("passport-partial"))
+    merged = _merge_llm_payload({"confidence": 1.0}, baseline)
+    assert merged.confidence == pytest.approx(0.55)
+
+
+# ---------- hand-off to the Decision Agent (#441) ----------
+
+
+def test_extracted_identity_feeds_make_decision():
+    identity = _extract("passport-complete")
+    decision = _run(
+        make_decision(
+            identity,
+            SanctionsResult(status="clear"),
+            RiskAssessment(risk_score=0.1, risk_band="low"),
+        )
+    )
+    assert decision.decision == "approve"
+
+
+def test_low_confidence_extraction_forces_escalation():
+    identity = _extract("passport-partial")  # confidence 0.55 → above the floor
+    low = ExtractedIdentity(**{**identity.to_dict(), "confidence": 0.3})
+    decision = _run(
+        make_decision(
+            low,
+            SanctionsResult(status="clear"),
+            RiskAssessment(risk_score=0.1, risk_band="low"),
+        )
+    )
+    assert decision.decision == "escalate"
+    assert decision.requires_human_review is True


### PR DESCRIPTION
## What changed

Implements the Document Extraction Agent from KYC sub-issue #438.

- `examples/kyc-agent/src/agents/document_extractor.py` — `async extract_identity(document, use_llm=False) -> ExtractedIdentity`
- `ExtractedIdentity` promoted from a #441 stub to the canonical type published on #438 (`src/interfaces/kyc_types.py`)
- `examples/kyc-agent/tests/test_document_extractor.py` — 39 offline tests
- `examples/kyc-agent/tests/fixtures/documents/` — 7 synthetic documents covering the edge cases
- README section documenting the modes, the invariants and the confidence table

## Deliverables (from #438)

- [x] `examples/kyc-agent/src/agents/document_extractor.py`
- [x] Extracts name, DOB, address, document number and expiry from fixture JSON
- [x] Returns a structured `ExtractedIdentity` dataclass
- [x] Mock mode: deterministic extraction from fixtures, no LLM needed
- [x] LLM mode (optional): Haystack `OpenAIChatGenerator`, opt-in via `USE_LLM=true` + `OPENAI_API_KEY`
- [x] Tests: `tests/test_document_extractor.py`

## Design notes

**Never invent a value.** A field absent from the document comes back as `""`,
not as a plausible-looking string. Wrong-but-confident identity data is the
failure mode that costs banks fines.

**Never guess an ambiguous date.** `03/04/1985` could be 3 April or 4 March, so
it is returned verbatim and costs confidence. Only unambiguous forms
(`YYYY-MM-DD`, `YYYY/MM/DD`, `DD Mon YYYY`, `Mon DD, YYYY`, and `DD/MM/YYYY`
where the first component exceeds 12) normalise to ISO 8601.

**Confidence is computed, not guessed** (`kyc-document-extractor/v1.0.0`):

```
score = 1.0
      - 0.15 per missing required field
      - 0.05 if the name was recovered by splitting a full-name string
      - 0.05 per date that could not be normalised to ISO 8601
      clamped to [0.0, 1.0]
```

A `confidence` / `extraction_confidence` declared on the document caps the
result. A partial extraction can therefore never report `1.0`, which matters
because the Decision Agent (#441) treats a low confidence as an escalation
trigger — there is a test for that hand-off.

**The LLM can only fill gaps and lower confidence.** It cannot overwrite a
field read straight out of the document, and any failure (haystack-ai absent,
no API key, malformed reply, network error) is logged and degrades to the mock
extraction.

## Relationship to the other sub-issues

- **#441 (Decision Agent):** `ExtractedIdentity` was a stub there and is now
  canonical here, as that PR's README anticipated. `test_decision_agent.py` is
  updated for the new fields; the decision policy itself is untouched.
- **#437 (fixtures):** not merged yet, so the test fixtures in this PR are
  self-contained and fully synthetic (country `ZZ`, `TEST`-prefixed document
  numbers). The extractor already reads the customer-profile schema from #437,
  and `load_document("document-001")` resolves ids against `fixtures/documents/`
  once those land.
- **#443 (governance):** `extract_identity` is a pure function by design — PII
  scan on the raw document and a receipt on the `ExtractedIdentity` belong at
  the caller, not inside the extractor.

## Validation

```
$ python -m pytest tests/ -q
56 passed in 0.09s
```

No API keys, no network calls, no LLM required. `ruff check` on the new files
reports only the same import-ordering style already present in the merged
`decision_agent.py`, plus two intentional choices (`DocumentExtractionError`
subclasses `ValueError`; the LLM fallback catches broadly on purpose).

Closes #438
