### PR TITLE
 Add governed tool-calling agent with kill switch cookbook (#494)

### DIFF
--- a/cookbook/langchain/killswitch_agent.ipynb
+++ b/cookbook/langchain/killswitch_agent.ipynb
@@ -1,0 +1,335 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Governed tool-calling agent with a kill switch\n",
+    "\n",
+    "This notebook shows a LangChain-style tool-calling agent wrapped with **TealTiger** deterministic governance, plus an **emergency kill switch (FREEZE)** that instantly stops all agent actions without restarting the service.\n",
+    "\n",
+    "Production agents sometimes go haywire: calling tools in loops, spending budget, or executing dangerous actions. Operators need to freeze an agent *right now* and unfreeze it once the situation is understood.\n",
+    "\n",
+    "You will build an agent that:\n",
+    "\n",
+    "- exposes 5 tools (`search`, `calculator`, `email`, `file_write`, `database`),\n",
+    "- allows only `search` and `calculator` via a tool allowlist,\n",
+    "- unconditionally blocks `file_write` and `database` via FREEZE rules,\n",
+    "- rate-limits to 10 tool calls per minute,\n",
+    "- can be frozen mid-session (kill switch) and unfrozen to resume.\n",
+    "\n",
+    "No API keys are required. The tools are mocked and the governance engine is fully deterministic (no LLM in the governance path)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U -q \"langchain-tealtiger>=0.4.5\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define mock tools\n",
+    "\n",
+    "Each tool is a plain Python function. No network calls, so you can run this notebook anywhere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search(query: str) -> str:\n",
+    "    return f\"[search results for {query!r}]\"\n",
+    "\n",
+    "def calculator(expression: str) -> str:\n",
+    "    return f\"{expression} = {eval(expression, {'__builtins__': {}}, {})}\"\n",
+    "\n",
+    "def email(to: str, body: str) -> str:\n",
+    "    return f\"[email sent to {to}]\"\n",
+    "\n",
+    "def file_write(path: str, content: str) -> str:\n",
+    "    return f\"[wrote {len(content)} bytes to {path}]\"\n",
+    "\n",
+    "def database(query: str) -> str:\n",
+    "    return f\"[db executed: {query}]\"\n",
+    "\n",
+    "TOOLS = {\n",
+    "    \"search\": search,\n",
+    "    \"calculator\": calculator,\n",
+    "    \"email\": email,\n",
+    "    \"file_write\": file_write,\n",
+    "    \"database\": database,\n",
+    "}\n",
+    "print(\"Tools:\", list(TOOLS))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure governance\n",
+    "\n",
+    "The `TealTigerMiddleware` is what you attach to a real LangChain agent via `create_agent(..., middleware=[...])`. In this notebook you drive its governance engine directly through a tiny agent loop so the demo runs without a model.\n",
+    "\n",
+    "Policies:\n",
+    "\n",
+    "- **tool_allowlist** — only `search` and `calculator` may run.\n",
+    "- **freeze_tools** — `file_write` and `database` are immutable denies, blocked regardless of mode.\n",
+    "- **rate_limit** — at most 10 tool calls per minute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tealtiger import TealTigerMiddleware\n",
+    "\n",
+    "middleware = TealTigerMiddleware(\n",
+    "    policies=[\n",
+    "        {\"type\": \"tool_allowlist\", \"tools\": [\"search\", \"calculator\"]},\n",
+    "        {\"type\": \"rate_limit\", \"max_calls\": 10, \"window\": \"1m\"},\n",
+    "    ],\n",
+    "    freeze_tools=[\"file_write\", \"database\"],\n",
+    "    mode=\"ENFORCE\",\n",
+    ")\n",
+    "\n",
+    "# The governance engine used by the middleware. In a real agent you never call\n",
+    "# this directly; the middleware invokes it inside wrap_tool_call().\n",
+    "engine = middleware._engine\n",
+    "print(\"Middleware ready. Frozen tools:\", middleware.frozen_tools())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A minimal governed agent loop\n",
+    "\n",
+    "This helper simulates what happens inside `wrap_tool_call`: every tool call is evaluated by the governance engine first. A `DENY` short-circuits execution and returns a structured decision instead of running the tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tealtiger._types import GovernanceAction\n",
+    "\n",
+    "def call_tool(name: str, **args):\n",
+    "    \"\"\"Governed tool call: evaluate, then run only if allowed.\"\"\"\n",
+    "    decision = engine.evaluate(tool_name=name, tool_args=args)\n",
+    "    if decision.action == GovernanceAction.DENY:\n",
+    "        print(f\"  DENY  {name:<12} reason={decision.reason}\")\n",
+    "        print(f\"        reason_codes={decision.reason_codes}\")\n",
+    "        return None\n",
+    "    result = TOOLS[name](**args)\n",
+    "    print(f\"  ALLOW {name:<12} -> {result}\")\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Normal operation\n",
+    "\n",
+    "Allowlisted tools run. Non-allowlisted tools (`email`) are denied. Frozen tools (`file_write`, `database`) are denied even though they exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Normal operation:\")\n",
+    "call_tool(\"search\", query=\"tealtiger governance\")\n",
+    "call_tool(\"calculator\", expression=\"2 + 2\")\n",
+    "call_tool(\"email\", to=\"ops@example.com\", body=\"hi\")        # not in allowlist\n",
+    "call_tool(\"file_write\", path=\"/etc/passwd\", content=\"x\")   # frozen\n",
+    "call_tool(\"database\", query=\"DROP TABLE users\")            # frozen"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Rate limiting\n",
+    "\n",
+    "The agent is capped at 10 tool calls per minute. The 11th allowed call is throttled with a structured `RATE_LIMIT_EXCEEDED` decision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine.reset_session()  # clear the call counter for a clean demo\n",
+    "print(\"Firing 12 search calls (limit is 10/min):\")\n",
+    "for i in range(12):\n",
+    "    print(f\"call {i + 1:>2}:\", end=\" \")\n",
+    "    call_tool(\"search\", query=f\"q{i}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Kill switch — freeze all tools mid-session\n",
+    "\n",
+    "Something looks wrong. An operator engages the emergency kill switch. Every tool call is now denied with a `KILL_SWITCH` reason code, regardless of allowlist or mode. No service restart needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine.reset_session()\n",
+    "\n",
+    "print(\"Before kill switch:\")\n",
+    "call_tool(\"search\", query=\"before\")\n",
+    "\n",
+    "print(\"\\n>>> middleware.freeze_all()  # KILL SWITCH ENGAGED\\n\")\n",
+    "middleware.freeze_all()\n",
+    "print(\"is_frozen():\", middleware.is_frozen())\n",
+    "\n",
+    "print(\"\\nDuring freeze (all tools blocked):\")\n",
+    "call_tool(\"search\", query=\"during\")\n",
+    "call_tool(\"calculator\", expression=\"1 + 1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Unfreeze and resume\n",
+    "\n",
+    "Once the situation is understood, the operator releases the kill switch. Normal governance resumes: allowlisted tools work again, and the original FREEZE rules (`file_write`, `database`) are still enforced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\">>> middleware.unfreeze_all()  # KILL SWITCH RELEASED\\n\")\n",
+    "middleware.unfreeze_all()\n",
+    "print(\"is_frozen():\", middleware.is_frozen())\n",
+    "\n",
+    "print(\"\\nAfter unfreeze:\")\n",
+    "call_tool(\"search\", query=\"after\")\n",
+    "call_tool(\"calculator\", expression=\"3 * 7\")\n",
+    "call_tool(\"database\", query=\"SELECT 1\")   # still frozen by original policy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Targeted freeze — one tool at a time\n",
+    "\n",
+    "Beyond the all-or-nothing kill switch, you can freeze and unfreeze individual tools at runtime with `freeze(...)` / `unfreeze(...)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine.reset_session()\n",
+    "\n",
+    "print(\">>> middleware.freeze('calculator')\\n\")\n",
+    "middleware.freeze(\"calculator\")\n",
+    "print(\"frozen_tools():\", middleware.frozen_tools())\n",
+    "call_tool(\"search\", query=\"still ok\")\n",
+    "call_tool(\"calculator\", expression=\"9 - 4\")   # now frozen\n",
+    "\n",
+    "print(\"\\n>>> middleware.unfreeze('calculator')\\n\")\n",
+    "middleware.unfreeze(\"calculator\")\n",
+    "call_tool(\"calculator\", expression=\"9 - 4\")   # restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wiring into a real LangChain agent\n",
+    "\n",
+    "In production you attach the middleware to `create_agent` and expose the kill switch to your operations tooling (an admin endpoint, a CLI, a dashboard button). The governance runs inside `wrap_tool_call`, so no agent code changes are needed.\n",
+    "\n",
+    "```python\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain_tealtiger import TealTigerMiddleware\n",
+    "\n",
+    "middleware = TealTigerMiddleware(\n",
+    "    policies=[\n",
+    "        {\"type\": \"tool_allowlist\", \"tools\": [\"search\", \"calculator\"]},\n",
+    "        {\"type\": \"rate_limit\", \"max_calls\": 10, \"window\": \"1m\"},\n",
+    "    ],\n",
+    "    freeze_tools=[\"file_write\", \"database\"],\n",
+    "    mode=\"ENFORCE\",\n",
+    ")\n",
+    "\n",
+    "agent = create_agent(\n",
+    "    model=\"claude-sonnet-4-6\",\n",
+    "    tools=[search, calculator, email, file_write, database],\n",
+    "    middleware=[middleware],\n",
+    ")\n",
+    "\n",
+    "# Emergency controls, callable from anywhere that holds the middleware:\n",
+    "middleware.freeze_all()      # halt everything\n",
+    "middleware.unfreeze_all()    # resume\n",
+    "middleware.freeze(\"database\")   # halt one tool\n",
+    "middleware.is_frozen(\"database\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next\n",
+    "\n",
+    "- **Governed SQL agent** — table-level access control with `table_allowlist` / `table_blocklist`.\n",
+    "- **PII redaction** — scan tool outputs and model responses with `pii_block` / `secret_detection` policies.\n",
+    "- **Audit evidence** — export governance decisions via `middleware._engine.evidence()` for SARIF / JUnit reporting.\n",
+    "\n",
+    "See the [langchain-tealtiger docs](https://pypi.org/project/langchain-tealtiger/) for the full policy reference."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
demonstrates the v0.4.5 runtime kill-switch API — tool allowlist, FREEZE rules, rate limiting, mid-session freeze_all()/unfreeze_all(), and targeted per-tool freeze; closes #494.