### PR TITLE
docs: add HIPAA-oriented medical RAG cookbook

### DIFF
--- a/cookbook/langchain/hipaa_medical_rag.ipynb
+++ b/cookbook/langchain/hipaa_medical_rag.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HIPAA-oriented medical RAG with LangChain and TealTiger\n",
+    "\n",
+    "This notebook uses synthetic medical FAQs and a deterministic mock model. It demonstrates defense in depth for a RAG pipeline: input PII scanning, retrieval-result scanning before context injection, output scanning, a per-session budget, and JSON audit evidence. No API key or patient data is required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install dependencies\n",
+    "\n",
+    "The notebook intentionally uses an in-memory lexical retriever so it can run without FAISS, Chroma, embeddings, or external services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"langchain-core>=1.0.0\" \"langchain-tealtiger>=0.1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import re\n",
+    "from typing import Any\n",
+    "\n",
+    "from langchain_core.documents import Document\n",
+    "from langchain_core.runnables import RunnableLambda\n",
+    "from tealtiger.guardrails import PIIDetectionGuardrail\n",
+    "\n",
+    "input_guard = PIIDetectionGuardrail({\"action\": \"block\"})\n",
+    "output_guard = PIIDetectionGuardrail({\"action\": \"redact\"})\n",
+    "audit_log: list[dict[str, Any]] = []\n",
+    "session = {\"cost_usd\": 0.0, \"budget_usd\": 0.03, \"session_id\": \"synthetic-session-001\"}\n",
+    "\n",
+    "documents = [\n",
+    "    Document(page_content=\"Adults with mild dehydration should follow the care team's oral rehydration plan.\", metadata={\"source\": \"synthetic_faq\", \"topic\": \"hydration\"}),\n",
+    "    Document(page_content=\"Seek urgent medical care for chest pain, severe breathing difficulty, or sudden weakness.\", metadata={\"source\": \"synthetic_faq\", \"topic\": \"urgent-care\"}),\n",
+    "    Document(page_content=\"Medication questions should be reviewed with a licensed clinician or pharmacist.\", metadata={\"source\": \"synthetic_faq\", \"topic\": \"medication\"}),\n",
+    "]\n",
+    "\n",
+    "def record(stage: str, action: str, **details: Any) -> None:\n",
+    "    audit_log.append({\"session_id\": session[\"session_id\"], \"stage\": stage, \"action\": action, **details})\n",
+    "\n",
+    "async def contains_pii(text: str) -> bool:\n",
+    "    result = await input_guard.evaluate(text)\n",
+    "    return not result.passed\n",
+    "\n",
+    "async def redact(text: str) -> str:\n",
+    "    result = await output_guard.evaluate(text)\n",
+    "    return result.metadata.get(\"redacted_text\", text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Governance-aware RAG stages\n",
+    "\n",
+    "The stages are explicit so a reviewer can see where a control applies. Retrieved documents are treated as untrusted context and are scanned before they reach the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def protect_input(state: dict[str, Any]) -> dict[str, Any]:\n",
+    "    query = state[\"query\"]\n",
+    "    if await contains_pii(query):\n",
+    "        record(\"input\", \"blocked_pii\")\n",
+    "        raise ValueError(\"Input blocked: remove patient identifiers before retrieval.\")\n",
+    "    record(\"input\", \"allowed\")\n",
+    "    return state\n",
+    "\n",
+    "async def retrieve(state: dict[str, Any]) -> dict[str, Any]:\n",
+    "    terms = set(re.findall(r\"[a-z]+\", state[\"query\"].lower()))\n",
+    "    ranked = sorted(documents, key=lambda doc: len(terms & set(doc.page_content.lower().split())), reverse=True)\n",
+    "    safe_docs = []\n",
+    "    for doc in ranked[:2]:\n",
+    "        if not await contains_pii(doc.page_content):\n",
+    "            safe_docs.append(doc)\n",
+    "    record(\"retrieval\", \"completed\", candidates=len(ranked), safe_documents=len(safe_docs))\n",
+    "    return {**state, \"docs\": safe_docs}\n",
+    "\n",
+    "def generate(state: dict[str, Any]) -> dict[str, Any]:\n",
+    "    if session[\"cost_usd\"] + 0.01 > session[\"budget_usd\"]:\n",
+    "        record(\"budget\", \"blocked\")\n",
+    "        raise ValueError(\"Session budget exceeded.\")\n",
+    "    session[\"cost_usd\"] += 0.01\n",
+    "    context = \" \".join(doc.page_content for doc in state[\"docs\"])\n",
+    "    answer = f\"Synthetic answer based on approved context: {context}\"\n",
+    "    record(\"generation\", \"completed\", estimated_cost_usd=0.01)\n",
+    "    return {**state, \"answer\": answer}\n",
+    "\n",
+    "async def protect_output(state: dict[str, Any]) -> dict[str, Any]:\n",
+    "    answer = state[\"answer\"]\n",
+    "    safe_answer = await redact(answer)\n",
+    "    record(\"output\", \"redacted\" if safe_answer != answer else \"allowed\")\n",
+    "    return {**state, \"answer\": safe_answer}\n",
+    "\n",
+    "rag = (\n",
+    "    RunnableLambda(protect_input)\n",
+    "    | RunnableLambda(retrieve)\n",
+    "    | RunnableLambda(generate)\n",
+    "    | RunnableLambda(protect_output)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run safe and unsafe cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "safe_result = await rag.ainvoke({\"query\": \"What should I know about hydration?\"})\n",
+    "assert safe_result[\"answer\"]\n",
+    "assert session[\"cost_usd\"] == 0.01\n",
+    "\n",
+    "try:\n",
+    "    await rag.ainvoke({\"query\": \"What should I know? Patient SSN is 123-45-6789.\"})\n",
+    "except ValueError as exc:\n",
+    "    assert \"Input blocked\" in str(exc)\n",
+    "else:\n",
+    "    raise AssertionError(\"PII input was not blocked\")\n",
+    "\n",
+    "print(safe_result[\"answer\"])\n",
+    "print(\"Audit events:\", len(audit_log))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Verify output protection and audit export\n",
+    "\n",
+    "The following isolated check simulates an unsafe model output without invoking a real model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unsafe = await protect_output({\"answer\": \"The record number is 123-45-6789.\"})\n",
+    "assert \"123-45-6789\" not in unsafe[\"answer\"]\n",
+    "assert any(event[\"action\"] == \"redacted\" for event in audit_log)\n",
+    "\n",
+    "audit_json = json.dumps(audit_log, indent=2)\n",
+    "with open(\"hipaa_medical_rag_audit.json\", \"w\", encoding=\"utf-8\") as file:\n",
+    "    file.write(audit_json)\n",
+    "\n",
+    "print(audit_json)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Production notes\n",
+    "\n",
+    "- Replace the lexical retriever with FAISS, Chroma, or a managed vector store after validating its data-handling controls.\n",
+    "- Replace the mock generator with an approved model endpoint; keep the input, retrieval, output, budget, and audit stages around it.\n",
+    "- Use synthetic or de-identified data in development. This example is an engineering pattern, not medical advice or a HIPAA certification."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.10"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add a runnable LangChain + TealTiger cookbook for a synthetic medical RAG workflow.

## What it demonstrates

- Input PII blocking before retrieval.
- PII checks on retrieved documents before context injection.
- Output PII redaction.
- A deterministic mock generator with no API keys.
- Per-session budget enforcement.
- JSON audit evidence export.

The retriever uses an in-memory lexical implementation so the notebook stays dependency-light and deterministic. Production notes explain where to substitute FAISS, Chroma, an approved model endpoint, and de-identified data.

## Validation

- Executed all notebook cells successfully with `jupyter nbconvert --execute`.
- Confirmed no notebook cell produced an error.
- Confirmed synthetic PII input is blocked and unsafe output is redacted.
- Confirmed audit events are serializable as JSON.

Resolves #488